### PR TITLE
i18n: regenerate the string catalogue (extract + lupdate, no Transifex push)

### DIFF
--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -26,13 +26,26 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "for example: alertnotify=echo %%s | mail -s \"Gridcoin Alert\" admin@foo."
 "com\n"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a "
+"loopback address. Sending RPC credentials to it would transmit them "
+"unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the "
+"connection (for example over SSH) if it crosses an untrusted network."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "A poll with a yes/no/abstain response type cannot include any additional "
 "custom choices."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"An error occurred while setting up the RPC port %u for listening on %s: %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "An error occurred while setting up the RPC port %u for listening on IPv4: %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "An error occurred while setting up the RPC port %u for listening on IPv6, "
 "falling back to IPv4: %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Block file corruption detected and automatic recovery failed. Please restart "
+"with -reindex to rebuild the chain state."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Cannot access the data directory; check that it exists and that you have "
+"permission to read and write it."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Cannot obtain a lock on data directory %s. %s is probably already running "
 "and using that directory."),
@@ -45,20 +58,42 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Due to the failure to delete the blockchain data you will be required to "
 "manually delete the data before starting your wallet."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"ERROR: Checkpoint mismatch: Blockchain data may be corrupted.\n"
+"ERROR: Block index integrity check failed: Blockchain data may be "
+"corrupted.\n"
 "\n"
-"Gridcoin detected bad index entries. This may occur because of a late "
-"software upgrade, unexpected exit, or a power failure. Please run "
-"gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will "
-"re-download the blockchain. Your balance may appear incorrect until the "
+"Gridcoin detected a block index entry with a broken pprev linkage. This may "
+"occur because of a late software upgrade, unexpected exit, or a power "
+"failure that left the on-disk block index database in an inconsistent state. "
+"Please run gridcoinresearchd with the -resetblockchaindata parameter. Your "
+"wallet will re-download the blockchain. Your balance may appear incorrect "
+"until the synchronization finishes."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"ERROR: Block index integrity check failed: Blockchain data may be "
+"corrupted.\n"
+"\n"
+"Gridcoin detected a block index entry with a broken pprev linkage. This may "
+"occur because of a late software upgrade, unexpected exit, or a power "
+"failure that left the on-disk block index database in an inconsistent state. "
+"Your blockchain data is being reset and your wallet will resync from genesis "
+"when you restart. Your balance may appear incorrect until the "
 "synchronization finishes."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "ERROR: Checkpoint mismatch: Blockchain data may be corrupted.\n"
 "\n"
-"Gridcoin detected bad index entries. This may occur because of a late "
-"software upgrade, unexpected exit, or a power failure. Your blockchain data "
-"is being reset and your wallet will resync from genesis when you restart. "
-"Your balance may appear incorrect until the synchronization finishes."),
+"Gridcoin's compiled-in hardened checkpoint does not match the block at that "
+"height in your local block index. This may occur because of a late software "
+"upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd "
+"with the -resetblockchaindata parameter. Your wallet will re-download the "
+"blockchain. Your balance may appear incorrect until the synchronization "
+"finishes."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"ERROR: Checkpoint mismatch: Blockchain data may be corrupted.\n"
+"\n"
+"Gridcoin's compiled-in hardened checkpoint does not match the block at that "
+"height in your local block index. This may occur because of a late software "
+"upgrade, unexpected exit, or a power failure. Your blockchain data is being "
+"reset and your wallet will resync from genesis when you restart. Your "
+"balance may appear incorrect until the synchronization finishes."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error initializing database environment %s! To recover, BACKUP THAT "
 "DIRECTORY, then remove everything from it except for wallet.dat."),
@@ -86,8 +121,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error: Unsupported argument -socks found. Setting SOCKS version isn't "
 "possible anymore, only SOCKS5 proxies are supported."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Failed to download snapshot as mandatory client is available for download."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Failed: 80 block difficulty is less than %1. This wallet is almost certainly "
 "forked."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
@@ -99,6 +132,13 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "For polls about community representation, public relations, and "
 "communications."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Gridcoin detected a multi-superblock chain reorganization and is rebuilding "
+"the beacon registry to maintain consensus with the network. The wallet may "
+"be briefly unresponsive while the rebuild runs."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"No single address can attest to %s GRC in %u or fewer UTXOs. Consider "
+"consolidating UTXOs."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Please check your network and also check the config file and ensure your "
 "addnode entries are up-to-date. If you recently started the wallet, you may "
@@ -135,6 +175,10 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "characters supported by your system locale, or enable 8.3 filename "
 "generation."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"The default data directory is on a temporary filesystem, so the block chain "
+"and wallet would be lost when the program exits. Pass -datadir with a "
+"location on persistent storage."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "The network has experienced a low-level error and this probably means your "
 "IP address or other network connection parameters are not configured "
 "correctly. Please check your network configuration on your computer."),
@@ -163,10 +207,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Unable to bind to %s on this computer. Gridcoin is probably already running."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Unable to download a snapshot, as the wallet has detected that a new "
-"mandatory version is available for install. The mandatory upgrade must be "
-"installed before the snapshot can be downloaded and applied."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Verify (1) that you have BOINC installed correctly, (2) that you have "
 "attached at least one whitelisted project, (3) that you advertised your "
 "beacon with the same email as you use for your BOINC project(s), and (4) "
@@ -194,9 +234,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "research rewards by staking - increase balance or use MRC"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Warning: ETTS is infinite. No coins to stake - increase balance or use MRC"),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Warning: Ending this process after Stage 2 will result in syncing from 0 or "
-"an incomplete/corrupted blockchain."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Warning: Please check that your computer's date and time are correct! If "
 "your clock is wrong Gridcoin will not work properly."),
@@ -284,10 +321,10 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "(genesis), the sync process can take from 2 to 4 hours, or longer on a slow "
 "computer. If you have synced your wallet before but you just started the "
 "wallet up, then wait a few more minutes and retry the diagnostics again."),
+QT_TRANSLATE_NOOP("bitcoin-core", "-maxmempool must be between %d and %d MB."),
 QT_TRANSLATE_NOOP("bitcoin-core", "A poll choice cannot be empty."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Active by Greylist Override"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Active"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Are you sure you want to cancel the snapshot operation?"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Authorized"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Automatically Greylisted"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Balance too low to create a contract."),
@@ -302,8 +339,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Boinc Reward"),
 QT_TRANSLATE_NOOP("bitcoin-core", "CPID Count"),
 QT_TRANSLATE_NOOP("bitcoin-core", "CPID count polls are not supported."),
 QT_TRANSLATE_NOOP("bitcoin-core", "CPID"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Cancel snapshot operation?"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Cancel"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot resolve -bind address: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot resolve -externalip address: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot write default address"),
@@ -339,15 +374,12 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Error: could not start node"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Exceeded the number of choices in the poll: %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Expired while pending"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Explorer"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Failed to download snapshot.zip; See debug.log"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to listen on any port. Use -listen=0 if you want this."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to rename bootstrap file to .old for backup purposes."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed: Count = %1"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Fees Collected"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Files:"),
 QT_TRANSLATE_NOOP("bitcoin-core", "For opinion or casual polls without any particular requirements."),
-QT_TRANSLATE_NOOP("bitcoin-core", "GB)"),
-QT_TRANSLATE_NOOP("bitcoin-core", "GB/"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Get help for a command"),
 QT_TRANSLATE_NOOP("bitcoin-core", "GitHub version: "),
 QT_TRANSLATE_NOOP("bitcoin-core", "Governance"),
@@ -374,8 +406,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount for -reservebalance=<amount>")
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid team"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Is Superblock"),
-QT_TRANSLATE_NOOP("bitcoin-core", "KB/s"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Latest Version GitHub data response:"),
 QT_TRANSLATE_NOOP("bitcoin-core", "List commands"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading Network Averages..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading addresses..."),
@@ -385,7 +415,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Loading history for contract type "),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading superblock cache..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading wallet..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Local version: "),
-QT_TRANSLATE_NOOP("bitcoin-core", "MB/s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Magnitude"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Magnitude+Balance"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Magnitude-only polls are not supported."),
@@ -394,13 +423,12 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Mandatory"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Manually Greylisted"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Marketing"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Multiple Choice"),
-QT_TRANSLATE_NOOP("bitcoin-core", "N/A"),
 QT_TRANSLATE_NOOP("bitcoin-core", "No UTXOs available due to reserve balance"),
-QT_TRANSLATE_NOOP("bitcoin-core", "No address contains %s GRC in %s UTXOs or fewer."),
 QT_TRANSLATE_NOOP("bitcoin-core", "No coins"),
 QT_TRANSLATE_NOOP("bitcoin-core", "No current polls"),
 QT_TRANSLATE_NOOP("bitcoin-core", "No eligible outputs greater than 1 GRC."),
 QT_TRANSLATE_NOOP("bitcoin-core", "No mature coins"),
+QT_TRANSLATE_NOOP("bitcoin-core", "No single address has the required %s GRC balance to create a poll."),
 QT_TRANSLATE_NOOP("bitcoin-core", "No wallet available."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Not authorized"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Offline"),
@@ -446,22 +474,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Reset Blockchain Data: Blockchain data remova
 QT_TRANSLATE_NOOP("bitcoin-core", "Reset Blockchain Data: Blockchain data removal was a success"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Resetting block chain index to prepare for reindexing..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Send command to -server or gridcoinresearchd"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Sending..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Single Choice"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Snapshot Process Complete!"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Snapshot Process Has Begun."),
-QT_TRANSLATE_NOOP("bitcoin-core", "Snapshot extraction failed! Cleaning up any extracted data"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Snapshot operation canceled due to an invalid snapshot zip."),
-QT_TRANSLATE_NOOP("bitcoin-core", "Snapshot operation canceled."),
-QT_TRANSLATE_NOOP("bitcoin-core", "Snapshot operation successful!"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Stage (1/4): Downloading snapshot.zip:         "),
-QT_TRANSLATE_NOOP("bitcoin-core", "Stage (1/4): Downloading snapshot.zip: Speed "),
-QT_TRANSLATE_NOOP("bitcoin-core", "Stage (2/4): Verify SHA256SUM of snapshot.zip"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Stage (2/4): Verify SHA256SUM of snapshot.zip: "),
-QT_TRANSLATE_NOOP("bitcoin-core", "Stage (3/4): Cleanup blockchain data"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Stage (3/4): Cleanup blockchain data:          "),
-QT_TRANSLATE_NOOP("bitcoin-core", "Stage (4/4): Extracting snapshot.zip"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Stage (4/4): Extracting snapshot.zip:          "),
 QT_TRANSLATE_NOOP("bitcoin-core", "Staking Only - No Eligible Research Projects"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Staking Only - No active beacon"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Staking Only - Non-cruncher Mode"),
@@ -472,8 +485,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Testnet-only version"),
 QT_TRANSLATE_NOOP("bitcoin-core", "The field is not well-formed."),
 QT_TRANSLATE_NOOP("bitcoin-core", "The field list is not well-formed."),
 QT_TRANSLATE_NOOP("bitcoin-core", "The latest release is "),
-QT_TRANSLATE_NOOP("bitcoin-core", "The wallet is now shutting down. Please restart your wallet."),
-QT_TRANSLATE_NOOP("bitcoin-core", "The wallet will now shutdown."),
 QT_TRANSLATE_NOOP("bitcoin-core", "This update is "),
 QT_TRANSLATE_NOOP("bitcoin-core", "To use the %s option"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to bind to %s on this computer (bind returned error %d, %s)"),
@@ -490,6 +501,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Verifying checkpoints..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Verifying database integrity..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Vote signature failed. See debug.log."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Wallet %s resides outside data directory %s."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Wallet balance of %s in top %s UTXOs is less than required %s GRC."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Wallet locked"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Wallet needed to be rewritten: restart Gridcoin to complete"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Warning: 45 days < ETTS = %1 <= 90 days"),
@@ -511,6 +523,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", "mandatory"),
 QT_TRANSLATE_NOOP("bitcoin-core", "message"),
 QT_TRANSLATE_NOOP("bitcoin-core", "mrc"),
 QT_TRANSLATE_NOOP("bitcoin-core", "poll"),
+QT_TRANSLATE_NOOP("bitcoin-core", "pool_approve"),
+QT_TRANSLATE_NOOP("bitcoin-core", "pool_register"),
 QT_TRANSLATE_NOOP("bitcoin-core", "project"),
 QT_TRANSLATE_NOOP("bitcoin-core", "protocol"),
 QT_TRANSLATE_NOOP("bitcoin-core", "scraper"),

--- a/src/qt/locale/bitcoin_af_ZA.ts
+++ b/src/qt/locale/bitcoin_af_ZA.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">Ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nee</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verwyder</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopieer &amp;etiket</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Redigeer</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Voer adresboekdata uit</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(geen etiket)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Slegs vir staking</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Tik asseblief die ou en nuwe wagwoord vir die beursie in.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Bevestig beursie enkripsie.</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Is jy seker jy wil jou beursie enkripteer?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Die beursie is nou bewaak</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin sal nou sluit om die enkripsieproses te voltooi. Onthou dat die enkripsie van jou beursie jou munte nie ten volle kan beskerm as gevolg van wanware wat jou rekenaar besmet nie.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>BELANGRIK: Enige vorige rugsteun wat u van u beursie-lêer gemaak het, moet vervang word met die nuut gegenereerde, versleutelde beursie-lêer. Om sekuriteitsredes sal vorige back-ups van die ongecodeerde beursie-lêer nutteloos word sodra u die nuwe versleutelde beursie begin gebruik.</translation>
+        <translation type="vanished">BELANGRIK: Enige vorige rugsteun wat u van u beursie-lêer gemaak het, moet vervang word met die nuut gegenereerde, versleutelde beursie-lêer. Om sekuriteitsredes sal vorige back-ups van die ongecodeerde beursie-lêer nutteloos word sodra u die nuwe versleutelde beursie begin gebruik.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Die beursie kon nie bewaak word nie</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Beursie bewaaking het misluk as gevolg van &apos;n interne fout. Die beursie is nie bewaak nie!</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Die wagfrase stem nie ooreen nie</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Beursie oopsluiting het misluk</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Die wagfrase wat ingetik was om die beursie oop te sluit, was verkeerd.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Die beursie se wagfrase verandering was suksesvol.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>&apos;N fatale fout het voorgekom. Gridcoin kan nie meer veilig voort en sal sluit.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Beursie</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Oorsig</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>S&amp;luit af</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifieer boodskap...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Uitvoer...</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Oop ontfouting en diagnostiese konsole</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Lêer</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Instellings</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin kliënt</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +972,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Laaste ontvang blok was Gegenereer wanneer %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Hierdie transaksie is oor die Groottelimiet. Jy kan dit steeds stuur vir &apos;n fooi van %1, wat gaan die nodusse wat verwerk jou transaksie en help om die netwerk ondersteun. Wil jy die fooi te betaal?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Transaksiefooi bevestig</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Gestuurde transaksie</translation>
     </message>
@@ -835,17 +1000,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -865,7 +1020,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -883,7 +1038,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>URI hantering</translation>
@@ -900,7 +1065,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -915,12 +1080,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Rugsteun Beursie</translation>
     </message>
@@ -931,18 +1096,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Rugsteun het misluk</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Daar was &apos;n fout in die poging om die Beursie data na die nuwe ligging stoor.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,7 +1116,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1208,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Netwerk ontvanklike</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Bedrag</translation>
+        <translation type="vanished">Bedrag</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Datum</translation>
+        <translation type="vanished">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Bevestig</translation>
+        <translation type="vanished">Bevestig</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Etiket</translation>
+        <translation type="vanished">Etiket</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Adres</translation>
+        <translation type="vanished">Adres</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Maak kopie van adres</translation>
     </message>
@@ -1251,17 +1410,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopieer transaksie ID</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopieer hoeveelheid</translation>
     </message>
@@ -1291,17 +1450,17 @@ Expires: %3
         <translation>Kopieer verandering</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>STOF</translation>
     </message>
@@ -1351,20 +1510,65 @@ Bedrae onder 0.546 keer die minimum relay fooi is aangedui as STOF.</translation
 Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(geen etiket)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>verander vanaf %1 (%2)</translation>
+        <translation type="vanished">verander vanaf %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(verandering)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(geen etiket)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">verander vanaf %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(verandering)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Bedrag</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(verandering)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etiket</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adres</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1390,7 +1594,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished">Adres</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1656,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,37 +1691,27 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Bedrag</translation>
+        <translation type="obsolete">Bedrag</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiket</translation>
+        <translation type="obsolete">Etiket</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adres</translation>
+        <translation type="obsolete">Adres</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Datum</translation>
+        <translation type="obsolete">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Bevestig</translation>
+        <translation type="obsolete">Bevestig</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,7 +1746,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1562,25 +1756,22 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(geen etiket)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">verander vanaf %1 (%2)</translation>
+        <translation type="obsolete">verander vanaf %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(verandering)</translation>
+        <translation type="obsolete">(verandering)</translation>
     </message>
 </context>
 <context>
@@ -1730,7 +1921,12 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1755,7 +1951,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1931,7 +2127,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1946,6 +2142,11 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1954,7 +2155,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>weergawe</translation>
     </message>
@@ -1982,7 +2183,16 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2054,22 +2264,22 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2133,7 +2343,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2252,6 +2462,370 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">Ja</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">nee</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Beursie ontsluit is gekanselleer.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2567,7 +3141,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation>&amp;Kanselleer</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>verstek</translation>
     </message>
@@ -2582,7 +3156,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Fout</translation>
@@ -2810,18 +3384,23 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2832,9 +3411,223 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Bedrag</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2948,7 +3741,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2988,6 +3781,11 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3023,7 +3821,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished">Vorm</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3033,7 +3831,17 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3046,7 +3854,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3099,6 +3907,83 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">Ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nee</translation>
     </message>
 </context>
 <context>
@@ -3183,12 +4068,17 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3213,12 +4103,12 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3305,7 +4195,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3343,7 +4233,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">(n.v.t)</translation>
     </message>
@@ -3453,14 +4343,48 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3470,7 +4394,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3485,12 +4409,35 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,7 +4447,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3562,6 +4509,11 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3657,7 +4609,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>(n.v.t)</translation>
     </message>
@@ -3743,7 +4695,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3976,7 +4928,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3991,7 +4943,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation>Tipe &lt;b&gt;help&lt;/b&gt; vir &apos;n oorsig van beskikbare bevele.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4049,12 +5001,6 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4146,40 +5092,37 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4637,7 +5580,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4758,7 +5701,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4872,7 +5815,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4895,7 +5838,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4907,7 +5850,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5031,7 +5974,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation>S&amp;tuur</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopieer hoeveelheid</translation>
     </message>
@@ -5091,7 +6034,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation> en </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Die Ontvanger se adres is nie geldig nie, asseblief recheck.</translation>
     </message>
@@ -5131,8 +6074,8 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation>Fout: Die transaksie verwerp is. Dit kan dalk gebeur as sommige van die munte in jou Beursie is reeds bestee is, so asof jy gebruik &apos;n afskrif van wallet.dat en munte was in die kopie bestee maar nie gemerk bestee hier.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(geen etiket)</translation>
     </message>
@@ -5239,7 +6182,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adres</translation>
     </message>
@@ -5377,42 +6320,42 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
         <translation>Tik &apos;n Gridcoin adres (bv. B8gZqgY4r2RoEdqYk3QsAqFckyf9pRHN6i)</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Die ingesleutelde posadres is ongeldig.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Kontroleer die adres, en probeer weer.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Die ingesleutelde adres verwys nie na &apos;n sleutel.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Beursie ontsluit is gekanselleer.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Private sleutel vir die ingesleutelde adres is nie beskikbaar nie.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Boodskap ondertekening het misluk.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Boodskap onderteken.</translation>
     </message>
@@ -5423,7 +6366,7 @@ Dit beteken dat &apos;n fooi van ten minste %2 word benodig.</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Kontroleer die handtekening en probeer weer.</translation>
     </message>
@@ -5474,7 +6417,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5482,32 +6425,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Oop tot %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>bots</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/Offline</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5530,74 +6473,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Bron</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Van</translation>
     </message>
@@ -5608,13 +6551,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Na</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>eie adres</translation>
@@ -5625,16 +6568,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etiket</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Krediet</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5647,31 +6590,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>nie aanvaar nie</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debiet</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Transaksie fooi</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Netto bedrag</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Boodskap</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Kommentaar</translation>
     </message>
@@ -5681,38 +6624,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
@@ -5744,11 +6687,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -5768,7 +6716,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Bedrag</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5796,12 +6744,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bevestig (%1 confirmations)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Bots</translation>
     </message>
@@ -6026,7 +6974,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transaksie status. Sweef oor hierdie gebied te wys nommer van confirmations.</translation>
     </message>
@@ -6054,7 +7037,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6109,7 +7092,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Min bedrag</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Maak kopie van adres</translation>
     </message>
@@ -6139,7 +7127,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Wys transaksie besonderhede</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Uitvoer transaksie Data</translation>
     </message>
@@ -6150,7 +7138,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Bevestig</translation>
     </message>
@@ -6195,7 +7183,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kon nie lêer %1 skryf nie.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Reeks:</translation>
     </message>
@@ -6231,19 +7219,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">S&amp;luit af</translation>
+        <translation type="obsolete">S&amp;luit af</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Sluit af</translation>
+        <translation type="obsolete">Sluit af</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Lêer</translation>
+        <translation type="obsolete">&amp;Lêer</translation>
     </message>
 </context>
 <context>
@@ -6257,7 +7242,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6283,18 +7268,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6371,15 +7356,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Stuur...</translation>
+        <translation type="vanished">Stuur...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>&apos;N Fout het voorgekom terwyl opstellings die RPC poort %u vir luister op IPv6, val terug na IPv4: %s</translation>
     </message>
@@ -6389,27 +7373,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>&apos;N Fout het voorgekom terwyl die RPC poort %u vir luister op IPv4 stel: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Gebruik:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lys bevele</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Kry hulp vir &apos;n bevel</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Waarskuwing: - paytxfee is baie hoog gestel! Dit is die transaksiefooi sal jy betaal as jy stuur &apos;n transaksie.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Waarskuwing: wallet.dat korrup, data herwin! Oorspronklike wallet.dat gestoor as Beursie. {timestamp} .bak in %s; As jou balans of transaksies is verkeerd jy moet &apos;n rugsteun teruggelaai.</translation>
     </message>
@@ -6419,13 +7403,13 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Waarskuwing: fout lees wallet.dat! Alle sleutels lees korrek, maar transaksie data of adres boek inskrywings dalk ontbreek of is foutief.</translation>
     </message>
     <message>
-        <location line="-191"/>
-        <location line="+344"/>
+        <location line="-228"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6450,12 +7434,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6475,21 +7459,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6520,11 +7490,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6544,7 +7509,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6584,7 +7549,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6620,11 +7585,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6664,12 +7624,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6734,7 +7689,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6746,11 +7701,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6821,16 +7771,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6950,11 +7890,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Het misluk om te luister op enige hawe. Gebruik - luister = 0 as jy dit wil hê.</translation>
     </message>
@@ -6981,16 +7916,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7069,16 +7994,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7101,11 +8016,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7149,18 +8059,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">(n.v.t)</translation>
+        <translation type="obsolete">(n.v.t)</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7181,6 +8085,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7409,78 +8318,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7535,16 +8374,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7554,7 +8383,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Die %s-opsie gebruik</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7563,7 +8392,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Gridcoin weergawe</translation>
     </message>
@@ -7578,7 +8407,7 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation>Ongeldige bedrag vir - mininput = &lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+101"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Beursie %s gesetel buite data gids %s.</translation>
     </message>
@@ -7588,12 +8417,85 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation>Verifieer tans databasis integriteit...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Fout met die inisialisering van databasis omgewing %s! Om te herwin, RUGSTEUN dat gids, dan verwyder alles uit dit behalwe vir wallet.dat.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7684,6 +8586,16 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7718,7 +8630,7 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation>Wallet.dat korrup, red, het misluk</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ongeldige - proxy adres: &apos;%s&apos;</translation>
     </message>
@@ -7728,7 +8640,7 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation>Ongeldige - TOR adres: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Adres kan oplos nie-penarie bevind: &apos;%s&apos;</translation>
     </message>
@@ -7738,12 +8650,12 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation>-ExternalIP adres kan oplos nie: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Ongeldige bedrag vir -reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Fout laai blkindex.dat</translation>
     </message>
@@ -7758,7 +8670,7 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation>Kon nie wallet.dat: Beursie vereis nuwer weergawe van Gridcoin</translation>
     </message>
     <message>
-        <location line="+149"/>
+        <location line="+125"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7803,7 +8715,7 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7813,37 +8725,37 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation>Beursie moes word week oorgeskryf: herlaai Gridcoin voltooi</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Fout laai wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Invoer bootstrap blockchain data lêer.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Laai adresse...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Fout: kon nie begin nie</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Kon nie bind aan %s op hierdie rekenaar nie. Gridcoin is waarskynlik reeds te laat loop.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Kon nie %s op hierdie rekenaar bind (penarie bevind teruggekeer fout %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Fout: Beursie gesluit, nie skep transaksie</translation>
     </message>
@@ -7858,37 +8770,36 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation>Fout: Hierdie transaksie vereis &apos;n transaksiefooi van ten minste %s as gevolg van sy bedrag, kompleksiteit, of gebruik van onlangs ontvang fondse</translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Stuur...</translation>
+        <translation type="vanished">Stuur...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Ongeldige bedrag</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Waarskuwing: Maak asseblief seker dat jou rekenaar se datum en tyd is korrek! As jou horlosie is verkeerd sal Gridcoin nie behoorlik werk nie.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Waarskuwing: Skyfspasie laag is!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Onbekende netwerk gespesifiseer in - onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Onvoldoende fondse</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Laai blok indeks...</translation>
     </message>
@@ -7898,7 +8809,7 @@ As die lêer bestaan nie, dit skep met eienaar-leesbare-net lêer toestemmings.<
         <translation>Laai beursie...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Verstek adres kan skryf</translation>
     </message>

--- a/src/qt/locale/bitcoin_ar.ts
+++ b/src/qt/locale/bitcoin_ar.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">نعم</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">لا</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;أمسح</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>نسخ &amp;الوصف</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>تعديل</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>وصف</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(لا وصف)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>أدخل عبارة مرور جديدة إلى المحفظة. الرجاء استخدام عبارة مرور تتكون من10 حروف عشوائية على الاقل, أو أكثر من 7 كلمات</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>تأكيد تشفير المحفظة</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>محفظة مشفرة</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>هام: أي نسخة إحتياطية سابقة  قمت بها لمحفظتك يجب استبدالها  بأخرى حديثة، مشفرة. لأسباب أمنية، النسخ الاحتياطية السابقة لملفات المحفظة الغير مشفرة تصبح عديمة الفائدة مع بداية استخدام المحفظة المشفرة الجديدة.</translation>
+        <translation type="vanished">هام: أي نسخة إحتياطية سابقة  قمت بها لمحفظتك يجب استبدالها  بأخرى حديثة، مشفرة. لأسباب أمنية، النسخ الاحتياطية السابقة لملفات المحفظة الغير مشفرة تصبح عديمة الفائدة مع بداية استخدام المحفظة المشفرة الجديدة.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>فشل تشفير المحفظة</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>فشل تشفير المحفظة بسبب خطأ داخلي. لم يتم تشفير محفظتك.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>كلمتي المرور ليستا متطابقتان</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>فشل فتح المحفظة</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>كلمة المرور التي تم إدخالها لفك تشفير المحفظة غير صحيحة.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>لقد تم تغير عبارة مرور المحفظة بنجاح</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>محفظة</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;نظرة عامة</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>خروج</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;التحقق من الرسالة...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>إفتح وحدة التصحيح و التشخيص</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;ملف</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;الاعدادات</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -826,17 +991,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>المعاملات  المرسلة</translation>
     </message>
@@ -854,17 +1019,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -884,7 +1039,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -902,7 +1057,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -919,7 +1084,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -934,12 +1099,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>المحفظة &lt;b&gt;مشفرة&lt;/b&gt; و &lt;b&gt;مقفلة&lt;/b&gt; حاليا</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -950,18 +1115,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -971,7 +1135,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1058,7 +1227,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1107,7 +1276,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1115,12 +1284,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1179,7 +1348,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1234,37 +1403,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>مبلغ</translation>
+        <translation type="vanished">مبلغ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">وصف</translation>
+        <translation type="obsolete">وصف</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">عنوان</translation>
+        <translation type="obsolete">عنوان</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>تاريخ</translation>
+        <translation type="vanished">تاريخ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>تأكيدات</translation>
+        <translation type="vanished">تأكيدات</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>تأكيد</translation>
+        <translation type="vanished">تأكيد</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>  انسخ عنوان</translation>
     </message>
@@ -1275,17 +1438,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>نسخ الكمية</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>نسخ رقم العملية</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>نسخ الكمية </translation>
     </message>
@@ -1315,17 +1478,17 @@ Expires: %3
         <translation>نسخ التعديل</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>نعم</translation>
     </message>
@@ -1365,20 +1528,61 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(لا وصف)</translation>
     </message>
     <message>
-        <location line="-10"/>
+        <source>(change)</source>
+        <translation type="vanished">(تغير)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(لا وصف)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
-        <translation>(تغير)</translation>
+        <translation type="unfinished">(تغير)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">مبلغ</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">وصف</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">عنوان</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">تاريخ</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">تأكيدات</translation>
     </message>
 </context>
 <context>
@@ -1404,7 +1608,7 @@ Expires: %3
         <translation type="unfinished">عنوان</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1466,7 +1670,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1501,37 +1705,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">مبلغ</translation>
+        <translation type="obsolete">مبلغ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">وصف</translation>
+        <translation type="obsolete">وصف</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">عنوان</translation>
+        <translation type="obsolete">عنوان</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">تاريخ</translation>
+        <translation type="obsolete">تاريخ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">تأكيدات</translation>
+        <translation type="obsolete">تأكيدات</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">تأكيد</translation>
+        <translation type="obsolete">تأكيد</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1566,7 +1764,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1576,25 +1774,18 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(لا وصف)</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(تغير)</translation>
+        <translation type="obsolete">(تغير)</translation>
     </message>
 </context>
 <context>
@@ -1744,7 +1935,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1769,7 +1965,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1945,7 +2141,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1960,6 +2156,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1968,7 +2169,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1996,7 +2197,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2080,22 +2290,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2159,7 +2369,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2278,6 +2488,382 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">مسح الكل</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">نعم</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">لا</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">تم الغاء عملية فتح المحفظة</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2593,7 +3179,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>الافتراضي</translation>
     </message>
@@ -2608,7 +3194,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">خطأ</translation>
@@ -2836,18 +3422,23 @@ Expires: %3
         <translation>رصيدك الكلي الحالي</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">نسخ الكمية</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2858,9 +3449,239 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">الحالة.</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">مبلغ</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2974,7 +3795,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,6 +3835,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3049,7 +3875,7 @@ Expires: %3
         <translation type="unfinished">نمودج</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3059,7 +3885,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3072,7 +3908,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3125,6 +3961,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">نعم</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">لا</translation>
     </message>
 </context>
 <context>
@@ -3209,12 +4122,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3239,12 +4157,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3331,7 +4249,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3369,7 +4287,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">غير معروف</translation>
     </message>
@@ -3503,14 +4421,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3520,7 +4472,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3535,12 +4487,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3550,7 +4525,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3612,6 +4587,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3707,7 +4687,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>غير معروف</translation>
     </message>
@@ -3863,7 +4843,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4026,7 +5006,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -4041,7 +5021,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation>%1 بايت</translation>
     </message>
@@ -4099,12 +5079,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4196,40 +5170,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4687,7 +5658,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4808,7 +5779,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4922,7 +5893,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4945,7 +5916,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4957,7 +5928,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +6052,7 @@ Expires: %3
         <translation>&amp;ارسال</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>نسخ الكمية </translation>
     </message>
@@ -5141,7 +6112,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5181,8 +6152,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(لا وصف)</translation>
     </message>
@@ -5289,7 +6260,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">عنوان</translation>
     </message>
@@ -5427,58 +6398,58 @@ Expires: %3
         <translation>اضغط  &quot;توقيع الرسالة&quot; لتوليد التوقيع</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>العنوان المدخل غير صالح</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>الرجاء التأكد من العنوان والمحاولة مرة اخرى</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>العنوان المدخل لا يشير الى مفتاح</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>تم الغاء عملية فتح المحفظة</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>المفتاح الخاص للعنوان المدخل غير موجود.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>فشل توقيع الرسالة.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>الرسالة موقعة.</translation>
     </message>
     <message>
         <location line="+61"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>فضلا تاكد من التوقيع وحاول مرة اخرى</translation>
     </message>
     <message>
-        <location line="-13"/>
+        <location line="-16"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5524,7 +6495,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5536,32 +6507,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>مفتوح حتى %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1 غير متواجد</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>غير مؤكدة/%1</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>تأكيد %1</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>الحالة.</translation>
     </message>
@@ -5588,74 +6559,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>تاريخ</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>المصدر</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>من</translation>
     </message>
@@ -5666,13 +6637,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>الى</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>عنوانه</translation>
@@ -5683,16 +6654,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>علامة</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5709,31 +6680,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>غير مقبولة</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>دين</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>رسوم المعاملة</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>رسالة </translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>تعليق</translation>
     </message>
@@ -5743,38 +6714,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>مبلغ</translation>
     </message>
@@ -5806,11 +6777,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>تاريخ</translation>
     </message>
@@ -5830,7 +6806,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">مبلغ</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5862,12 +6838,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>يتعارض</translation>
     </message>
@@ -6092,7 +7068,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>حالة المعاملة. تحوم حول هذا الحقل لعرض عدد  التأكيدات.</translation>
     </message>
@@ -6120,7 +7131,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6175,7 +7186,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>الحد الأدنى</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>  انسخ عنوان</translation>
     </message>
@@ -6205,7 +7221,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>عرض تفاصيل المعاملة</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6216,7 +7232,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>تأكيد</translation>
     </message>
@@ -6261,7 +7277,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>المدى:</translation>
     </message>
@@ -6297,19 +7313,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">خروج</translation>
+        <translation type="obsolete">خروج</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">الخروج من التطبيق</translation>
+        <translation type="obsolete">الخروج من التطبيق</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;ملف</translation>
+        <translation type="obsolete">&amp;ملف</translation>
     </message>
 </context>
 <context>
@@ -6323,7 +7336,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6349,18 +7362,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6435,43 +7448,35 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>فشل في الاستماع على أي منفذ. استخدام الاستماع = 0 إذا كنت تريد هذا.</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>عنوان البروكسي غير صحيح : &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>تحميل العنوان</translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="-14"/>
         <source>Insufficient funds</source>
         <translation>اموال غير كافية</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6497,17 +7502,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6531,21 +7556,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6586,11 +7597,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6607,6 +7613,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6651,6 +7667,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6691,11 +7712,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6741,11 +7757,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6833,6 +7844,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6844,11 +7860,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6919,16 +7930,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7092,11 +8093,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7119,16 +8115,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7248,16 +8234,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7292,7 +8268,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>تحميل المحفظه</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7313,82 +8289,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7439,16 +8340,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7529,6 +8420,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7638,6 +8534,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7672,18 +8578,41 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>لايمكن كتابة العنوان الافتراضي</translation>
     </message>
     <message>
-        <location line="+78"/>
-        <source>Local version: </source>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>MB/s</source>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+328"/>
+        <source>Local version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7727,18 +8656,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">غير معروف</translation>
+        <translation type="obsolete">غير معروف</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7759,6 +8682,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7967,7 +8895,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>إعادة مسح</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>انتهاء التحميل</translation>
     </message>

--- a/src/qt/locale/bitcoin_be_BY.ts
+++ b/src/qt/locale/bitcoin_be_BY.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">так</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">не</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Выдаліць</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Капіяваць Метку</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Рэдагаваць</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Метка</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>непазначаны</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Увядзіце новы пароль для гаманца.&lt;br/&gt;Парольная фраза павинна складацца&lt;b&gt; не меньш чым з дзесяці сімвалаў&lt;/b&gt;, ці &lt;b&gt;больш чым з васьмі слоў&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Пацвердзіце шыфраванне гаманца</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Гаманец зашыфраваны</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>ВАЖНА: Усе папярэднія копіі гаманца варта замяніць новым зашыфраваным файлам. У мэтах бяспекі папярэднія копіі незашыфраванага файла-гаманца стануць неўжывальнымі, калі вы станеце карыстацца новым зашыфраваным гаманцом.</translation>
+        <translation type="vanished">ВАЖНА: Усе папярэднія копіі гаманца варта замяніць новым зашыфраваным файлам. У мэтах бяспекі папярэднія копіі незашыфраванага файла-гаманца стануць неўжывальнымі, калі вы станеце карыстацца новым зашыфраваным гаманцом.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Шыфраванне гаманца няўдалае</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Шыфраванне гаманца не адбылося з-за ўнутранай памылкі. Гаманец незашыфраваны.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Уведдзеныя паролі не супадаюць</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Разблакаванне гаманца няўдалае</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Уведзены пароль  для расшыфравання гаманца памылковы</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Парольная фраза гаманца паспяхова зменена.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Гаманец</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>Агляд</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Выйсці</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Праверыць паведамленне...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Адкрыць кансоль дыягностыкі і адладкі</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>Ф&amp;айл</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>Наладкі</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,17 +973,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Дасланыя транзакцыі</translation>
     </message>
@@ -836,17 +1001,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -866,7 +1021,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -884,7 +1039,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -901,7 +1066,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +1081,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Гаманец &lt;b&gt;зашыфраваны&lt;/b&gt; і зараз &lt;b&gt;заблакаваны&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -932,18 +1097,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +1117,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1040,7 +1209,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1089,7 +1258,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,12 +1266,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,7 +1330,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1216,37 +1385,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Колькасць</translation>
+        <translation type="vanished">Колькасць</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Метка</translation>
+        <translation type="obsolete">Метка</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Адрас</translation>
+        <translation type="obsolete">Адрас</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>Дата</translation>
+        <translation type="vanished">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Пацверджанняў</translation>
+        <translation type="vanished">Пацверджанняў</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Пацверджана</translation>
+        <translation type="vanished">Пацверджана</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Капіяваць адрас</translation>
     </message>
@@ -1257,17 +1420,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Капіяваць колькасць</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Капіяваць ID транзакцыі</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Капіяваць колькасць</translation>
     </message>
@@ -1297,17 +1460,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>так</translation>
     </message>
@@ -1347,20 +1510,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>непазначаны</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">непазначаны</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Колькасць</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Метка</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Адрас</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Дата</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Пацверджанняў</translation>
     </message>
 </context>
 <context>
@@ -1386,7 +1586,7 @@ Expires: %3
         <translation type="unfinished">Адрас</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1448,7 +1648,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,37 +1683,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Колькасць</translation>
+        <translation type="obsolete">Колькасць</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Метка</translation>
+        <translation type="obsolete">Метка</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Адрас</translation>
+        <translation type="obsolete">Адрас</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Дата</translation>
+        <translation type="obsolete">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Пацверджанняў</translation>
+        <translation type="obsolete">Пацверджанняў</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Пацверджана</translation>
+        <translation type="obsolete">Пацверджана</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1548,7 +1742,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,25 +1752,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">непазначаны</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1726,7 +1909,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1751,7 +1939,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1927,7 +2115,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,6 +2130,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1950,7 +2143,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1978,7 +2171,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2053,22 +2255,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2132,7 +2334,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2251,6 +2453,373 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">так</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">не</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2566,7 +3135,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2581,7 +3150,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Памылка</translation>
@@ -2809,18 +3378,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Капіяваць колькасць</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2831,9 +3405,227 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Статус</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Колькасць</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2947,7 +3739,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2987,6 +3779,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3022,7 +3819,7 @@ Expires: %3
         <translation type="unfinished">Форма</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3032,7 +3829,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,7 +3852,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3098,6 +3905,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">так</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">не</translation>
     </message>
 </context>
 <context>
@@ -3182,12 +4066,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3212,12 +4101,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3304,7 +4193,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3342,7 +4231,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3458,14 +4347,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4398,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,12 +4413,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,7 +4451,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3567,6 +4513,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3677,7 +4628,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3818,7 +4769,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4932,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3996,7 +4947,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4054,12 +5005,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4151,40 +5096,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4642,7 +5584,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4763,7 +5705,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4877,7 +5819,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4900,7 +5842,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4912,7 +5854,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5036,7 +5978,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Капіяваць колькасць</translation>
     </message>
@@ -5096,7 +6038,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5136,8 +6078,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>непазначаны</translation>
     </message>
@@ -5244,7 +6186,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Адрас</translation>
     </message>
@@ -5382,42 +6324,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5428,7 +6370,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5479,7 +6421,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5488,32 +6430,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/непацверджана</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 пацверджанняў</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Статус</translation>
     </message>
@@ -5537,74 +6479,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5615,13 +6557,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5632,16 +6574,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5655,31 +6597,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Паведамленне</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Каментар</translation>
     </message>
@@ -5689,38 +6631,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Колькасць</translation>
     </message>
@@ -5752,11 +6694,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
@@ -5776,7 +6723,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Колькасць</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5805,12 +6752,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Пацверджана (%1 пацверджанняў)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6035,7 +6982,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Статус транзакцыі. Навядзіце курсар на гэтае поле, каб паказаць колькасць пацверджанняў.</translation>
     </message>
@@ -6063,7 +7045,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,7 +7100,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Мін. колькасць</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Капіяваць адрас</translation>
     </message>
@@ -6148,7 +7135,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6159,7 +7146,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Пацверджана</translation>
     </message>
@@ -6204,7 +7191,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Прамежак:</translation>
     </message>
@@ -6240,19 +7227,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Выйсці</translation>
+        <translation type="obsolete">Выйсці</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Выйсці з праграмы</translation>
+        <translation type="obsolete">Выйсці з праграмы</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">Ф&amp;айл</translation>
+        <translation type="obsolete">Ф&amp;айл</translation>
     </message>
 </context>
 <context>
@@ -6266,7 +7250,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6292,18 +7276,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6378,33 +7362,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+381"/>
+        <location filename="../bitcoinstrings.cpp" line="+411"/>
         <source>Loading addresses...</source>
         <translation>Загружаем адрасы...</translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="-14"/>
         <source>Insufficient funds</source>
         <translation>Недастаткова сродкаў</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6430,17 +7406,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6464,21 +7460,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6519,11 +7501,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6540,6 +7517,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6584,6 +7571,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6624,11 +7616,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6674,11 +7661,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6766,6 +7748,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6777,11 +7764,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6852,16 +7834,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7031,11 +8003,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7062,16 +8029,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7196,16 +8153,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7242,11 +8189,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7291,17 +8233,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7322,6 +8254,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7551,82 +8488,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7677,16 +8539,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7767,6 +8619,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7876,6 +8733,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7910,12 +8777,40 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-200"/>
+        <location line="-179"/>
         <source>Done loading</source>
         <translation>Загрузка выканана</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-295"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+278"/>
         <source>Error</source>
         <translation>Памылка</translation>
     </message>

--- a/src/qt/locale/bitcoin_bg.ts
+++ b/src/qt/locale/bitcoin_bg.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">да</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">не</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Изтриване</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Копирай &amp;име</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Редактирай</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Име</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(без име)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Въведете новата парола към портфейла.&lt;br/&gt;Моля ползвайте парола съставена от &lt;b&gt;десет или повече произволни символа&lt;/b&gt;, или &lt;b&gt;осем или повече думи&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Потвърдете на шифрирането на портфейла</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Портфейлът е шифриран</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>ВАЖНО: Всички стари запазвания, които сте направили на Вашият портфейл трябва да замените с запазване на новополучения, шифриран портфейл. От съображения за сигурност, предишните запазвания на нешифрирани портфейли ще станат неизползваеми веднага, щом започнете да използвате новият, шифриран портфейл.</translation>
+        <translation type="vanished">ВАЖНО: Всички стари запазвания, които сте направили на Вашият портфейл трябва да замените с запазване на новополучения, шифриран портфейл. От съображения за сигурност, предишните запазвания на нешифрирани портфейли ще станат неизползваеми веднага, щом започнете да използвате новият, шифриран портфейл.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Шифрирането беше неуспешно</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Шифрирането на портфейла беше неуспешно, поради софтуерен проблем. Портфейлът не е шифриран.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Паролите не съвпадат</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Неуспешно отключване на портфейла</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Паролата въведена за дешифриране на портфейла е грешна.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Паролата на портфейла беше променена успешно.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Портфейл</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Баланс</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Из&amp;ход</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Проверка на съобщение...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Отворете конзолата за диагностика и отстраняване на грешки</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Настройки</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Изходяща транзакция</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Портфейлът е &lt;b&gt;криптиран&lt;/b&gt; и &lt;b&gt;заключен&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Сума</translation>
+        <translation type="vanished">Сума</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Име</translation>
+        <translation type="obsolete">Име</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Адрес</translation>
+        <translation type="obsolete">Адрес</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>Дата</translation>
+        <translation type="vanished">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Потвърждения</translation>
+        <translation type="vanished">Потвърждения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Потвърдени</translation>
+        <translation type="vanished">Потвърдени</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Копирай адрес</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Копирай сума</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Копирай транзакция с ID</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Копиране на количеството</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Копирай рестото</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>да</translation>
     </message>
@@ -1341,20 +1504,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(без име)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>ресто от %1 (%2)</translation>
+        <translation type="vanished">ресто от %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(промени)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(без име)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">ресто от %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(промени)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Сума</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(промени)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Име</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Адрес</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Дата</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Потвърждения</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1588,7 @@ Expires: %3
         <translation type="unfinished">Адрес</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1650,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1685,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Сума</translation>
+        <translation type="obsolete">Сума</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Име</translation>
+        <translation type="obsolete">Име</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Адрес</translation>
+        <translation type="obsolete">Адрес</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Дата</translation>
+        <translation type="obsolete">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Потвърждения</translation>
+        <translation type="obsolete">Потвърждения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Потвърдени</translation>
+        <translation type="obsolete">Потвърдени</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1744,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1754,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(без име)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">ресто от %1 (%2)</translation>
+        <translation type="obsolete">ресто от %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(промени)</translation>
+        <translation type="obsolete">(промени)</translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1919,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1949,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2125,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2140,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2153,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2181,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2262,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2341,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2460,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;Изчисти</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">да</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">не</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Отключването на портфейла беше отменено.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3139,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>подразбиране</translation>
     </message>
@@ -2572,7 +3154,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Грешка</translation>
@@ -2800,18 +3382,23 @@ Expires: %3
         <translation>Текущият ви общ баланс</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Копирай сума</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3409,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Статус</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Сума</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3739,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3779,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3819,7 @@ Expires: %3
         <translation type="unfinished">Формуляр</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3829,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3852,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,6 +3905,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">да</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">не</translation>
     </message>
 </context>
 <context>
@@ -3173,12 +4066,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4101,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4193,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4231,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">Несъществуващ</translation>
     </message>
@@ -3443,14 +4341,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4392,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4407,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4445,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4507,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3647,7 +4607,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>Несъществуващ</translation>
     </message>
@@ -3778,7 +4738,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4926,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4941,7 @@ Expires: %3
         <translation>Въведeте &lt;/b&gt;помощ&lt;/b&gt; за да видите наличните команди.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation>%1 Байт</translation>
     </message>
@@ -4039,12 +4999,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5090,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5578,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5699,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5813,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5836,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5848,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5972,7 @@ Expires: %3
         <translation>И&amp;зпрати</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Копиране на количеството</translation>
     </message>
@@ -5081,7 +6032,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6072,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(без име)</translation>
     </message>
@@ -5229,7 +6180,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Адрес</translation>
     </message>
@@ -5367,42 +6318,42 @@ Expires: %3
         <translation>Натиснете &quot;Подписване на съобщение&quot; за да създадете подпис</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Въведеният адрес е невалиден.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Моля проверете адреса и опитайте отново.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Въведеният адрес не може да се съпостави с валиден ключ.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Отключването на портфейла беше отменено.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Не е наличен частен ключ за въведеният адрес.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Подписването на съобщение беше неуспешно.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Съобщението е подписано.</translation>
     </message>
@@ -5413,7 +6364,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Проверете подписа и опитайте отново.</translation>
     </message>
@@ -5464,7 +6415,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6423,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Подлежи на промяна до %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/офлайн</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/непотвърдени</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>включена в %1 блока</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Статус</translation>
     </message>
@@ -5520,74 +6471,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Източник</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>От</translation>
     </message>
@@ -5598,13 +6549,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>За</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>собствен адрес</translation>
@@ -5615,16 +6566,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>име</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Кредит</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6588,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>не е приет</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Дебит</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Такса</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Нетна сума</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Съобщение</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Коментар</translation>
     </message>
@@ -5671,38 +6622,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Сума</translation>
     </message>
@@ -5734,11 +6685,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
@@ -5758,7 +6714,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Сума</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6742,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Потвърдени (%1 потвърждения)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Конфликтно</translation>
     </message>
@@ -6016,7 +6972,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Състояние на транзакцията. Задръжте върху това поле за брой потвърждения.</translation>
     </message>
@@ -6044,7 +7035,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7090,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Минимална сума</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Копирай адрес</translation>
     </message>
@@ -6129,7 +7125,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Подробности за транзакцията</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7136,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Потвърдени</translation>
     </message>
@@ -6185,7 +7181,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>От:</translation>
     </message>
@@ -6221,19 +7217,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Из&amp;ход</translation>
+        <translation type="obsolete">Из&amp;ход</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Изход от приложението</translation>
+        <translation type="obsolete">Изход от приложението</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Файл</translation>
+        <translation type="obsolete">&amp;Файл</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7240,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7266,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,43 +7352,35 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Провалено &quot;слушане&quot; на всеки порт. Използвайте -listen=0 ако искате това.</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Невалиден -proxy address: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>Зареждане на адреси...</translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="-14"/>
         <source>Insufficient funds</source>
         <translation>Недостатъчно средства</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6421,17 +7406,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6455,21 +7460,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6510,11 +7501,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6531,6 +7517,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6575,6 +7571,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6615,11 +7616,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6665,11 +7661,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6757,6 +7748,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6768,11 +7764,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6843,16 +7834,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7021,11 +8002,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7048,16 +8024,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7177,16 +8143,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7223,11 +8179,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7271,18 +8222,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">Несъществуващ</translation>
+        <translation type="obsolete">Несъществуващ</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7303,6 +8248,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7532,82 +8482,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7658,16 +8533,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7748,6 +8613,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7857,6 +8727,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7891,12 +8771,40 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-200"/>
+        <location line="-179"/>
         <source>Done loading</source>
         <translation>Зареждането е завършено</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-295"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+278"/>
         <source>Error</source>
         <translation>Грешка</translation>
     </message>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Elimina</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copia l&apos;eti&amp;queta</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Edita</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introduïu la contrasenya nova al moneder.&lt;br/&gt;Utilitzeu una contrasenya de &lt;b&gt;deu o més caràcters aleatoris&lt;/b&gt;, o &lt;b&gt;vuit o més paraules&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Introduïu l&apos;antiga i la nova frase-contrasenya per a la cartera.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirma l&apos;encriptació del moneder</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Moneder encriptat</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANT: Tota copia de seguretat que hàgiu realitzat hauria de ser reemplaçada pel, recentment generat, fitxer encriptat del moneder. Per motius de seguretat, les còpies de seguretat anteriors del fitxer de moneder no encriptat esdevindran inusables tan aviat com començar a utilitzar el nou moneder encriptat.</translation>
+        <translation type="vanished">IMPORTANT: Tota copia de seguretat que hàgiu realitzat hauria de ser reemplaçada pel, recentment generat, fitxer encriptat del moneder. Per motius de seguretat, les còpies de seguretat anteriors del fitxer de moneder no encriptat esdevindran inusables tan aviat com començar a utilitzar el nou moneder encriptat.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>L&apos;encriptació del moneder ha fallat</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>L&apos;encriptació del moneder ha fallat per un error intern. El moneder no ha estat encriptat.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Les contrasenyes introduïdes no coincideixen.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>El desbloqueig del moneder ha fallat</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contrasenya introduïda per a desencriptar el moneder és incorrecta.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>La contrasenya del moneder ha estat modificada correctament.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Moneder</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Panorama general</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>S&amp;urt</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifica el missatge...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Obre la consola de diagnòstic i depuració</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fitxer</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuració</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transacció enviada</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>El moneder està &lt;b&gt;encriptat&lt;/b&gt; i actualment &lt;b&gt;bloquejat&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Import</translation>
+        <translation type="vanished">Import</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmacions</translation>
+        <translation type="vanished">Confirmacions</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmat</translation>
+        <translation type="vanished">Confirmat</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Adreça</translation>
+        <translation type="vanished">Adreça</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copia l&apos;adreça</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copia l&apos;import</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copia l&apos;ID de transacció</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copia la quantitat</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Copia el canvi</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>sí</translation>
     </message>
@@ -1341,20 +1504,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>canvia de %1 (%2)</translation>
+        <translation type="vanished">canvia de %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(canvia)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(sense etiqueta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">canvia de %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(canvia)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Import</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(canvia)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adreça</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmacions</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1588,7 @@ Expires: %3
         <translation type="unfinished">Adreça</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1650,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1685,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Import</translation>
+        <translation type="obsolete">Import</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adreça</translation>
+        <translation type="obsolete">Adreça</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Confirmacions</translation>
+        <translation type="obsolete">Confirmacions</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmat</translation>
+        <translation type="obsolete">Confirmat</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1744,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1754,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">canvia de %1 (%2)</translation>
+        <translation type="obsolete">canvia de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(canvia)</translation>
+        <translation type="obsolete">(canvia)</translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1919,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1949,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2125,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2140,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2153,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2181,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2262,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2341,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2460,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Neteja-ho &amp;tot</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">El desbloqueig del moneder ha estat cancelat.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3139,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>Per defecte</translation>
     </message>
@@ -2572,7 +3154,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2800,18 +3382,23 @@ Expires: %3
         <translation>El balanç total actual</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copia l&apos;import</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3409,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Estat</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Import</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3739,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3779,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3819,7 @@ Expires: %3
         <translation type="unfinished">Formulari</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3829,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3852,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3904,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4066,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4101,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4193,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4231,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4341,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4392,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4407,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4445,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4507,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3687,7 +4647,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3783,7 +4743,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4926,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4941,7 @@ Expires: %3
         <translation>Escriviu &lt;b&gt;help&lt;\b&gt; per a obtenir un llistat de les ordres disponibles.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4999,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5090,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5578,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5699,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5813,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5836,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5848,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5972,7 @@ Expires: %3
         <translation>E&amp;nvia</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copia la quantitat</translation>
     </message>
@@ -5081,7 +6032,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6072,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
@@ -5229,7 +6180,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adreça</translation>
     </message>
@@ -5367,42 +6318,42 @@ Expires: %3
         <translation>Feu clic a «Signa el missatge» per a generar una signatura</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>L&apos;adreça introduïda no és vàlida.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Comproveu l&apos;adreça i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>L&apos;adreça introduïda no referencia a cap clau.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>El desbloqueig del moneder ha estat cancelat.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La clau privada per a la adreça introduïda no està disponible.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>La signatura del missatge ha fallat.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Missatge signat.</translation>
     </message>
@@ -5413,7 +6364,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Comproveu la signatura i torneu-ho a provar.</translation>
     </message>
@@ -5464,7 +6415,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6423,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Obert fins %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/fora de línia</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/sense confirmar</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmacions</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Estat</translation>
     </message>
@@ -5520,74 +6471,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -5598,13 +6549,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>adreça pròpia</translation>
@@ -5615,16 +6566,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Crèdit</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6588,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>no acceptat</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Dèbit</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Comissió de transacció</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Import net</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Missatge</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Comentari</translation>
     </message>
@@ -5671,38 +6622,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Import</translation>
     </message>
@@ -5734,11 +6685,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5758,7 +6714,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Import</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6742,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmat (%1 confirmacions)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>En conflicte</translation>
     </message>
@@ -6016,7 +6972,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estat de la transacció. Desplaceu-vos sobre aquest camp per mostrar el nombre de confirmacions.</translation>
     </message>
@@ -6044,7 +7035,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7090,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Import mínim</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copia l&apos;adreça</translation>
     </message>
@@ -6129,7 +7125,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mostra detalls de la transacció</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7136,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmat</translation>
     </message>
@@ -6185,7 +7181,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Rang:</translation>
     </message>
@@ -6221,19 +7217,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">S&amp;urt</translation>
+        <translation type="obsolete">S&amp;urt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Surt de l&apos;aplicació</translation>
+        <translation type="obsolete">Surt de l&apos;aplicació</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fitxer</translation>
+        <translation type="obsolete">&amp;Fitxer</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7240,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7266,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,38 +7352,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ha fallat escoltar a qualsevol port. Feu servir -listen=0 si voleu fer això.</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Adreça -proxy invalida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>S&apos;estan carregant les adreces...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6435,17 +7415,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6466,6 +7436,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6680,42 +7655,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6769,7 +7709,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6799,18 +7739,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Xarxa desconeguda especificada a -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Balanç insuficient</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6836,17 +7776,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6870,21 +7830,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6925,11 +7871,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6946,6 +7887,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6990,6 +7941,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7030,11 +7986,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7080,11 +8031,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7172,6 +8118,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7183,11 +8134,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7258,16 +8204,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7436,11 +8372,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7463,16 +8394,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7592,16 +8513,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7636,7 +8547,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>S&apos;està carregant el moneder...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7646,57 +8557,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+20"/>
         <source>Unknown poll response type.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7743,6 +8604,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7852,6 +8718,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7886,17 +8762,45 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>No es pot escriure l&apos;adreça per defecte</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+383"/>
         <source>Rescanning...</source>
         <translation>S&apos;està reescanejant...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Ha acabat la càrrega</translation>
     </message>

--- a/src/qt/locale/bitcoin_ca_ES.ts
+++ b/src/qt/locale/bitcoin_ca_ES.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Elimina</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copia l&apos;eti&amp;queta</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Edita</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exportar dades de la llibreta d&apos;adreces </translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Només per a fer &quot;stake&quot;</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introduïu la contrasenya nova al moneder.&lt;br/&gt;Utilitzeu una contrasenya de &lt;b&gt;deu o més caràcters aleatoris&lt;/b&gt;, o &lt;b&gt;vuit o més paraules&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Introdueixi tant l&apos;antiga com la nova contrasenya de moneder.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirma l&apos;encriptació del moneder</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Esteu segur que voleu encriptar el vostre moneder?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Moneder encriptat</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin tancarà ara per acabar el procés de xifrat. Recordeu que l&apos;encriptació del seu moneder no pot protegir completament les seves monedes de ser robades pel malware que pugui infectar al seu equip.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANT: Tota copia de seguretat que hàgiu realitzat hauria de ser reemplaçada pel, recentment generat, fitxer encriptat del moneder. Per motius de seguretat, les còpies de seguretat anteriors del fitxer de moneder no encriptat esdevindran inusables tan aviat com començar a utilitzar el nou moneder encriptat.</translation>
+        <translation type="vanished">IMPORTANT: Tota copia de seguretat que hàgiu realitzat hauria de ser reemplaçada pel, recentment generat, fitxer encriptat del moneder. Per motius de seguretat, les còpies de seguretat anteriors del fitxer de moneder no encriptat esdevindran inusables tan aviat com començar a utilitzar el nou moneder encriptat.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>L&apos;encriptació del moneder ha fallat</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>L&apos;encriptació del moneder ha fallat per un error intern. El moneder no ha estat encriptat.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Les contrasenyes introduïdes no coincideixen.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>El desbloqueig del moneder ha fallat</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contrasenya introduïda per a desencriptar el moneder és incorrecta.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>La contrasenya del moneder ha estat modificada correctament.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>S&apos;ha produït un error fatal. Gridcoin ja no pot continuar de forma segura i es tancarà.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Moneder</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Panorama general</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>S&amp;urt</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifica el missatge...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Exportar...</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Obre la consola de diagnòstic i depuració</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fitxer</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuració</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Client Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +972,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>El darrer bloc rebut s&apos;ha generat %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Aquesta transacció es troba sobre el límit de mida. Encara pot enviar-la amb una comisió de %1, aquesta va als nodes que processen la seva transacció i ajuda a mantenir la xarxa. Vol pagar la quota?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Confirmeu comisió</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transacció enviada</translation>
     </message>
@@ -835,17 +1000,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -865,7 +1020,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -883,7 +1038,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Manejant URI</translation>
@@ -900,7 +1065,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -915,12 +1080,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>El moneder està &lt;b&gt;encriptat&lt;/b&gt; i actualment &lt;b&gt;bloquejat&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Realitzar còpia de seguretat del moneder</translation>
     </message>
@@ -931,18 +1096,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Còpia de seguretat fallida</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Hi ha un error al tractar de salvar les dades del seu moneder a la nova ubicació.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,7 +1116,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1208,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alerta de xarxa</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Import</translation>
+        <translation type="vanished">Import</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmacions</translation>
+        <translation type="vanished">Confirmacions</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmat</translation>
+        <translation type="vanished">Confirmat</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="vanished">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Adreça</translation>
+        <translation type="vanished">Adreça</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copia l&apos;adreça</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copia l&apos;import</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copia l&apos;ID de transacció</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copia la quantitat</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Copia el canvi</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>POLS</translation>
     </message>
@@ -1351,20 +1514,65 @@ Les quantitats inferiors a 0.546 vegades la quota mínima del relé es mostren c
 En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>canvia de %1 (%2)</translation>
+        <translation type="vanished">canvia de %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(canvia)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(sense etiqueta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">canvia de %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(canvia)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(canvia)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmacions</translation>
     </message>
 </context>
 <context>
@@ -1390,7 +1598,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1660,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,37 +1695,23 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Confirmacions</translation>
+        <translation type="obsolete">Confirmacions</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmat</translation>
+        <translation type="obsolete">Confirmat</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,7 +1746,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1562,25 +1756,22 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">canvia de %1 (%2)</translation>
+        <translation type="obsolete">canvia de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(canvia)</translation>
+        <translation type="obsolete">(canvia)</translation>
     </message>
 </context>
 <context>
@@ -1730,7 +1921,12 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1755,7 +1951,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1931,7 +2127,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1946,6 +2142,11 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1954,7 +2155,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versió</translation>
     </message>
@@ -1982,7 +2183,16 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2054,22 +2264,22 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2133,7 +2343,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2252,6 +2462,370 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Neteja-ho &amp;tot</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">El desbloqueig del moneder ha estat cancelat.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2567,7 +3141,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation>&amp;Cancel·la</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>Per defecte</translation>
     </message>
@@ -2582,7 +3156,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2810,18 +3384,23 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copia l&apos;import</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2832,9 +3411,223 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Estat</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2948,7 +3741,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2988,6 +3781,11 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3023,7 +3821,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished">Formulari</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3033,7 +3831,17 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3046,7 +3854,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3098,6 +3906,83 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3183,12 +4068,17 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3213,12 +4103,12 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3305,7 +4195,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3343,7 +4233,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3453,14 +4343,48 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3470,7 +4394,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3485,12 +4409,35 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,7 +4447,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3562,6 +4509,11 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3692,7 +4644,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3763,7 +4715,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3976,7 +4928,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3991,7 +4943,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation>Escriviu &lt;b&gt;help&lt;\b&gt; per a obtenir un llistat de les ordres disponibles.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4049,12 +5001,6 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4146,40 +5092,37 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4637,7 +5580,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4758,7 +5701,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4872,7 +5815,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4895,7 +5838,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4907,7 +5850,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5031,7 +5974,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation>E&amp;nvia</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copia la quantitat</translation>
     </message>
@@ -5091,7 +6034,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation>i</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>L&apos;adreça remetent no és vàlida, si us plau comprovi-la.</translation>
     </message>
@@ -5131,8 +6074,8 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation>Error: La transacció ha sigut rebutjada. Això pot passar si algunes de les monedes al moneder ja s&apos;han gastat, per exemple, si vostè utilitza una còpia del wallet.dat i les monedes han estat gastades a la cópia pero no s&apos;han marcat com a gastades aqui.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
@@ -5239,7 +6182,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5377,42 +6320,42 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
         <translation>Introduïu la signatura Gridcoin</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>L&apos;adreça introduïda no és vàlida.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Comproveu l&apos;adreça i torneu-ho a provar.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>L&apos;adreça introduïda no referencia a cap clau.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>El desbloqueig del moneder ha estat cancelat.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La clau privada per a la adreça introduïda no està disponible.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>La signatura del missatge ha fallat.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Missatge signat.</translation>
     </message>
@@ -5423,7 +6366,7 @@ En aquest cas es requereix una comisió d&apos;almenys %2.</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Comproveu la signatura i torneu-ho a provar.</translation>
     </message>
@@ -5474,7 +6417,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5482,32 +6425,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Obert fins %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>conflicte</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/fora de línia</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/sense confirmar</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmacions</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Estat</translation>
     </message>
@@ -5530,74 +6473,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -5608,13 +6551,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>adreça pròpia</translation>
@@ -5625,16 +6568,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Crèdit</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5647,31 +6590,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>no acceptat</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Dèbit</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Comissió de transacció</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Import net</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Missatge</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Comentari</translation>
     </message>
@@ -5681,38 +6624,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Import</translation>
     </message>
@@ -5744,11 +6687,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5768,7 +6716,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Quantitat</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5796,12 +6744,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmat (%1 confirmacions)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>En conflicte</translation>
     </message>
@@ -6026,7 +6974,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estat de la transacció. Desplaceu-vos sobre aquest camp per mostrar el nombre de confirmacions.</translation>
     </message>
@@ -6054,7 +7037,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6109,7 +7092,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Import mínim</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copia l&apos;adreça</translation>
     </message>
@@ -6139,7 +7127,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mostra detalls de la transacció</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exportació de dades de transaccions</translation>
     </message>
@@ -6150,7 +7138,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmat</translation>
     </message>
@@ -6195,7 +7183,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>No s&apos;ha pogut escriure al fitxer %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Rang:</translation>
     </message>
@@ -6231,19 +7219,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">S&amp;urt</translation>
+        <translation type="obsolete">S&amp;urt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Surt de l&apos;aplicació</translation>
+        <translation type="obsolete">Surt de l&apos;aplicació</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fitxer</translation>
+        <translation type="obsolete">&amp;Fitxer</translation>
     </message>
 </context>
 <context>
@@ -6257,7 +7242,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6283,18 +7268,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6371,15 +7356,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Enviant...</translation>
+        <translation type="vanished">Enviant...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ha sorgit un error al configurar el port RPC %u escoltant a IPv6, retrocedint a IPv4: %s</translation>
     </message>
@@ -6389,27 +7373,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ha sorgit un error al configurar el port RPC %u escoltant a IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Ús:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Llista d&apos;ordres</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Obtenir ajuda per a un ordre.</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Advertència: el -paytxfee és molt elevat! Aquesta és la comissió de transacció que pagaràs quan enviis una transacció.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Advertència: L&apos;arxiu wallet.dat és corrupte, dades rescatades! L&apos;arxiu wallet.dat original ha estat desat com wallet.{estampa_temporal}.bak al directori %s; si el teu balanç o transaccions son incorrectes hauries de restaurar-lo de un backup.</translation>
     </message>
@@ -6419,7 +7403,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Advertència: Error llegint l&apos;arxiu wallet.dat!! Totes les claus es llegeixen correctament, però hi ha dades de transaccions o entrades del llibre d&apos;adreces absents o bé son incorrectes.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Error: La creació de transacció ha fallat.</translation>
     </message>
@@ -6429,24 +7413,24 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Error: La transacció ha sigut rebutjada. Això pot passar si algunes de les monedes al moneder ja s&apos;han gastat, per exemple, si vostè utilitza una còpia del wallet.dat i les monedes han estat gastades a la cópia pero no s&apos;han marcat com a gastades aqui.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ha fallat escoltar a qualsevol port. Feu servir -listen=0 si voleu fer això.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Utilitza la opció %s</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
         <translation>Has de configurar el rpcpassword=&lt;password&gt; a l&apos;arxiu de configuració:\n %s\n Si l&apos;arxiu no existeix, crea&apos;l amb els permís owner-readable-only.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>versió Gridcoin</translation>
     </message>
@@ -6461,7 +7445,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Quantitat invalida per a -mininput=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+101"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>El moneder %s resideix fora del directori de dades %s.</translation>
     </message>
@@ -6471,12 +7455,85 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Comprovant la integritat de la base de dades ...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Error en inicialitzar l&apos;entorn de base de dades %s! Per recuperar, FACI UNA COPIA DE SEGURETAT D&apos;AQUEST DIRECTORI, a continuació, retiri tot d&apos;ella excepte l&apos;arxiu wallet.dat.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6567,6 +7624,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6601,7 +7668,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>L&apos;arxiu wallet.data és corrupte, el rescat de les dades ha fallat</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Adreça -proxy invalida: &apos;%s&apos;</translation>
     </message>
@@ -6611,7 +7678,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Adreça -tor invalida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>No es pot resoldre l&apos;adreça -bind: &apos;%s&apos;</translation>
     </message>
@@ -6621,23 +7688,23 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>No es pot resoldre l&apos;adreça -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Quantitat invalida per a -reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Error carregant blkindex.dat</translation>
     </message>
     <message>
-        <location line="-316"/>
-        <location line="+344"/>
+        <location line="-351"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6662,12 +7729,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6687,21 +7754,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6727,11 +7780,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6751,7 +7799,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6791,7 +7839,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6827,11 +7875,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6871,12 +7914,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6941,7 +7979,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6953,11 +7991,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7028,16 +8061,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7166,11 +8189,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7193,16 +8211,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7281,16 +8289,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7313,11 +8311,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7362,17 +8355,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7393,6 +8376,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7616,78 +8604,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7742,16 +8660,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7801,7 +8709,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7811,37 +8719,37 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>El moneder necessita ser reescrita: reiniciar Gridcoin per completar</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Error carregant wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Important fitxer de dades d&apos;arrencada de la cadena de blocs</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>S&apos;estan carregant les adreces...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Error: no s&apos;ha pogut iniciar el node</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>No es pot enllaçar a %s en aquest equip. Gridcoin probablement ja estigui en funcionament.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Impossible d&apos;unir %s a aquest ordinador (s&apos;ha retornat l&apos;error %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Error: Moneder bloquejat, no es pot de crear la transacció</translation>
     </message>
@@ -7856,37 +8764,36 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Error: Aquesta transacció requereix una comisió d&apos;almenys %s degut a la seva quantitat, complexitat, o l&apos;ús dels fons rebuts recentment</translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Enviant...</translation>
+        <translation type="vanished">Enviant...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Quanitat invalida</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Avís: Comproveu que la data i hora de l&apos;equip siguin correctes! Si el seu rellotge és erroni Gridcoin no funcionarà correctament.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Avís: L&apos;espai en disc és baix!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Xarxa desconeguda especificada a -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Balanç insuficient</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>S&apos;està carregant l&apos;índex de blocs...</translation>
     </message>
@@ -7896,17 +8803,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>S&apos;està carregant el moneder...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>No es pot escriure l&apos;adreça per defecte</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>S&apos;està reescanejant...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Ha acabat la càrrega</translation>
     </message>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ano</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>S&amp;maž</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopíruj &amp;označení</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Uprav</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Označení</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(bez označení)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Zadej nové heslo k peněžence.&lt;br/&gt;Použij &lt;b&gt;alespoň deset náhodných znaků&lt;/b&gt; nebo &lt;b&gt;alespoň osm slov&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Zadej staré a nové heslo k pen?žence.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Potvrď zašifrování peněženky</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Peněženka je zašifrována</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>DŮLEŽITÉ: Všechny předchozí zálohy peněženky by měly být nahrazeny nově vygenerovanou, zašifrovanou peněženkou. Z bezpečnostních důvodů budou předchozí zálohy nešifrované peněženky nepoužitelné, jakmile začneš používat novou zašifrovanou peněženku.</translation>
+        <translation type="vanished">DŮLEŽITÉ: Všechny předchozí zálohy peněženky by měly být nahrazeny nově vygenerovanou, zašifrovanou peněženkou. Z bezpečnostních důvodů budou předchozí zálohy nešifrované peněženky nepoužitelné, jakmile začneš používat novou zašifrovanou peněženku.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Zašifrování peněženky selhalo</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Zašifrování peněženky selhalo kvůli vnitřní chybě. Tvá peněženka tedy nebyla zašifrována.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Zadaná hesla nejsou shodná.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Nepodařilo se odemknout peněženku</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Nezadal jsi správné heslo pro dešifrování peněženky.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Heslo k peněžence bylo v pořádku změněno.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Peněženka</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Přehled</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Konec</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Ověř zprávu...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Otevři ladicí a diagnostickou konzoli</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Soubor</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Nastavení</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,17 +973,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Odeslané transakce</translation>
     </message>
@@ -836,17 +1001,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -866,7 +1021,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -884,7 +1039,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -901,7 +1066,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +1081,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Peněženka je &lt;b&gt;zašifrovaná&lt;/b&gt; a momentálně &lt;b&gt;zamčená&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -932,18 +1097,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +1117,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1040,7 +1209,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1089,7 +1258,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,12 +1266,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Upozorn?ní sít?</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,7 +1330,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1216,37 +1385,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Částka</translation>
+        <translation type="vanished">Částka</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Označení</translation>
+        <translation type="obsolete">Označení</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Datum</translation>
+        <translation type="vanished">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Potvrzení</translation>
+        <translation type="vanished">Potvrzení</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Potvrzeno</translation>
+        <translation type="vanished">Potvrzeno</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Adresa</translation>
+        <translation type="vanished">Adresa</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopíruj adresu</translation>
     </message>
@@ -1257,17 +1420,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopíruj částku</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopíruj ID transakce</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopíruj počet</translation>
     </message>
@@ -1297,17 +1460,17 @@ Expires: %3
         <translation>Kopíruj drobné</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>ano</translation>
     </message>
@@ -1347,20 +1510,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(bez označení)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>drobné z %1 (%2)</translation>
+        <translation type="vanished">drobné z %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(drobné)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(bez označení)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">drobné z %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(drobné)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(drobné)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Označení</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresa</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Potvrzení</translation>
     </message>
 </context>
 <context>
@@ -1386,7 +1594,7 @@ Expires: %3
         <translation type="unfinished">Adresa</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1448,7 +1656,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,37 +1691,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Označení</translation>
+        <translation type="obsolete">Označení</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adresa</translation>
+        <translation type="obsolete">Adresa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Datum</translation>
+        <translation type="obsolete">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Potvrzení</translation>
+        <translation type="obsolete">Potvrzení</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Potvrzeno</translation>
+        <translation type="obsolete">Potvrzeno</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1548,7 +1746,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,25 +1756,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(bez označení)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">drobné z %1 (%2)</translation>
+        <translation type="obsolete">drobné z %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(drobné)</translation>
+        <translation type="obsolete">(drobné)</translation>
     </message>
 </context>
 <context>
@@ -1726,7 +1921,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1751,7 +1951,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1927,7 +2127,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,6 +2142,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1950,7 +2155,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1978,7 +2183,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2053,22 +2267,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2132,7 +2346,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2251,6 +2465,373 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">ano</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Odemčení peněženky bylo zrušeno.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2566,7 +3147,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>výchozí</translation>
     </message>
@@ -2581,7 +3162,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
@@ -2809,18 +3390,23 @@ Expires: %3
         <translation>Celkový stav tvého účtu</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopíruj částku</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2831,9 +3417,227 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Stav</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2947,7 +3751,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2987,6 +3791,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3022,7 +3831,7 @@ Expires: %3
         <translation type="unfinished">Formulář</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3032,7 +3841,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,7 +3864,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3098,6 +3917,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ano</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
     </message>
 </context>
 <context>
@@ -3182,12 +4078,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3212,12 +4113,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3304,7 +4205,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3342,7 +4243,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">nedostupná informace</translation>
     </message>
@@ -3458,14 +4359,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4410,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,12 +4425,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,7 +4463,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3567,6 +4525,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4625,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>nedostupná informace</translation>
     </message>
@@ -3783,7 +4746,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4944,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3996,7 +4959,7 @@ Expires: %3
         <translation>Napsáním &lt;b&gt;help&lt;/b&gt; si vypíšeš přehled dostupných příkazů.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4054,12 +5017,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4151,40 +5108,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4642,7 +5596,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4763,7 +5717,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4877,7 +5831,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4900,7 +5854,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4912,7 +5866,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5036,7 +5990,7 @@ Expires: %3
         <translation>Pošl&amp;i</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopíruj počet</translation>
     </message>
@@ -5096,7 +6050,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresa p?íjemce je neplatná, p?ekontroluj ji prosím.</translation>
     </message>
@@ -5136,8 +6090,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(bez označení)</translation>
     </message>
@@ -5244,7 +6198,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresa</translation>
     </message>
@@ -5382,42 +6336,42 @@ Expires: %3
         <translation>Kliknutím na „Podepiš zprávu“ vygeneruješ podpis</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Zadaná adresa je neplatná.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Zkontroluj ji prosím a zkus to pak znovu.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Zadaná adresa nepasuje ke klíči.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Odemčení peněženky bylo zrušeno.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Soukromý klíč pro zadanou adresu není dostupný.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Nepodařilo se podepsat zprávu.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Zpráva podepsána.</translation>
     </message>
@@ -5428,7 +6382,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Zkontroluj ho prosím a zkus to pak znovu.</translation>
     </message>
@@ -5479,7 +6433,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5488,32 +6442,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Otřevřeno dokud %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepotvrzeno</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potvrzení</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Stav</translation>
     </message>
@@ -5537,74 +6491,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Zdroj</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
@@ -5615,13 +6569,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Pro</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>vlastní adresa</translation>
@@ -5632,16 +6586,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>označení</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Příjem</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5655,31 +6609,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>neakceptováno</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Výdaj</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Transakční poplatek</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Čistá částka</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Zpráva</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Komentář</translation>
     </message>
@@ -5689,38 +6643,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
@@ -5752,11 +6706,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -5776,7 +6735,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>?ástka</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5805,12 +6764,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Potvrzeno (%1 potvrzení)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>V kolizi</translation>
     </message>
@@ -6035,7 +6994,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Stav transakce. Najetím myši na toto políčko si zobrazíš počet potvrzení.</translation>
     </message>
@@ -6063,7 +7057,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,7 +7112,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minimální částka</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopíruj adresu</translation>
     </message>
@@ -6148,7 +7147,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Zobraz detaily transakce</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6159,7 +7158,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Potvrzeno</translation>
     </message>
@@ -6204,7 +7203,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Rozsah:</translation>
     </message>
@@ -6240,19 +7239,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Konec</translation>
+        <translation type="obsolete">&amp;Konec</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Ukonči aplikaci</translation>
+        <translation type="obsolete">Ukonči aplikaci</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Soubor</translation>
+        <translation type="obsolete">&amp;Soubor</translation>
     </message>
 </context>
 <context>
@@ -6266,7 +7262,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6292,18 +7288,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6378,17 +7374,9 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>P?i nastavování naslouchacího RPC portu %u pro IPv6 nastala chyba, vracím se k IPv4: %s</translation>
     </message>
@@ -6398,27 +7386,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>P?i nastavování naslouchacího RPC portu %u pro IPv4 nastala chyba: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Užití:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Výpis p?íkaz?</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Získat nápov?du pro p?íkaz</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Upozorn?ní: -paytxfee je nastaveno velmi vysoko! Toto je transak?ní poplatek, který zaplatíš za každou poslanou transakci.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Upozorn?ní: soubor wallet.dat je poškozený, data jsou však zachrán?na! P?vodní soubor wallet.dat je uložený jako wallet.{timestamp}.bak v %s. Pokud je stav tvého ú?tu nebo transakce nesprávné, z?ejm? bys m?l obnovit zálohu.</translation>
     </message>
@@ -6428,32 +7416,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Upozorn?ní: nastala chyba p?i ?tení souboru wallet.dat! Všechny klí?e se p?e?etly správn?, ale data o transakcích nebo záznamy v adresá?i mohou chyb?t ?i být nesprávné.</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-191"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+149"/>
         <source>The wallet will now shutdown. Please start your wallet to begin sync from zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+168"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6504,11 +7477,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Nepodařilo se naslouchat na žádném portu. Použij -listen=0, pokud to byl tvůj záměr.</translation>
     </message>
@@ -6535,16 +7503,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6648,16 +7606,6 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -6680,11 +7628,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6728,18 +7671,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">nedostupná informace</translation>
+        <translation type="obsolete">nedostupná informace</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6763,7 +7700,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>No wallet available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6984,82 +7921,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7114,16 +7976,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7133,7 +7985,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>K použití volby %s</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7142,12 +7994,85 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Pokud konfigura?ní soubor ješt? neexistuje, vytvo? ho tak, aby ho mohl ?íst pouze vlastník.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="-224"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+79"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Neplatná ?ástka pro -paytxfee=&lt;?ástka&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+28"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7199,6 +8124,11 @@ Pokud konfigura?ní soubor ješt? neexistuje, vytvo? ho tak, aby ho mohl ?íst p
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7308,6 +8238,16 @@ Pokud konfigura?ní soubor ješt? neexistuje, vytvo? ho tak, aby ho mohl ?íst p
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7342,18 +8282,18 @@ Pokud konfigura?ní soubor ješt? neexistuje, vytvo? ho tak, aby ho mohl ?íst p
         <translation>Soubor wallet.dat je poškozen, jeho záchrana se nezda?ila</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Neplatná -proxy adresa: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7378,12 +8318,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+19"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7398,21 +8338,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7453,11 +8379,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7477,7 +8398,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7517,7 +8438,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7553,11 +8474,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7598,11 +8514,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7672,7 +8583,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7687,7 +8598,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Authorized</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7757,7 +8668,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Nemohu p?eložit -bind adresu: &apos;%s&apos;</translation>
     </message>
@@ -7867,32 +8778,32 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Chyba p?i na?ítání wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Načítám adresy...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Neda?í se mi p?ipojit na %s na tomhle po?íta?i (operace bind vrátila chybu %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Neplatná ?ástka</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+87"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>V -onlynet byla uvedena neznámá síť: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Nedostatek prostředků</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Načítám index bloků...</translation>
     </message>
@@ -7902,17 +8813,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Načítám peněženku...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Nemohu napsat výchozí adresu</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Přeskenovávám…</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Načítání dokončeno</translation>
     </message>

--- a/src/qt/locale/bitcoin_cy.ts
+++ b/src/qt/locale/bitcoin_cy.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Dileu</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Address</source>
         <translation>Cyfeiriad</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(heb label)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Teipiwch yr hen cyfrinymadrodd a chyfrinymadrodd newydd i mewn i&apos;r waled.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Cadarnau amgryptiad y waled</translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Waled wedi&apos;i amgryptio</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Amgryptiad waled wedi methu</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Methodd amgryptiad y waled oherwydd gwall mewnol. Ni amgryptwyd eich waled.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Dydy&apos;r cyfrinymadroddion a ddarparwyd ddim yn cyd-fynd â&apos;u gilydd.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Methodd ddatgloi&apos;r waled</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Waled</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Trosolwg</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>A&amp;llanfa</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Ffeil</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Gosodiadau</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -820,17 +981,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Trafodiad a anfonwyd</translation>
     </message>
@@ -848,17 +1009,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -878,7 +1029,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -896,7 +1047,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -913,7 +1074,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -928,12 +1089,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Mae&apos;r waled &lt;b&gt;wedi&apos;i amgryptio&lt;/b&gt; ac &lt;b&gt;ar glo&lt;/b&gt; ar hyn o bryd</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -944,18 +1105,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -965,7 +1125,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1052,7 +1217,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1101,7 +1266,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1109,12 +1274,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1173,7 +1338,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1228,37 +1393,15 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Dyddiad</translation>
+        <translation type="vanished">Dyddiad</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Cyfeiriad</translation>
+        <translation type="vanished">Cyfeiriad</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1269,17 +1412,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1309,17 +1452,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1359,19 +1502,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(heb label)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(heb label)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Cyfeiriad</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Dyddiad</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1398,7 +1578,7 @@ Expires: %3
         <translation type="unfinished">Cyfeiriad</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1460,7 +1640,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1495,37 +1675,15 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Cyfeiriad</translation>
+        <translation type="obsolete">Cyfeiriad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Dyddiad</translation>
+        <translation type="obsolete">Dyddiad</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1560,7 +1718,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1570,25 +1728,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(heb label)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1738,7 +1885,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1763,7 +1915,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1939,7 +2091,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1954,6 +2106,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1962,7 +2119,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1990,7 +2147,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2071,22 +2237,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2150,7 +2316,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2269,6 +2435,379 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2584,7 +3123,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2599,7 +3138,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Gwall</translation>
@@ -2827,18 +3366,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2849,9 +3393,235 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2965,7 +3735,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3775,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3040,7 +3815,7 @@ Expires: %3
         <translation type="unfinished">Ffurflen</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3050,7 +3825,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3063,7 +3848,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3115,6 +3900,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3200,12 +4062,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3230,12 +4097,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3322,7 +4189,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3360,7 +4227,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3488,14 +4355,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,7 +4406,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3520,12 +4421,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3535,7 +4459,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3597,6 +4521,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3707,7 +4636,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3848,7 +4777,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4011,7 +4940,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -4026,7 +4955,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4084,12 +5013,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4181,40 +5104,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4672,7 +5592,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4793,7 +5713,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4907,7 +5827,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4930,7 +5850,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4942,7 +5862,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5066,7 +5986,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5126,7 +6046,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5166,8 +6086,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(heb label)</translation>
     </message>
@@ -5274,7 +6194,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Cyfeiriad</translation>
     </message>
@@ -5412,42 +6332,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5458,7 +6378,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5509,7 +6429,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5520,32 +6440,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Agor tan %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5571,74 +6491,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Dyddiad</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5649,13 +6569,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5666,16 +6586,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5691,31 +6611,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Neges</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5725,38 +6645,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5788,11 +6708,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Dyddiad</translation>
     </message>
@@ -5812,7 +6737,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5843,12 +6768,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6073,7 +6998,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6101,7 +7061,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6156,7 +7116,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6186,7 +7151,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6197,7 +7162,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6242,7 +7207,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6278,19 +7243,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">A&amp;llanfa</translation>
+        <translation type="obsolete">A&amp;llanfa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Gadael rhaglen</translation>
+        <translation type="obsolete">Gadael rhaglen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Ffeil</translation>
+        <translation type="obsolete">&amp;Ffeil</translation>
     </message>
 </context>
 <context>
@@ -6304,7 +7266,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6330,18 +7292,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6416,23 +7378,15 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
         <location filename="../bitcoinstrings.cpp" line="+12"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6458,17 +7412,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6492,21 +7466,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6547,11 +7507,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6571,7 +7526,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6611,7 +7566,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6652,11 +7607,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6702,11 +7652,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6793,7 +7738,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6805,11 +7750,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6880,16 +7820,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7069,11 +7999,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7100,16 +8025,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7239,16 +8154,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7294,11 +8199,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Magnitude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7339,21 +8239,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7370,6 +8308,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7599,82 +8542,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7725,16 +8593,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7815,6 +8673,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7920,6 +8783,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>poll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nej</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Slet</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopiér &amp;mærkat</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Redigér</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Eksporter Adresse Bog</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Mærkat</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ingen mærkat)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Kun til renteberegning</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Indtast det nye kodeord til tegnebogen.&lt;br/&gt;Brug venligst et kodeord på &lt;b&gt;ti eller flere tilfældige tegn&lt;/b&gt; eller &lt;b&gt;otte eller flere ord&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Indtast den gamle og den nye adgangskode til tegnebogen.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Bekræft tegnebogskryptering</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Er du sikker på, at du ønsker at kryptere din tegnebog?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Tegnebog krypteret</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin lukker nu for at afslutte krypteringen. Husk at en krypteret  tegnebog ikke fuldt ud beskytter dine mønter mod at blive stjålet af malware som har inficeret din computer.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>VIGTIGT: Enhver tidligere sikkerhedskopi, som du har lavet af tegnebogsfilen, bør blive erstattet af den nyligt genererede, krypterede tegnebogsfil. Af sikkerhedsmæssige årsager vil tidligere sikkerhedskopier af den ikke-krypterede tegnebogsfil blive ubrugelige i det øjeblik, du starter med at anvende den nye, krypterede tegnebog.</translation>
+        <translation type="vanished">VIGTIGT: Enhver tidligere sikkerhedskopi, som du har lavet af tegnebogsfilen, bør blive erstattet af den nyligt genererede, krypterede tegnebogsfil. Af sikkerhedsmæssige årsager vil tidligere sikkerhedskopier af den ikke-krypterede tegnebogsfil blive ubrugelige i det øjeblik, du starter med at anvende den nye, krypterede tegnebog.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Tegnebogskryptering mislykkedes</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Tegnebogskryptering mislykkedes på grund af en intern fejl. Din tegnebog blev ikke krypteret.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>De angivne adgangskoder stemmer ikke overens.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Tegnebogsoplåsning mislykkedes</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Den angivne adgangskode for tegnebogsdekrypteringen er forkert.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Tegnebogens adgangskode blev ændret.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Der opstod en fejl under forsøg på at gemme dataene i tegnebogen til den nye placering.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Tegnebog</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Oversigt</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Luk</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verificér besked…</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Eksporter...</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Åbn fejlsøgnings- og diagnosticeringskonsollen</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fil</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Opsætning</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[testnetværk]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin klient</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +972,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Sidst modtagne blok blev genereret %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Denne transaktion er over grænsen størrelse. Du kan stadig sende det for et gebyr på %1, der går til de noder, der behandler din transaktion og hjælper med at støtte netværket. Ønsker du at betale gebyret?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Bekræft transaktionsgebyr</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Afsendt transaktion</translation>
     </message>
@@ -835,17 +1000,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -865,7 +1020,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -883,7 +1038,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>URI håndtering</translation>
@@ -900,7 +1065,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -915,12 +1080,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Tegnebog er &lt;b&gt;krypteret&lt;/b&gt; og i øjeblikket &lt;b&gt;låst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Sikkerhedskopier Tegnebog</translation>
     </message>
@@ -931,18 +1096,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Sikkerhedskopiering Mislykkedes</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Der opstod en fejl under forsøg på at gemme data i tegnebogen til den nye placering.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,7 +1116,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1208,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Netværksadvarsel</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Beløb</translation>
+        <translation type="vanished">Beløb</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Dato</translation>
+        <translation type="vanished">Dato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Bekræftelser</translation>
+        <translation type="vanished">Bekræftelser</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Bekræftet</translation>
+        <translation type="vanished">Bekræftet</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Mærkat</translation>
+        <translation type="vanished">Mærkat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Adresse</translation>
+        <translation type="vanished">Adresse</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopiér adresse</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopiér beløb</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopiér transaktions-ID</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopiér mængde</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Kopiér byttepenge</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>ja</translation>
     </message>
@@ -1351,20 +1514,65 @@ Beløb under 0,546 gange det minimale gebyr er vist som DUST.</translation>
 Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(ingen mærkat)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>byttepenge fra %1 (%2)</translation>
+        <translation type="vanished">byttepenge fra %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(byttepange)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(ingen mærkat)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">byttepenge fra %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(byttepange)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Beløb</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(byttepange)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Mærkat</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresse</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Dato</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Bekræftelser</translation>
     </message>
 </context>
 <context>
@@ -1390,7 +1598,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished">Adresse</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1660,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,37 +1695,31 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Beløb</translation>
+        <translation type="obsolete">Beløb</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Mærkat</translation>
+        <translation type="obsolete">Mærkat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adresse</translation>
+        <translation type="obsolete">Adresse</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Dato</translation>
+        <translation type="obsolete">Dato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Bekræftelser</translation>
+        <translation type="obsolete">Bekræftelser</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Bekræftet</translation>
+        <translation type="obsolete">Bekræftet</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,7 +1754,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1562,25 +1764,22 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(ingen mærkat)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">byttepenge fra %1 (%2)</translation>
+        <translation type="obsolete">byttepenge fra %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(byttepange)</translation>
+        <translation type="obsolete">(byttepange)</translation>
     </message>
 </context>
 <context>
@@ -1730,7 +1929,12 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1755,7 +1959,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1931,7 +2135,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1946,6 +2150,11 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1954,7 +2163,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1982,7 +2191,16 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2054,22 +2272,22 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2133,7 +2351,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2252,6 +2470,370 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Ryd &amp;alle</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">nej</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Tegnebogsoplåsning annulleret.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2567,7 +3149,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation>&amp;Annullér</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>standard</translation>
     </message>
@@ -2582,7 +3164,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Fejl</translation>
@@ -2810,18 +3392,23 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopiér beløb</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2832,9 +3419,223 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Beløb</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2948,7 +3749,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2988,6 +3789,11 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3023,7 +3829,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished">Formular</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3033,7 +3839,17 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3046,7 +3862,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3099,6 +3915,83 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nej</translation>
     </message>
 </context>
 <context>
@@ -3183,12 +4076,17 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3213,12 +4111,12 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3305,7 +4203,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3343,7 +4241,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3453,14 +4351,48 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3470,7 +4402,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3485,12 +4417,35 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,7 +4455,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3562,6 +4517,11 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3692,7 +4652,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3758,7 +4718,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3976,7 +4936,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3991,7 +4951,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation>Tast &lt;b&gt;help&lt;/b&gt; for en oversigt over de tilgængelige kommandoer.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4049,12 +5009,6 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4146,40 +5100,37 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4637,7 +5588,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4758,7 +5709,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4872,7 +5823,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4895,7 +5846,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4907,7 +5858,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5031,7 +5982,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation>&amp;Afsend</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopiér mængde</translation>
     </message>
@@ -5091,7 +6042,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation>og</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Modtagerens adresse er ikke gyldig. Tjek venligst adressen igen.</translation>
     </message>
@@ -5131,8 +6082,8 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation>Fejl: Transaktionen blev afvist. Dette kan ske, hvis nogle af mønterne i din tegnebog allerede er blevet brugt, som hvis du brugte en kopi af wallet.dat og mønterne blev brugt i kopien, men ikke markeret som brugt her.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(ingen mærkat)</translation>
     </message>
@@ -5239,7 +6190,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresse</translation>
     </message>
@@ -5377,42 +6328,42 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
         <translation>Indtast Gridcoin underskrift</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Den indtastede adresse er ugyldig.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Tjek venligst adressen og forsøg igen.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Den indtastede adresse henviser ikke til en nøgle.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Tegnebogsoplåsning annulleret.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Den private nøgle for den indtastede adresse er ikke tilgængelig.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Signering af besked mislykkedes.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Besked signeret.</translation>
     </message>
@@ -5423,7 +6374,7 @@ Det betyder, at et gebyr på mindst %2 er påkrævet.</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Tjek venligst signaturen og forsøg igen.</translation>
     </message>
@@ -5474,7 +6425,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5482,32 +6433,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Åben indtil %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>konflikt</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/ubekræftet</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 bekræftelser</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5530,74 +6481,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Fra</translation>
     </message>
@@ -5608,13 +6559,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Til</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>egen adresse</translation>
@@ -5625,16 +6576,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>mærkat</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Kredit</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5647,31 +6598,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>ikke accepteret</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debet</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Transaktionsgebyr</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Nettobeløb</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Besked</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
@@ -5681,38 +6632,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
@@ -5744,11 +6695,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
@@ -5768,7 +6724,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5796,12 +6752,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bekræftet (%1 bekræftelser)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Konflikt</translation>
     </message>
@@ -6026,7 +6982,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transaktionsstatus. Hold musen over dette felt for at vise antallet af bekræftelser.</translation>
     </message>
@@ -6054,7 +7045,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6109,7 +7100,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minimumsbeløb</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopiér adresse</translation>
     </message>
@@ -6139,7 +7135,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Vis transaktionsdetaljer</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exportere transaktionsdata</translation>
     </message>
@@ -6150,7 +7146,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Bekræftet</translation>
     </message>
@@ -6195,7 +7191,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kunne ikke skrive til filen %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Interval:</translation>
     </message>
@@ -6231,19 +7227,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Luk</translation>
+        <translation type="obsolete">&amp;Luk</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Afslut program</translation>
+        <translation type="obsolete">Afslut program</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fil</translation>
+        <translation type="obsolete">&amp;Fil</translation>
     </message>
 </context>
 <context>
@@ -6257,7 +7250,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6283,18 +7276,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6371,15 +7364,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Sender...</translation>
+        <translation type="vanished">Sender...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Der opstod en fejl ved angivelse af RPC-porten %u til at lytte på IPv6, falder tilbage til IPv4: %s</translation>
     </message>
@@ -6389,27 +7381,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Der opstod en fejl ved angivelse af RPC-porten %u til at lytte på IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Anvendelse:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Liste over kommandoer</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Få hjælp til en kommando</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Advarsel: -paytxfee er sat meget højt! Dette er det gebyr du vil betale, hvis du sender en transaktion.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Advarsel: wallet.dat ødelagt, data reddet! Oprindelig wallet.net gemt som wallet.{timestamp}.bak i %s; hvis din saldo eller dine transaktioner er forkert, bør du genskabe fra en sikkerhedskopi.</translation>
     </message>
@@ -6419,7 +7411,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Advarsel: fejl under læsning af wallet.dat! Alle nøgler blev læst korrekt, men transaktionsdata eller adressebogsposter kan mangle eller være forkerte.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Fejl: Transaktion oprettelse mislykkedes</translation>
     </message>
@@ -6429,17 +7421,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Fejl: Transaktionen blev afvist. Dette kan ske, hvis nogle af mønterne i din pung allerede er blevet brugt, som hvis du brugte en kopi af wallet.dat og mønterne blev brugt i kopien, men ikke markeret her.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Lytning på enhver port mislykkedes. Brug -listen=0, hvis du ønsker dette.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>For at bruge %s mulighed</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -6448,7 +7440,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Hvis filen ikke eksisterer, opret den og giv ingen andre end ejeren læserettighed.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="+151"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ugyldigt beløb for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
@@ -6458,7 +7450,7 @@ Hvis filen ikke eksisterer, opret den og giv ingen andre end ejeren læserettigh
         <translation>Ugyldigt beløb for -mininput = &lt;beløb&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+101"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Wallet %s placeret udenfor data mappe %s.</translation>
     </message>
@@ -6468,12 +7460,85 @@ Hvis filen ikke eksisterer, opret den og giv ingen andre end ejeren læserettigh
         <translation>Bekræfter database integritet ...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Fejl initialisering database miljø %s! For at gendanne, BACKUP denne mappe, og derefter fjern alt bortset fra wallet.dat.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6564,6 +7629,16 @@ Hvis filen ikke eksisterer, opret den og giv ingen andre end ejeren læserettigh
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6598,7 +7673,7 @@ Hvis filen ikke eksisterer, opret den og giv ingen andre end ejeren læserettigh
         <translation>wallet.dat ødelagt, redning af data mislykkedes</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ugyldig -proxy adresse: “%s”</translation>
     </message>
@@ -6608,7 +7683,7 @@ Hvis filen ikke eksisterer, opret den og giv ingen andre end ejeren læserettigh
         <translation>Ugyldig-tor-adresse: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kan ikke finde -bind adressen: &apos;%s&apos;</translation>
     </message>
@@ -6618,23 +7693,23 @@ Hvis filen ikke eksisterer, opret den og giv ingen andre end ejeren læserettigh
         <translation>Kan ikke finde -externalip adressen: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Ugyldigt beløb for -reservebalance = &lt;beløb&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Fejl ved indlæsning af blkindex.dat</translation>
     </message>
     <message>
-        <location line="-316"/>
-        <location line="+344"/>
+        <location line="-351"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6659,12 +7734,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6684,21 +7759,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6724,11 +7785,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6748,7 +7804,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6788,7 +7844,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6824,11 +7880,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6868,12 +7919,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6938,7 +7984,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6950,11 +7996,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7025,16 +8066,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7158,11 +8189,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7185,16 +8211,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7278,16 +8294,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7310,11 +8316,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7359,17 +8360,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7390,6 +8381,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7613,78 +8609,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7739,16 +8665,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7798,7 +8714,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7808,37 +8724,37 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Det er nødvendig for wallet at blive omskrevet: Genstart Gridcoin for fuldføre</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Fejl ved indlæsning af wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Import af bootstrap blockchain datafil.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Indlæser adresser…</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Fejl: kunne ikke starte node</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Kunne ikke binde sig til %s på denne computer. Gridcoin kører sikkert allerede.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Kunne ikke tildele %s på denne computer (bind returnerede fejl %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Fejl: Wallet låst, ude af stand til at skabe transaktion</translation>
     </message>
@@ -7853,37 +8769,36 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Fejl: Denne transaktion kræver et transaktionsgebyr på mindst %s på grund af dens størrelse, kompleksitet, eller anvendelse af nylig modtaget midler</translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Sender...</translation>
+        <translation type="vanished">Sender...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Ugyldigt beløb</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Advarsel: Kontroller venligst, at computerens dato og klokkeslæt er korrekt! Hvis dit ur er forkert vil Gridcoin ikke fungere korrekt.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Advarsel: Diskplads lav!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Ukendt netværk anført i -onlynet: “%s”</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Manglende dækning</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Indlæser blokindeks…</translation>
     </message>
@@ -7893,17 +8808,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Indlæser tegnebog…</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Kan ikke skrive standardadresse</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Genindlæser…</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Indlæsning gennemført</translation>
     </message>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Versionsinformationen</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation>Versionsinformationen sind im Testnetz nicht verfügbar.</translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation>Erforderlich</translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Löschen</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>&amp;Bezeichnung kopieren</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Editieren</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exportiere Addressbuch Daten</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(keine Bezeichnung)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Nur Coins, die verzinst werden</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Geben Sie die neue Passphrase für die Wallet ein.&lt;br&gt;Bitte benutzen Sie eine Passphrase bestehend aus &lt;b&gt;zehn oder mehr zufälligen Zeichen&lt;/b&gt; oder &lt;b&gt;acht oder mehr Wörtern&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Geben Sie die alte und neue Wallet-Passphrase ein.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Wallet-Verschlüsselung bestätigen</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Sind Sie sich sicher, dass Sie Ihre Wallet verschlüsseln möchten?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Wallet verschlüsselt</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin wird jetzt runterfahren um den Verschlüsselungsprozess zu vervollständigen. Erinnern Sie sich, dass das Verschlüsseln ihres Wallets nicht reicht um es vollständig vor Diebstahl zu schützen, z.B. durch. Viren, die ihren Rechner infiziert haben.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>WICHTIG: Alle vorherigen Wallet-Sicherungen sollten durch die neu erzeugte, verschlüsselte Wallet ersetzt werden. Aus Sicherheitsgründen werden vorherige Sicherungen der unverschlüsselten Wallet nutzlos, sobald Sie die neue, verschlüsselte Wallet verwenden.</translation>
+        <translation type="vanished">WICHTIG: Alle vorherigen Wallet-Sicherungen sollten durch die neu erzeugte, verschlüsselte Wallet ersetzt werden. Aus Sicherheitsgründen werden vorherige Sicherungen der unverschlüsselten Wallet nutzlos, sobald Sie die neue, verschlüsselte Wallet verwenden.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Wallet-Verschlüsselung fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Die Wallet-Verschlüsselung ist aufgrund eines internen Fehlers fehlgeschlagen. Ihre Wallet wurde nicht verschlüsselt.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Die eingegebenen Passphrasen stimmen nicht überein.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Wallet-Entsperrung fehlgeschlagen</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Die eingegebene Passphrase zur Wallet-Entschlüsselung war nicht korrekt.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Die Wallet-Passphrase wurde erfolgreich geändert.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation>IP/Netzmaske</translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Ein fataler Fehler passierte. Gridcoin kann nicht mehr länger sicher ausgführt werden und wird runterfahren.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Übersicht</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Beenden</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Nachricht &amp;verifizieren...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Exportiere...</translation>
@@ -652,17 +782,21 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Debugging- und Diagnosekonsole öffnen</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
-        <translation>Neuesten Snapshot herunterladen und anwenden</translation>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Download and apply latest snapshot</source>
+        <translation type="vanished">Neuesten Snapshot herunterladen und anwenden</translation>
+    </message>
+    <message>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation>&amp;Blockchain-Daten zurücksetzen</translation>
     </message>
@@ -682,12 +816,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Werte auf der Übersichtsseite maskieren</translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Datei</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Einstellungen</translation>
     </message>
@@ -722,19 +876,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Kein Staking: Deaktiviert durch Konfiguration.</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[Testnetz]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation>Keine aktiven Verbindungen zum Gridcoin-Netzwerk. Wenn dies länger als ein paar Minuten anhält, bitte die Konfiguration und die Netzwerkverbindung überprüfen.</translation>
     </message>
@@ -807,17 +976,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Letzter erhaltener Block wurde %1 generiert.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Diese Transaktion ist über dem Grössenlimit. Sie können sie immer noch für eine Gebühr über %1 verschicken, die an die Knoten geht, die ihre Transaktion bearbeiten und unterstützen damit das Netzwerk. Wollen sie diese Gebühr bezahlen?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Bestätige Transaktionsgebühren</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Gesendete Transaktion</translation>
     </message>
@@ -838,17 +1007,15 @@ Typ: %3
 Adresse: %4</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation>Soll der neueste Snapshot heruntergeladen und angewendet werden? Wenn ja, wird die Wallet heruntergefahren und die Aufgabe ausgeführt.</translation>
+        <translation type="vanished">Soll der neueste Snapshot heruntergeladen und angewendet werden? Wenn ja, wird die Wallet heruntergefahren und die Aufgabe ausgeführt.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation>Warnung: Das Abbrechen nach Stufe 2 führt zu einer Synchronisierung von Anfang an (bei 0 Blöcken) oder zu beschädigten Blockchain-Dateien.</translation>
+        <translation type="vanished">Warnung: Das Abbrechen nach Stufe 2 führt zu einer Synchronisierung von Anfang an (bei 0 Blöcken) oder zu beschädigten Blockchain-Dateien.</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation>Blockchain-Daten wirklich löschen und von Null an synchronisieren?</translation>
     </message>
@@ -868,7 +1035,7 @@ Adresse: %4</translation>
         <translation>Die Gridcoinwallet beenden?</translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -886,7 +1053,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>URI Handhabung</translation>
@@ -903,7 +1080,7 @@ Are you sure you want to proceed?</source>
         <translation>Wallet ist &lt;b&gt;nicht verschlüsselt&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation>Wallet ist &lt;b&gt;verschlÃ¼sselt&lt;/b&gt; und momentan %1 </translation>
     </message>
@@ -918,12 +1095,12 @@ Are you sure you want to proceed?</source>
         <translation>&lt;b&gt;vollstÃ¤ndig entsperrt&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Wallet ist &lt;b&gt;verschlüsselt&lt;/b&gt; und aktuell &lt;b&gt;gesperrt&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Wallet Backup</translation>
     </message>
@@ -934,18 +1111,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Backup Fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Es gab einen Fehler beim speichern ihrer Wallet Datei in dem neuen Ort.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation>Konfiguration sichern</translation>
     </message>
@@ -955,7 +1131,12 @@ Are you sure you want to proceed?</source>
         <translation>Wallet-Konfiguration (*.conf)</translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation>nicht verfügbar</translation>
     </message>
@@ -1047,7 +1228,7 @@ Scraper die nicht veröffentlichen: %5.</translation>
         <translation>Scraper: Es konnte keine Konvergenz erreicht werden. Wird in ein paar Minuten erneut versucht.</translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1105,12 +1286,12 @@ Läuft ab: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Netzwerkalarm</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation>Niedrige Schwierigkeit!</translation>
     </message>
@@ -1164,7 +1345,7 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation>Alles auswählen</translation>
     </message>
@@ -1214,32 +1395,27 @@ Läuft ab: %3
         <translation>Bereit zum Konsolidieren</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Betrag</translation>
+        <translation type="vanished">Betrag</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Datum</translation>
+        <translation type="vanished">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Bestätigungen</translation>
+        <translation type="vanished">Bestätigungen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Bestätigt</translation>
+        <translation type="vanished">Bestätigt</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Bezeichnung</translation>
+        <translation type="vanished">Bezeichnung</translation>
     </message>
     <message>
-        <location line="-424"/>
+        <location line="-376"/>
         <source>Coin Control</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1249,12 +1425,11 @@ Läuft ab: %3
         <translation>&amp;Listenmodus</translation>
     </message>
     <message>
-        <location line="+133"/>
         <source>Address</source>
-        <translation>Adresse</translation>
+        <translation type="vanished">Adresse</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Adresse kopieren</translation>
     </message>
@@ -1265,17 +1440,17 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Betrag kopieren</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Transaktionskennung kopieren</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Anzahl kopieren</translation>
     </message>
@@ -1305,17 +1480,17 @@ Läuft ab: %3
         <translation>Wechselgeld kopieren</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation>Keine auswählen</translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>STAUB</translation>
     </message>
@@ -1365,20 +1540,65 @@ Läuft ab: %3
  Dies bedeutet, dass eine Gebühr von mindestens %2 benötigt wird.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(keine Bezeichnung)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>Wechselgeld von %1 (%2)</translation>
+        <translation type="vanished">Wechselgeld von %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(Wechselgeld)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(keine Bezeichnung)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">Wechselgeld von %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(Wechselgeld)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Betrag</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(Wechselgeld)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Bezeichnung</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresse</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Bestätigungen</translation>
     </message>
 </context>
 <context>
@@ -1404,7 +1624,7 @@ Läuft ab: %3
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1466,7 +1686,7 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation>Alles auswählen</translation>
     </message>
@@ -1501,37 +1721,31 @@ Läuft ab: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Betrag</translation>
+        <translation type="vanished">Betrag</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation>Bezeichnung</translation>
+        <translation type="vanished">Bezeichnung</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Adresse</translation>
+        <translation type="vanished">Adresse</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>Datum</translation>
+        <translation type="vanished">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Bestätigungen</translation>
+        <translation type="vanished">Bestätigungen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Bestätigt</translation>
+        <translation type="vanished">Bestätigt</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation>Anzahl</translation>
     </message>
@@ -1566,7 +1780,7 @@ Läuft ab: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1576,25 +1790,22 @@ Läuft ab: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation>Nichts auswählen</translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation>(keine Bezeichnung)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">Wechselgeld von %1 (%2)</translation>
+        <translation type="obsolete">Wechselgeld von %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(Wechselgeld)</translation>
+        <translation type="obsolete">(Wechselgeld)</translation>
     </message>
 </context>
 <context>
@@ -1744,7 +1955,12 @@ Läuft ab: %3
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation>Teste...</translation>
     </message>
@@ -1769,7 +1985,7 @@ Läuft ab: %3
         <translation>Fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation>Ein oder mehrere Tests haben einen Warnstatus generiert. Wallet-Betrieb kann beeinträchtigt sein. Bitte die individuellen Test-Tool-Tipps für Details und empfohlene Maßnahmen beachten.</translation>
     </message>
@@ -1945,7 +2161,7 @@ Läuft ab: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation>Ein neues Datenverzeichnis wird erstellt.</translation>
     </message>
@@ -1960,6 +2176,11 @@ Läuft ab: %3
         <translation>Pfad existiert bereits und ist kein Verzeichnis.</translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Datenverzeichnis kann hier nicht erstellt werden.</translation>
@@ -1968,7 +2189,7 @@ Läuft ab: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2031,7 +2252,16 @@ Läuft ab: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation>Fehler: Angegebenes Datenverzeichnis &quot;%1&quot; kann nicht erstellt werden.</translation>
     </message>
@@ -2068,22 +2298,22 @@ Läuft ab: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2147,7 +2377,7 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2266,6 +2496,370 @@ Läuft ab: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;Zurücksetzen</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Wallet-Entsperrung wurde abgebrochen.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2581,7 +3175,7 @@ Läuft ab: %3
         <translation>A&amp;bbrechen</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>Standard</translation>
     </message>
@@ -2596,7 +3190,7 @@ Läuft ab: %3
         <translation>Hell</translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
@@ -2824,18 +3418,23 @@ Läuft ab: %3
         <translation>Aktuelle Abstimmungen</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Betrag kopieren</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2846,9 +3445,223 @@ Läuft ab: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n Sekunde</numerusform>
+            <numerusform>%n Sekunde(n)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n Minute</numerusform>
+            <numerusform>%n Minute(n)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n Stunde(n)</numerusform>
+            <numerusform>%n Stunde(n)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n Tag(e)</numerusform>
+            <numerusform>%n Tag(e)</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Betrag</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation>Node-ID</translation>
     </message>
@@ -2962,7 +3775,7 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation>Abstimmung beendet.</translation>
     </message>
@@ -3002,6 +3815,11 @@ Läuft ab: %3
         <source>Top Answer:</source>
         <translation>Top Antwort:</translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3032,7 +3850,7 @@ Läuft ab: %3
 <context>
     <name>PollTab</name>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation>&quot;Aktualisieren&quot; drücken, um die Liste zu aktualisieren.</translation>
     </message>
@@ -3042,7 +3860,17 @@ Läuft ab: %3
         <translation>Dies kann mehrere Minuten dauern.</translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation>Zeige Ergebnis</translation>
     </message>
@@ -3060,7 +3888,7 @@ Läuft ab: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
@@ -3112,6 +3940,83 @@ Läuft ab: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished">keine</translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3197,12 +4102,17 @@ Läuft ab: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation>Abstimmung erstellen</translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation>Kontostand</translation>
     </message>
@@ -3227,12 +4137,12 @@ Läuft ab: %3
         <translation>Mehrfachauswahl</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation>Diese Abstimmung wird %1 plus Transaktionsgebühr kosten. Fortfahren?</translation>
     </message>
@@ -3319,7 +4229,7 @@ Läuft ab: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3357,7 +4267,35 @@ Läuft ab: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
@@ -3366,7 +4304,13 @@ Läuft ab: %3
 </translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation>Fehler: Konfigurationsdatei kann nicht gelesen werden. Bitte den Pfad und das Format der Datei überprüfen.</translation>
     </message>
@@ -3376,7 +4320,7 @@ Läuft ab: %3
         <translation>Fehler: Angegebenes Datenverzeichnis &quot;%1&quot; existiert nicht.</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3391,12 +4335,35 @@ Läuft ab: %3
         <translation>Fehler beim Initialisieren der Einstellungen: %1</translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation>%1 ist noch nicht sicher beendet worden...</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation>k. A.</translation>
     </message>
@@ -3511,7 +4478,7 @@ Läuft ab: %3
         <translation>%1 verbleibend.</translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3521,7 +4488,7 @@ Läuft ab: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3578,6 +4545,11 @@ Läuft ab: %3
     <message>
         <location line="+1"/>
         <source>MRCs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3673,7 +4645,7 @@ Läuft ab: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>k.A.</translation>
     </message>
@@ -3749,7 +4721,7 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3992,7 +4964,7 @@ Läuft ab: %3
         <translation>Nein</translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation>Willkommen in der Gridcoin RPC-Konsole!</translation>
     </message>
@@ -4007,7 +4979,7 @@ Läuft ab: %3
         <translation>Bitte &lt;b&gt;help&lt;/b&gt; eingeben, um eine Übersicht verfügbarer Befehle zu erhalten.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4068,10 +5040,8 @@ Läuft ab: %3
         <translation>Ausgehend</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+6"/>
         <source>Unknown</source>
-        <translation>Unbekannt</translation>
+        <translation type="vanished">Unbekannt</translation>
     </message>
 </context>
 <context>
@@ -4162,40 +5132,37 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation>Nicht auf der Whitelist</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4653,7 +5620,7 @@ Läuft ab: %3
         <translation>&quot;Weiter&quot; drücken, wenn Sie fertig sind.</translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation>Adressbezeichnung</translation>
     </message>
@@ -4774,7 +5741,7 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4888,7 +5855,7 @@ Läuft ab: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4911,7 +5878,7 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation>Verfügbar (%1)</translation>
@@ -4923,7 +5890,7 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation>Inaktiv</translation>
     </message>
@@ -5047,7 +6014,7 @@ Läuft ab: %3
         <translation>Gridcoin-Adresse eingeben (z.B. S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Anzahl kopieren</translation>
     </message>
@@ -5107,7 +6074,7 @@ Läuft ab: %3
         <translation> und </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Die Zahlungsadresse ist ungültig, bitte nochmals überprüfen.</translation>
     </message>
@@ -5147,8 +6114,8 @@ Läuft ab: %3
         <translation>Fehler: Die Transaktion wurde abgelehnt. Dies könnte passiert sein, wenn einige der Coins in ihrem Wallet bereits ausgegeben wurden. </translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(keine Bezeichnung)</translation>
     </message>
@@ -5255,7 +6222,7 @@ Läuft ab: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresse</translation>
     </message>
@@ -5393,42 +6360,42 @@ Läuft ab: %3
         <translation>Gridcoin Signatur eingeben</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Die eingegebene Adresse ist ungültig.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Bitte überprüfen Sie die Adresse und versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Die eingegebene Adresse verweist nicht auf einen Schlüssel.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Wallet-Entsperrung wurde abgebrochen.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Privater Schlüssel zur eingegebenen Adresse ist nicht verfügbar.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Signierung der Nachricht fehlgeschlagen.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Nachricht signiert.</translation>
     </message>
@@ -5439,7 +6406,7 @@ Läuft ab: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Bitte überprüfen Sie die Signatur und versuchen Sie es erneut.</translation>
     </message>
@@ -5490,7 +6457,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5498,32 +6465,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Offen bis %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>kollidiert</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/unbestätigt</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 Bestätigungen</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5546,74 +6513,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Quelle</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Von</translation>
     </message>
@@ -5624,13 +6591,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>An</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>eigene Adresse</translation>
@@ -5641,16 +6608,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Gutschrift</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation>
             <numerusform>vollständig bestätigt in %n weiteren Block</numerusform>
@@ -5663,31 +6630,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>nicht angenommen</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Belastung</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Transaktionsgebühr</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Nettobetrag</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Nachricht</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
@@ -5697,38 +6664,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
@@ -5760,11 +6727,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -5784,7 +6756,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Betrag</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5812,12 +6784,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bestätigt (%1 Bestätigungen)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>in Konflikt stehend</translation>
     </message>
@@ -6042,7 +7014,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transaktionsstatus. Fahren Sie mit der Maus über dieses Feld, um die Anzahl der Bestätigungen zu sehen.</translation>
     </message>
@@ -6070,7 +7077,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation>Transaktionshistorie</translation>
     </message>
@@ -6125,7 +7132,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mindestbetrag</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Adresse kopieren</translation>
     </message>
@@ -6155,7 +7167,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Transaktionsdetails anzeigen</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exportiere Transaktionsdaten</translation>
     </message>
@@ -6166,7 +7178,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Kommaseparierte Datei</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Bestätigt</translation>
     </message>
@@ -6211,7 +7223,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kann Datei nicht schreiben %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Zeitraum:</translation>
     </message>
@@ -6247,19 +7259,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Beenden</translation>
+        <translation type="obsolete">&amp;Beenden</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Anwendung beenden</translation>
+        <translation type="obsolete">Anwendung beenden</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Datei</translation>
+        <translation type="obsolete">&amp;Datei</translation>
     </message>
 </context>
 <context>
@@ -6273,7 +7282,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6299,18 +7308,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation>Abstimmung nicht gefunden.</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6387,15 +7396,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Wird gesendet...</translation>
+        <translation type="vanished">Wird gesendet...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Beim Einrichten des abzuhörenden RPC-Ports %u für IPv6 ist ein Fehler aufgetreten, es wird auf IPv4 zurückgegriffen: %s</translation>
     </message>
@@ -6405,23 +7413,23 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Beim Einrichten des abzuhörenden RPC-Ports %u für IPv4 ist ein Fehler aufgetreten: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Benutzung:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Befehle auflisten</translation>
     </message>
     <message>
-        <location line="-367"/>
-        <location line="+344"/>
+        <location line="-397"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-342"/>
+        <location line="-374"/>
         <source>The Gridcoin developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6441,12 +7449,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished">Eine Abstimmung mit einem Ja/Nein/Enthaltung Antworttyp kann keine zusätzlichen benutzerdefinierten Auswahlmöglichkeiten enthalten.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6461,21 +7469,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+46"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6500,7 +7494,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6517,6 +7511,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6561,6 +7565,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6596,11 +7605,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6640,12 +7644,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6710,7 +7709,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6723,11 +7722,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <location line="+1"/>
         <source>Active</source>
         <translation type="unfinished">Aktiv</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6792,16 +7786,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6885,11 +7869,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -6912,16 +7891,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6985,16 +7954,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7017,11 +7976,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7060,18 +8014,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished">Mehrfachauswahl</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation>k. A.</translation>
+        <translation type="vanished">k. A.</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7088,6 +8036,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <location line="+1"/>
         <source>No mature coins</source>
         <translation>Keine reifen (vollständig bestätigten) Coins</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -7300,62 +8253,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
         <translation type="unfinished">Einfachauswahl</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Staking Only - No Eligible Research Projects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7395,16 +8298,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+4"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation>Die PID-Datei &apos;%s&apos; konnte nicht erstellt werden: %s</translation>
@@ -7415,7 +8308,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Unbekannter Abstimmungstyp. Das sollte niemals passieren.</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+9"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7506,6 +8404,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7530,17 +8438,70 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>unbekannt</translation>
     </message>
     <message>
-        <location line="-505"/>
+        <location line="-519"/>
         <source>The %s developers</source>
         <translation>Die %s Entwickler</translation>
     </message>
     <message>
-        <location line="+282"/>
+        <location line="+15"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+235"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Block Version</source>
         <translation>Blockversion</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+15"/>
         <source>Client Version</source>
         <translation>Clientversion</translation>
     </message>
@@ -7570,7 +8531,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>FEHLER</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+25"/>
         <source>GitHub version: </source>
         <translation>GitHub-Version:</translation>
     </message>
@@ -7585,12 +8546,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Importiere Blockchain Datendatei(en).</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+31"/>
         <source>Malformed CPID</source>
         <translation>Fehlerhafte CPID</translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+14"/>
         <source>Organization</source>
         <translation>Organisation</translation>
     </message>
@@ -7600,12 +8561,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Projekt E-Mail stimmt nicht überein</translation>
     </message>
     <message>
-        <location line="-251"/>
+        <location line="-239"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Warnung: -paytxfee ist auf einen sehr hohen Wert festgelegt! Dies ist die Gebühr die beim Senden einer Transaktion fällig wird.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Warnung: wallet.dat beschädigt, Rettung erfolgreich! Original wallet.dat wurde als wallet.{Zeitstempel}.dat in %s gespeichert. Falls ihr Kontostand oder Transaktionen nicht korrekt sind, sollten Sie von einer Datensicherung wiederherstellen.</translation>
     </message>
@@ -7615,7 +8576,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Warnung: Lesen von wallet.dat fehlgeschlagen! Alle Schlüssel wurden korrekt gelesen, Transaktionsdaten bzw. Adressbucheinträge fehlen aber möglicherweise oder sind inkorrekt.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Fehler: Erstellung der Transaktion fehlgeschlagen</translation>
     </message>
@@ -7625,27 +8586,26 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Fehler: Transaktion wurde abgelehnt. Das kann geschehen wenn einige Coins in dem Wallet bereits ausgegeben wurden. Wenn von einer Kopie der wallet.dat Coins ausgegeben wurden, werden sie hier nicht sofort als Ausgabe aufgeführt.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Fehler, es konnte kein Port abgehört werden. Wenn dies so gewünscht wird -listen=0 verwenden.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Zur Nutzung der %s Option</translation>
     </message>
     <message>
-        <location line="-434"/>
+        <location line="-432"/>
         <source>Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet.</source>
         <translation>Aufgrund des Fehlers, die Blockchain-Daten zu löschen, müssen die Daten manuell gelöscht werden, bevor die Wallet erneut gestartet wird.</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation>Fehler beim Herunterladen des Snapshots, da ein zwingend erforderliches Client-Update zum Herunterladen verfügbar ist.</translation>
+        <translation type="vanished">Fehler beim Herunterladen des Snapshots, da ein zwingend erforderliches Client-Update zum Herunterladen verfügbar ist.</translation>
     </message>
     <message>
-        <location line="+127"/>
+        <location line="+195"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7654,32 +8614,28 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechten nur für den Dateibesitzer.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Gridcoin Version</translation>
     </message>
     <message>
-        <location line="+102"/>
         <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation>Stufe (1/4): Herunterladen von snapshot.zip:</translation>
+        <translation type="vanished">Stufe (1/4): Herunterladen von snapshot.zip:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation>Stufe (2/4): Überprüfen der SHA256SUM von snapshot.zip:</translation>
+        <translation type="vanished">Stufe (2/4): Überprüfen der SHA256SUM von snapshot.zip:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation>Stufe (3/4): Bereinigung der Blockchain-Daten:</translation>
+        <translation type="vanished">Stufe (3/4): Bereinigung der Blockchain-Daten:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Stage (4/4): Extracting snapshot.zip:          </source>
-        <translation>Stufe (4/4): Extrahiere snapshot.zip:</translation>
+        <translation type="vanished">Stufe (4/4): Extrahiere snapshot.zip:</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+105"/>
         <source>Unknown error</source>
         <translation>Unbekannter Fehler</translation>
     </message>
@@ -7689,7 +8645,7 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Unbekannt</translation>
     </message>
     <message>
-        <location line="-21"/>
+        <location line="-19"/>
         <source>Staking Only - No active beacon</source>
         <translation>Nur Staking - Kein aktiver Beacon</translation>
     </message>
@@ -7699,7 +8655,7 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Nur Staking - Pool erkannt</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+7"/>
         <source>This update is </source>
         <translation>Dieses Update ist</translation>
     </message>
@@ -7719,12 +8675,12 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Unbekannter Abstimmungsgewichtstyp.</translation>
     </message>
     <message>
-        <location line="-85"/>
+        <location line="-69"/>
         <source>No current polls</source>
         <translation>Keine aktuellen Abstimmungen</translation>
     </message>
     <message>
-        <location line="-30"/>
+        <location line="-25"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ungültiger Betrag für -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
@@ -7739,7 +8695,7 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Initialisierungsprüfung fehlgeschlagen. Gridcoin wird heruntergefahren.</translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Wallet %s liegt außerhalb des Daten Verzeichnisses %s.</translation>
     </message>
@@ -7749,12 +8705,12 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Überprüfe Datenbank Integrität...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-404"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Fehler beim initialisieren der Datenbank Umgebung %s! Um wiederherzustellen, fertige ein Backup des Verzeichnisses an, dann entferne alles davon ausser die wallet.dat Datei. </translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+436"/>
         <source>vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7764,7 +8720,7 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>wallet.dat beschädigt, Rettung fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ungültige Adresse in -proxy: &apos;%s&apos;</translation>
     </message>
@@ -7774,7 +8730,7 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Ungültige Tor Addresse: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kann Adresse in -bind nicht auflösen: &apos;%s&apos;</translation>
     </message>
@@ -7784,12 +8740,12 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Kann Adresse in -externalip nicht auflösen: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Ungültige Anzahl für &apos;reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Fehler beim laden von blkindex.dat</translation>
     </message>
@@ -7804,12 +8760,12 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Fehler beim Laden von wallet.dat. Wallet benötigt neuere Version von Gridcoin</translation>
     </message>
     <message>
-        <location line="+158"/>
+        <location line="+134"/>
         <source>Verifying checkpoints...</source>
         <translation>Überprüfe Checkpoints...</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Wallet locked</source>
         <translation>Wallet gesperrt</translation>
     </message>
@@ -7819,37 +8775,37 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Wallet muss neu geschrieben werden. Starte Gridcoin neu um auszuführen</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Fehler beim Laden von wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Importiere Bootstrap Block Kette Datei.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Lade Adressen...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Fehler: Node konnte nicht gestartet werden</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Fehler beim anbinden %s auf diesem Computer. Gridcoin läuft wahrscheinlich bereits.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Kann auf diesem Computer nicht an %s binden (von bind zurückgegebener Fehler %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Fehler: Wallet verschlüsselt, unmöglich Transaktion zu erstellen</translation>
     </message>
@@ -7864,42 +8820,41 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Fehler: Diese Transaktion benötigt eine Transaktionsgebühr von mindestens %s wegen der Anzahl, Komplexität oder Benutzung von neuerlich erhaltenen Beträgen </translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Wird gesendet...</translation>
+        <translation type="vanished">Wird gesendet...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Ungültiger Betrag</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Wanung : Bitte prüfen Sie ob Datum und Uhrzeit richtig eingestellt sind. Wenn das Datum falsch ist Gridcoin nicht richtig funktionieren.</translation>
     </message>
     <message>
-        <location line="+291"/>
+        <location line="+265"/>
         <source>Vote signature failed. See debug.log.</source>
         <translation>Abstimmungssignierung fehlgeschlagen. Siehe debug.log.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Warning: Disk space is low!</source>
         <translation>Warnung: Festplatte hat wenig freien Speicher!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Unbekannter Netztyp in -onlynet angegeben: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Unzureichender Kontostand</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Lade Blockindex...</translation>
     </message>
@@ -7909,17 +8864,17 @@ Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese mit Leserechte
         <translation>Lade Wallet...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Standardadresse kann nicht geschrieben werden</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Durchsuche erneut...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Laden abgeschlossen</translation>
     </message>

--- a/src/qt/locale/bitcoin_el_GR.ts
+++ b/src/qt/locale/bitcoin_el_GR.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Πορτοφόλι</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Επισκόπηση</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Έ&amp;ξοδος</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Επιβεβαίωση μηνύματος</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Άνοιγμα κονσόλας αποσφαλμάτωσης και διαγνωστικών</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Αρχείο</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ρυθμίσεις</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Η συναλλαγή απεστάλη</translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Το πορτοφόλι είναι &lt;b&gt;κρυπτογραφημένο&lt;/b&gt; και &lt;b&gt;κλειδωμένο&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Ποσό</translation>
+        <translation type="vanished">Ποσό</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>Ημερομηνία</translation>
+        <translation type="vanished">Ημερομηνία</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Επικυρώσεις</translation>
+        <translation type="vanished">Επικυρώσεις</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Επικυρωμένες</translation>
+        <translation type="vanished">Επικυρωμένες</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1251,17 +1402,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1442,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,20 +1492,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Ποσό</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Ημερομηνία</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Επικυρώσεις</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1568,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1630,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1665,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Ποσό</translation>
+        <translation type="obsolete">Ποσό</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Ημερομηνία</translation>
+        <translation type="obsolete">Ημερομηνία</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Επικυρώσεις</translation>
+        <translation type="obsolete">Επικυρώσεις</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Επικυρωμένες</translation>
+        <translation type="obsolete">Επικυρωμένες</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1716,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,24 +1726,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1720,7 +1883,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1913,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2089,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2104,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2117,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2145,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2226,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2305,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2424,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Καθαρισμός &amp;Όλων</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3103,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>προεπιλογή</translation>
     </message>
@@ -2572,7 +3118,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Σφάλμα</translation>
@@ -2800,18 +3346,23 @@ Expires: %3
         <translation>Το τρέχον συνολικό υπόλοιπο</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3373,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Ποσό</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3703,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3743,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3783,7 @@ Expires: %3
         <translation type="unfinished">Φόρμα</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3793,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3816,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3868,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4030,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4065,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4157,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4195,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">Μη διαθέσιμο</translation>
     </message>
@@ -3443,14 +4305,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4356,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4371,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4409,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4471,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3647,7 +4571,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>Μη διαθέσιμο</translation>
     </message>
@@ -3778,7 +4702,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4890,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4905,7 @@ Expires: %3
         <translation>Γράψτε &lt;b&gt;help&lt;/b&gt; για μια επισκόπηση των διαθέσιμων εντολών</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4963,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5054,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5542,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5663,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5777,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5800,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5812,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5936,7 @@ Expires: %3
         <translation>Αποστολη</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +5996,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6036,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5229,7 +6144,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5367,42 +6282,42 @@ Expires: %3
         <translation>Επαναφορά όλων επαλήθευμενων πεδίων μήνυματος </translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6328,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6379,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6387,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6435,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Ημερομηνία</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6513,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6530,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6552,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6586,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">Ποσό</translation>
     </message>
@@ -5734,11 +6649,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">Ημερομηνία</translation>
     </message>
@@ -5758,7 +6678,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Ποσό</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6706,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6936,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +6999,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7054,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6129,7 +7089,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7100,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">Επικυρωμένες</translation>
     </message>
@@ -6185,7 +7145,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6221,19 +7181,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Έ&amp;ξοδος</translation>
+        <translation type="obsolete">Έ&amp;ξοδος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Εξοδος από την εφαρμογή</translation>
+        <translation type="obsolete">Εξοδος από την εφαρμογή</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Αρχείο</translation>
+        <translation type="obsolete">&amp;Αρχείο</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7204,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7230,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,38 +7316,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>ταλαιπωρηθειτε για να ακούσετε σε οποιαδήποτε θύρα. Χρήση - ακούστε = 0 , αν θέλετε αυτό.</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Δεν είναι έγκυρη η διεύθυνση διαμεσολαβητή: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>Φόρτωση διευθύνσεων...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6434,18 +7378,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">Μη διαθέσιμο</translation>
+        <translation type="obsolete">Μη διαθέσιμο</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6466,6 +7404,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6680,42 +7623,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6769,7 +7677,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6799,18 +7707,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Άγνωστo δίκτυο ορίζεται σε onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Ανεπαρκές κεφάλαιο</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6836,17 +7744,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6870,21 +7798,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6925,11 +7839,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6946,6 +7855,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6990,6 +7909,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7030,11 +7954,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7080,11 +7999,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7172,6 +8086,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7183,11 +8102,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7258,16 +8172,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7431,11 +8335,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7458,16 +8357,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7587,16 +8476,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7631,7 +8510,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Φόρτωση πορτοφολιού...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7641,57 +8520,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+20"/>
         <source>Unknown poll response type.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7738,6 +8567,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7847,6 +8681,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7881,17 +8725,45 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>Δεν μπορώ να γράψω την προεπιλεγμένη διεύθυνση</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+383"/>
         <source>Rescanning...</source>
         <translation>Ανίχνευση...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Η φόρτωση ολοκληρώθηκε</translation>
     </message>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Delete</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished">Label</translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +472,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Gridcoin</source>
         <translation type="unfinished">Gridcoin</translation>
     </message>
@@ -371,7 +487,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished">Wallet</translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,7 +628,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -632,6 +753,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -653,16 +779,6 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +798,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -722,19 +858,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +958,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -835,17 +986,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -865,7 +1006,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -883,7 +1024,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -900,7 +1051,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -915,12 +1066,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,18 +1082,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,7 +1102,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1194,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1070,7 +1225,17 @@ Current beacon expired!
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="-715"/>
+        <source>Reset blockchain data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+722"/>
         <source>CPID: %1
 Beacon age: %2
 Expires: %3
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1205,42 +1370,32 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Amount</translation>
+        <translation type="obsolete">Amount</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation type="unfinished">Date</translation>
+        <translation type="obsolete">Date</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmed</translation>
+        <translation type="obsolete">Confirmed</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation type="unfinished">Label</translation>
+        <translation type="obsolete">Label</translation>
     </message>
     <message>
-        <location line="-128"/>
+        <location line="-80"/>
         <source>&amp;List mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+133"/>
         <source>Address</source>
-        <translation type="unfinished">Address</translation>
+        <translation type="obsolete">Address</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1251,17 +1406,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1446,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,19 +1496,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Amount</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Label</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Address</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Date</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1380,7 +1572,7 @@ Expires: %3
         <translation type="unfinished">Address</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1634,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1669,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Amount</translation>
+        <translation type="obsolete">Amount</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Label</translation>
+        <translation type="obsolete">Label</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Address</translation>
+        <translation type="obsolete">Address</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Date</translation>
+        <translation type="obsolete">Date</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmed</translation>
+        <translation type="obsolete">Confirmed</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1724,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,24 +1734,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1720,7 +1891,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1921,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2097,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2112,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2125,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2007,7 +2188,16 @@ Expires: %3
         <translation type="unfinished">Gridcoin</translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2234,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2313,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2432,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Clear &amp;All</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3111,7 @@ Expires: %3
         <translation>&amp;Cancel</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2572,7 +3126,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
@@ -2800,18 +3354,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3381,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Amount</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3711,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3751,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3791,7 @@ Expires: %3
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3801,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3824,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3876,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4038,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4073,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4165,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,14 +4203,48 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3350,7 +4254,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3365,12 +4269,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">N/A</translation>
     </message>
@@ -3485,7 +4412,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3545,13 +4472,18 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
         <source>The wallet must be in sync to manage beacons. Please wait for synchronization to complete before using the researcher and beacon configuration wizard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3647,7 +4579,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
@@ -3718,7 +4650,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4898,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4913,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4971,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5062,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
+        <location line="+3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
+        <location line="+3"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5550,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5671,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5785,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5808,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5820,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5944,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +6004,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6044,8 @@ Expires: %3
         <translation type="unfinished">Error: The transaction was rejected. This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5229,7 +6152,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Address</translation>
     </message>
@@ -5367,42 +6290,42 @@ Expires: %3
         <translation>Enter Gridcoin signature</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6336,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6387,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6395,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6443,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Date</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6521,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6538,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6560,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6594,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">Amount</translation>
     </message>
@@ -5734,11 +6657,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
@@ -5758,7 +6686,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Amount</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6714,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6944,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +7007,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7062,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6129,7 +7097,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7108,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">Confirmed</translation>
     </message>
@@ -6185,7 +7153,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6219,24 +7187,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>UpgradeQt</name>
-    <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Quit application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>VoteWizard</name>
     <message>
         <location filename="../forms/voting/votewizard.ui" line="+20"/>
@@ -6247,7 +7197,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7223,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6361,15 +7311,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation type="unfinished">Sending...</translation>
+        <translation type="obsolete">Sending...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation></translation>
     </message>
@@ -6379,22 +7328,22 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation></translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Usage:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>List commands</translation>
     </message>
     <message>
-        <location line="-351"/>
+        <location line="-376"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6409,21 +7358,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+46"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6443,7 +7378,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+6"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6458,7 +7393,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6493,7 +7428,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+15"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6528,7 +7463,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+5"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6568,12 +7503,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6638,7 +7568,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6650,11 +7580,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6683,17 +7608,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Cannot write to data directory &apos;%s&apos;; check permissions.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6743,12 +7658,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+4"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6769,16 +7679,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Get help for a command</source>
         <translation>Get help for a command</translation>
     </message>
@@ -6793,23 +7693,23 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-342"/>
-        <location line="+344"/>
+        <location line="-374"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished">Gridcoin</translation>
     </message>
     <message>
-        <location line="-342"/>
+        <location line="-374"/>
         <source>The Gridcoin developers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
+        <location line="+157"/>
         <source>The data directory path &apos;%s&apos; contains characters that cannot be represented in the system code page, and Windows 8.3 short filename generation is not available on this volume. Please choose a data directory path using only characters supported by your system locale, or enable 8.3 filename generation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
+        <location line="+223"/>
         <source>Initializing local researcher context...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6824,23 +7724,13 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
+        <location line="+17"/>
         <source>Loading superblock cache...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6864,18 +7754,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">N/A</translation>
+        <translation type="obsolete">N/A</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6891,6 +7775,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7069,46 +7958,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+4"/>
         <source>Staking Only - Non-cruncher Mode</source>
         <translation type="unfinished"></translation>
@@ -7134,16 +7983,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+4"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
@@ -7154,7 +7993,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+14"/>
         <source>Warning: Cannot connect to NTP server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7199,27 +8038,95 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+10"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-224"/>
+        <location line="-201"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-281"/>
+        <location line="-318"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+15"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+31"/>
         <source>Error: Unsupported argument -socks found. Setting SOCKS version isn&apos;t possible anymore, only SOCKS5 proxies are supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+210"/>
+        <location line="+15"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Block Version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7259,7 +8166,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+5"/>
         <source>Checking block index...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7319,12 +8226,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+3"/>
         <source>Failed: Count = %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+5"/>
         <source>GitHub version: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7370,11 +8277,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7389,7 +8291,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+4"/>
         <source>Magnitude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7409,7 +8311,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+10"/>
         <source>Not authorized</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7444,12 +8346,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-251"/>
+        <location line="-239"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</translation>
     </message>
@@ -7459,7 +8361,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation></translation>
     </message>
@@ -7469,32 +8371,22 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation></translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Failed to listen on any port. Use -listen=0 if you want this.</translation>
     </message>
     <message>
-        <location line="+107"/>
+        <location line="+100"/>
         <source>Single Choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+26"/>
+        <location line="+12"/>
         <source>To use the %s option</source>
         <translation>To use the %s option</translation>
     </message>
     <message>
-        <location line="-463"/>
+        <location line="-474"/>
         <source>%s, you must set a rpcpassword in the configuration file:
  %s
 It is recommended you use the following random password:
@@ -7509,27 +8401,17 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+42"/>
         <source>Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
+        <location line="+69"/>
         <source>Failure to do so will result in undefined behaviour or failure to start wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+50"/>
+        <location line="+126"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7538,37 +8420,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
 If the file does not exist, create it with owner-readable-only file permissions.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Gridcoin version</translation>
     </message>
     <message>
-        <location line="+92"/>
+        <location line="+88"/>
         <source>Resetting block chain index to prepare for reindexing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Staking Only - No Eligible Research Projects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7578,7 +8440,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7588,7 +8450,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
+        <location line="-19"/>
         <source>Staking Only - No active beacon</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7603,7 +8465,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+6"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7623,12 +8485,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-85"/>
+        <location line="-69"/>
         <source>No current polls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
+        <location line="-25"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
@@ -7643,7 +8505,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Wallet %s resides outside data directory %s.</translation>
     </message>
@@ -7653,12 +8515,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation></translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-404"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+445"/>
+        <location line="+407"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
         <source>beacon</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7680,6 +8547,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>poll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7713,7 +8590,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation></translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Invalid -proxy address: &apos;%s&apos;</translation>
     </message>
@@ -7723,7 +8600,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Invalid -tor address: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Cannot resolve -bind address: &apos;%s&apos;</translation>
     </message>
@@ -7733,12 +8610,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Cannot resolve -externalip address: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Error loading blkindex.dat</translation>
     </message>
@@ -7753,17 +8630,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Error loading wallet.dat: Wallet requires newer version of Gridcoin</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+68"/>
         <source>Offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
+        <location line="+66"/>
         <source>Verifying checkpoints...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7773,37 +8650,37 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Wallet needed to be rewritten: restart Gridcoin to complete</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Error loading wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Loading addresses...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Error: could not start node</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Unable to bind to %s on this computer. Gridcoin is probably already running.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Unable to bind to %s on this computer (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation></translation>
     </message>
@@ -7818,27 +8695,26 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation></translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Sending...</translation>
+        <translation type="vanished">Sending...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Invalid amount</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</translation>
     </message>
     <message>
-        <location line="+291"/>
+        <location line="+265"/>
         <source>Vote signature failed. See debug.log.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7863,17 +8739,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Warning: Disk space is low!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Unknown network specified in -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Insufficient funds</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Loading block index...</translation>
     </message>
@@ -7883,17 +8759,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Loading wallet...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Cannot write default address</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Rescanning...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Done loading</translation>
     </message>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">jes</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Forigi</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopii &amp;Etikedon</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Redakti</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etikedo</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(neniu etikedo)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Tajpu la malnovan kaj novan monujajn pasfrazojn.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Konfirmo de ?ifrado de la monujo</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>La monujo estas ?ifrita</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>GRAVE: anta?aj sekur-kopioj de via monujo-dosiero estas forigindaj kiam vi havas nove kreitan ?ifritan monujo-dosieron. Pro sekureco, anta?aj kopioj de la ne?ifrita dosiero ne plu funkcios tuj kiam vi ekuzos la novan ?ifritan dosieron.</translation>
+        <translation type="vanished">GRAVE: anta?aj sekur-kopioj de via monujo-dosiero estas forigindaj kiam vi havas nove kreitan ?ifritan monujo-dosieron. Pro sekureco, anta?aj kopioj de la ne?ifrita dosiero ne plu funkcios tuj kiam vi ekuzos la novan ?ifritan dosieron.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>?ifrado de la monujo fiaskis</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>?ifrado de monujo fiaskis pro interna eraro. Via monujo ne estas ?ifrita.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>La pasfrazoj entajpitaj ne samas.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Mal?loso de la monujo fiaskis</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La pasfrazo enigita por ?ifrado de monujo ne ?ustas.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Vi sukcese ?an?is la pasfrazon de la monujo.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Monujo</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Superrigardo</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Eliri</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Kontroli mesaĝon...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Malfermi konzolon de sencimigo kaj diagnozo</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Dosiero</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Agordoj</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Sendita transakcio</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Monujo estas &lt;b&gt;ĉifrita&lt;/b&gt; kaj aktuale &lt;b&gt;ŝlosita&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Reta Averto</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Sumo</translation>
+        <translation type="vanished">Sumo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etikedo</translation>
+        <translation type="obsolete">Etikedo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Dato</translation>
+        <translation type="vanished">Dato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Konfirmoj</translation>
+        <translation type="vanished">Konfirmoj</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Konfirmita</translation>
+        <translation type="vanished">Konfirmita</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Adreso</translation>
+        <translation type="vanished">Adreso</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopii adreson</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopii sumon</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopii transakcian ID-on</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopii kvanton</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Kopii restmonon</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>jes</translation>
     </message>
@@ -1341,20 +1504,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(neniu etikedo)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>restmono de %1 (%2)</translation>
+        <translation type="vanished">restmono de %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(restmono)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(neniu etikedo)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">restmono de %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(restmono)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Sumo</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(restmono)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etikedo</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adreso</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Dato</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Konfirmoj</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1588,7 @@ Expires: %3
         <translation type="unfinished">Adreso</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1650,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1685,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Sumo</translation>
+        <translation type="obsolete">Sumo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etikedo</translation>
+        <translation type="obsolete">Etikedo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adreso</translation>
+        <translation type="obsolete">Adreso</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Dato</translation>
+        <translation type="obsolete">Dato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Konfirmoj</translation>
+        <translation type="obsolete">Konfirmoj</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Konfirmita</translation>
+        <translation type="obsolete">Konfirmita</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1744,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1754,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(neniu etikedo)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">restmono de %1 (%2)</translation>
+        <translation type="obsolete">restmono de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(restmono)</translation>
+        <translation type="obsolete">(restmono)</translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1919,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1949,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2125,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2140,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2153,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2181,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2262,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2341,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2460,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;Forigi Ĉion</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">jes</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Mal?loso de monujo estas nuligita.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3139,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>defaŭlta</translation>
     </message>
@@ -2572,7 +3154,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Eraro</translation>
@@ -2800,18 +3382,23 @@ Expires: %3
         <translation>via aktuala totala saldo</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopii sumon</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3409,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Stato</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Sumo</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3739,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3779,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3819,7 @@ Expires: %3
         <translation type="unfinished">Formularo</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3829,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3852,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,6 +3905,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">jes</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
     </message>
 </context>
 <context>
@@ -3173,12 +4066,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4101,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4193,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4231,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">neaplikebla</translation>
     </message>
@@ -3443,14 +4341,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4392,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4407,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4445,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4507,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3647,7 +4607,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>neaplikebla</translation>
     </message>
@@ -3768,7 +4728,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4926,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4941,7 @@ Expires: %3
         <translation>Tajpu &lt;b&gt;help&lt;/b&gt; por superrigardo de la disponeblaj komandoj.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4999,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5090,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5578,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5699,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5813,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5836,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5848,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5972,7 @@ Expires: %3
         <translation>Ŝendi</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopii kvanton</translation>
     </message>
@@ -5081,7 +6032,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>La adreso de la ricevonto ne validas. Bonvolu kontroli.</translation>
     </message>
@@ -5121,8 +6072,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(neniu etikedo)</translation>
     </message>
@@ -5229,7 +6180,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adreso</translation>
     </message>
@@ -5367,42 +6318,42 @@ Expires: %3
         <translation>Klaku &quot;Subskribi Mesa?on&quot; por krei subskribon</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>La adreso, kiun vi enmetis, estas nevalida.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Bonvolu kontroli la adreson kaj reprovi.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>La adreso, kiun vi enmetis, referencas neniun ?losilon.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Mal?loso de monujo estas nuligita.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La privata ?losilo por la enigita adreso ne disponeblas.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Subskribo de mesa?o fiaskis.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Mesa?o estas subskribita.</translation>
     </message>
@@ -5413,7 +6364,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Bonvolu kontroli la subskribon kaj reprovu.</translation>
     </message>
@@ -5464,7 +6415,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6423,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Malferma ?is %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/senkonekte</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nekonfirmite</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 konfirmoj</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
@@ -5520,74 +6471,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Fonto</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -5598,13 +6549,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Al</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>propra adreso</translation>
@@ -5615,16 +6566,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etikedo</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Kredito</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6588,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>ne akceptita</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debeto</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Krompago</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Neta sumo</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Mesa?o</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Komento</translation>
     </message>
@@ -5671,38 +6622,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Sumo</translation>
     </message>
@@ -5734,11 +6685,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
@@ -5758,7 +6714,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Sumo</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6742,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Konfirmita (%1 konfirmoj)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6972,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transakcia stato. ?vebi super tiu ?i kampo por montri la nombron de konfirmoj.</translation>
     </message>
@@ -6044,7 +7035,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7090,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minimuma sumo</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopii adreson</translation>
     </message>
@@ -6129,7 +7125,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Montri detalojn de transakcio</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7136,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Konfirmita</translation>
     </message>
@@ -6185,7 +7181,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Intervalo:</translation>
     </message>
@@ -6221,19 +7217,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Eliri</translation>
+        <translation type="obsolete">&amp;Eliri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Eliri la aplikaĵon</translation>
+        <translation type="obsolete">Eliri la aplikaĵon</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Dosiero</translation>
+        <translation type="obsolete">&amp;Dosiero</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7240,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7266,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,17 +7352,9 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Eraro okazis dum estigo de RPC-pordo %u por a?skulti per IPv6; retrodefa?ltas al IPv4: %s</translation>
     </message>
@@ -6379,27 +7364,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Eraro okazis dum estigo de RPC-pordo %u por a?skulti per IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Uzado:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Listigi komandojn</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Vidigi helpon pri iu komando</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Averto: -paytxfee estas agordita per tre alta valoro! Tio estas la krompago, kion vi pagos se vi sendas la transakcion.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Averto: via wallet.dat estas difektita, sed la datumoj sukcese savi?is! La originala wallet.dat estas nun konservita kiel wallet.{timestamp}.bak en %s; se via saldo a? transakcioj estas mal?ustaj vi devus resta?ri per alia sekurkopio.</translation>
     </message>
@@ -6409,32 +7394,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Averto: okazis eraro dum lego de wallet.dat! ?iuj ?losiloj sukcese legi?is, sed la transakciaj datumoj a? la adresaro eble mankas a? mal?ustas.</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-191"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+149"/>
         <source>The wallet will now shutdown. Please start your wallet to begin sync from zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+168"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6485,11 +7455,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ne sukcesis aŭskulti ajnan pordon. Uzu -listen=0 se tion vi volas.</translation>
     </message>
@@ -6516,16 +7481,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6629,16 +7584,6 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -6661,11 +7606,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6709,18 +7649,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">neaplikebla</translation>
+        <translation type="obsolete">neaplikebla</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6744,7 +7678,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>No wallet available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6965,82 +7899,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7095,16 +7954,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7114,7 +7963,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Por uzi la agordon %s</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7123,12 +7972,85 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Se la dosiero ne ekzistas, kreu ?in kun permeso &quot;nur posedanto rajtas legi&quot;.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="-224"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+79"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nevalida sumo por -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+28"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7180,6 +8102,11 @@ Se la dosiero ne ekzistas, kreu ?in kun permeso &quot;nur posedanto rajtas legi&
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7289,6 +8216,16 @@ Se la dosiero ne ekzistas, kreu ?in kun permeso &quot;nur posedanto rajtas legi&
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7323,18 +8260,18 @@ Se la dosiero ne ekzistas, kreu ?in kun permeso &quot;nur posedanto rajtas legi&
         <translation>wallet.dat estas difektita, riparo malsukcesis</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Nevalid adreso -proxy: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7359,12 +8296,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+19"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7379,21 +8316,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7434,11 +8357,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7458,7 +8376,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7498,7 +8416,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7534,11 +8452,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7579,11 +8492,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7653,7 +8561,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7668,7 +8576,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Authorized</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7738,7 +8646,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Ne eblas trovi la adreson -bind: &apos;%s&apos;</translation>
     </message>
@@ -7848,32 +8756,32 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Eraro dum ?argado de wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Ŝarĝante adresojn...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Ne eblis bindi al %s en tiu ?i komputilo (bind resendis eraron %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Nevalida sumo</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+87"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Nekonata reto specifita en -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Nesufiĉa mono</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Ŝarĝante blok-indekson...</translation>
     </message>
@@ -7883,17 +8791,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Ŝargado de monujo...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Ne eblas skribi defaŭltan adreson</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Reskanado...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Ŝargado finiĝis</translation>
     </message>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Eliminar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar &amp;Etiqueta</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exportar Data de Libro de Direcciones</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Para &quot;Staking&quot; solamente</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introduzca la nueva contraseña del monedero. &lt;br/&gt;Por favor utilice una contraseña de &lt;b&gt;diez o más carácteres aleatorios&lt;/b&gt;, o &lt;b&gt;ocho o más palabras&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Introduzca la contraseña anterior del monedero y la nueva. </translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar cifrado del monedero</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>¿Seguro que desea cifrar su monedero?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Monedero cifrado</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin cerrará para terminar el proceso de encriptación. Recuerde que la encriptación de su monedero no puede proteger completamente que sus monedas sean robadas por malware infectando su computadora.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: Cualquier copia de seguridad anterior que haya hecho en su archivo de monedero debería ser reemplazada con el archivo de monedero cifrado generado recientemente. Por razones de seguridad, las copias de seguridad anteriores del archivo de monedero descifrado serán inútiles en cuanto empiece a utilizar el nuevo monedero cifrado.</translation>
+        <translation type="vanished">IMPORTANTE: Cualquier copia de seguridad anterior que haya hecho en su archivo de monedero debería ser reemplazada con el archivo de monedero cifrado generado recientemente. Por razones de seguridad, las copias de seguridad anteriores del archivo de monedero descifrado serán inútiles en cuanto empiece a utilizar el nuevo monedero cifrado.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Fracasó el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Falló el cifrado del monedero debido a un error interno. Su monedero no fue cifrado.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>La contraseña introducida no coincide.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Fracasó el desbloqueo del monedero</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña introducida para el cifrado del monedero es incorrecta.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>La contraseña del monedero se ha cambiado con éxito.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Se ha producido un error fatal. Gridcoin ya no puede continuar de forma segura y cerrará.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Monedero</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista general</translation>
     </message>
@@ -508,7 +633,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>S&amp;alir</translation>
     </message>
@@ -633,6 +758,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verificar mensaje...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Exportar...</translation>
@@ -653,17 +783,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Abrir la consola de depuración y diagnóstico</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -683,12 +813,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuración</translation>
     </message>
@@ -723,19 +873,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Cliente Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,17 +973,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Último bloque recibido se generó en %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Esta transacción se encuentra sobre el límite de tamaño. Usted todavía puede enviarlo a un costo de %1, lo que va a los nodos que procesan sus transacciones y ayuda a apoyar la red. ¿Quieres pagar la cuota?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Confirme tarifa de transacción</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transacción enviada</translation>
     </message>
@@ -836,17 +1001,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -866,7 +1021,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -884,7 +1039,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Manejar URI</translation>
@@ -901,7 +1066,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +1081,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Copia de Seguridad de Monedero</translation>
     </message>
@@ -932,18 +1097,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Copia de Seguridad a fracasado</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Hubo un error al tratar de salvar los datos de su monedero a la nueva ubicación.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +1117,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1040,7 +1209,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1092,12 +1261,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alerta de red</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1156,7 +1325,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1211,37 +1380,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Cantidad</translation>
+        <translation type="vanished">Cantidad</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Fecha</translation>
+        <translation type="vanished">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmaciones</translation>
+        <translation type="vanished">Confirmaciones</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmado</translation>
+        <translation type="vanished">Confirmado</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="vanished">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Dirección</translation>
+        <translation type="vanished">Dirección</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copiar ubicación</translation>
     </message>
@@ -1252,17 +1415,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copiar cantidad</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID de transacción</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidad</translation>
     </message>
@@ -1292,17 +1455,17 @@ Expires: %3
         <translation>Copiar cambio</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>sí</translation>
     </message>
@@ -1352,20 +1515,65 @@ Las cantidades inferiores a 0.546 veces la cuota mínima del relé se muestran e
 Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>cambia desde %1 (%2)</translation>
+        <translation type="vanished">cambia desde %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(cambio)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">cambia desde %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(cambio)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Cantidad</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(cambio)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmaciones</translation>
     </message>
 </context>
 <context>
@@ -1391,7 +1599,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished">Dirección</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1453,7 +1661,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1488,37 +1696,31 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Cantidad</translation>
+        <translation type="obsolete">Cantidad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Dirección</translation>
+        <translation type="obsolete">Dirección</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Fecha</translation>
+        <translation type="obsolete">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Confirmaciones</translation>
+        <translation type="obsolete">Confirmaciones</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="obsolete">Confirmado</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1553,7 +1755,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1563,25 +1765,22 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">cambia desde %1 (%2)</translation>
+        <translation type="obsolete">cambia desde %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(cambio)</translation>
+        <translation type="obsolete">(cambio)</translation>
     </message>
 </context>
 <context>
@@ -1731,7 +1930,12 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1756,7 +1960,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1932,7 +2136,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1947,6 +2151,11 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1955,7 +2164,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>Versión</translation>
     </message>
@@ -1983,7 +2192,16 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2055,22 +2273,22 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2134,7 +2352,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2253,6 +2471,370 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Vaciar &amp;todo</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">El desbloqueo del monedero fue cancelado.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2568,7 +3150,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>predeterminado</translation>
     </message>
@@ -2583,7 +3165,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2811,18 +3393,23 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copiar cantidad</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2833,9 +3420,223 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Estado</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Cantidad</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2949,7 +3750,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2989,6 +3790,11 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3024,7 +3830,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished">Formulario</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3034,7 +3840,17 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3047,7 +3863,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3099,6 +3915,83 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3184,12 +4077,17 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3214,12 +4112,12 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3306,7 +4204,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3344,7 +4242,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">N/D</translation>
     </message>
@@ -3454,14 +4352,48 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3471,7 +4403,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3486,12 +4418,35 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3501,7 +4456,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3563,6 +4518,11 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3658,7 +4618,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>N/D</translation>
     </message>
@@ -3729,7 +4689,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3977,7 +4937,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation>¡Bienvenido a la consola RPC de Gridcoin!</translation>
     </message>
@@ -3992,7 +4952,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation>Escriba &lt;b&gt;help&lt;/b&gt; para ver un resumen de los comandos disponibles.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4050,12 +5010,6 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4147,40 +5101,37 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4638,7 +5589,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4759,7 +5710,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4873,7 +5824,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4896,7 +5847,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4908,7 +5859,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5032,7 +5983,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation>Introduzca una dirección de Gridcoin (p. ej. S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidad</translation>
     </message>
@@ -5092,7 +6043,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation>y</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>La dirección de recepción no es válida, compruébela de nuevo.</translation>
     </message>
@@ -5132,8 +6083,8 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation>Error: La transacción ha sido rechazada. Esto puede ocurrir si algunas de sus monedas en el monedero ya se gastaron, por ejemplo, si se usa una copia del wallet.dat y se gastaron las monedas de la copia pero no se han marcado como gastadas aquí.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
@@ -5240,7 +6191,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Dirección</translation>
     </message>
@@ -5378,42 +6329,42 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
         <translation>Introduce la firma Gridcoin</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>La dirección introducida no es válida.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Por favor revise la dirección e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>La dirección introducida no remite a una clave.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>El desbloqueo del monedero fue cancelado.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La clave privada de la dirección introducida no está disponible.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Falló la firma del mensaje.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Mensaje firmado.</translation>
     </message>
@@ -5424,7 +6375,7 @@ Esto significa que se requiere una cuota de al menos %2.</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Por favor compruebe la firma y pruebe de nuevo.</translation>
     </message>
@@ -5475,7 +6426,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5483,32 +6434,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Abierto hasta %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>en conflicto</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/sin conexión</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/no confirmado</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>confirmaciones %1</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
@@ -5531,74 +6482,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Desde</translation>
     </message>
@@ -5609,13 +6560,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>dirección propia</translation>
@@ -5626,16 +6577,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Credito</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5648,31 +6599,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>no aceptada</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Enviado</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Comisión de transacción</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Cantidad neta</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
@@ -5682,39 +6633,39 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Gridcoin generada monedas deben madurar 110 bloques antes de que se pueden gastar. Cuando se genera este bloque, se transmitió a la red para ser añadido a la cadena de bloque. Si no consigue entrar en la cadena, su estado cambia a &quot;no aceptado&quot; y no es gastar. Ocasionalmente esto puede ocurrir si otro nodo genera un bloque en unos segundos del tuyo.
 </translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
@@ -5746,11 +6697,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
@@ -5770,7 +6726,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantidad</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5798,12 +6754,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Confirmación (%1 de%2 confirmaciones recomendadas)&lt;br&gt;</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmaciones)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>En conflicto</translation>
     </message>
@@ -6028,7 +6984,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estado de transacción. Pasa el ratón sobre este campo para ver el número de confirmaciones.</translation>
     </message>
@@ -6056,7 +7047,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6111,7 +7102,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantidad mínima</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copiar ubicación</translation>
     </message>
@@ -6141,7 +7137,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mostrar detalles de la transacción</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exportar datos de transacción</translation>
     </message>
@@ -6152,7 +7148,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
@@ -6197,7 +7193,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>No se puede escribir en el archivo %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Rango:</translation>
     </message>
@@ -6233,19 +7229,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">S&amp;alir</translation>
+        <translation type="obsolete">S&amp;alir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Salir de la aplicación</translation>
+        <translation type="obsolete">Salir de la aplicación</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Archivo</translation>
+        <translation type="obsolete">&amp;Archivo</translation>
     </message>
 </context>
 <context>
@@ -6259,7 +7252,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6285,18 +7278,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6373,15 +7366,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Enviando...</translation>
+        <translation type="vanished">Enviando...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ha ocurrido un error al configurar el puerto RPC %u para escuchar mediante IPv6. Recurriendo a IPv4: %s</translation>
     </message>
@@ -6391,29 +7383,29 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ha ocurrido un error al configurar el puerto RPC %u para escucha en IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Muestra comandos
 </translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Recibir ayuda para un comando
 </translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Aviso: ¡-paytxfee tiene un valor muy alto! Esta es la comisión que pagará si envía una transacción.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Aviso: ¡Recuperados datos de wallet.dat corrupto! El wallet.dat original se ha guardado como wallet.{timestamp}.bak en %s; si hubiera errores en su saldo o transacciones, deberá restaurar una copia de seguridad.</translation>
     </message>
@@ -6423,7 +7415,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Aviso: ¡Error al leer wallet.dat! Todas las claves se han leído correctamente, pero podrían faltar o ser incorrectos los datos de transacciones o las entradas de la libreta de direcciones.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Error: Error en la creación de la transacción</translation>
     </message>
@@ -6433,17 +7425,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Error: La transacción ha sido rechazada. Esto puede ocurrir si algunas de sus monedas en el monedero ya se gastaron, por ejemplo, si se usa una copia del wallet.dat y se gastaron las monedas de la copia pero no se han marcado como gastadas aquí.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ha fallado la escucha en todos los puertos. Use -listen=0 si desea esto.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Para utilizar la opción %s</translation>
     </message>
     <message>
-        <location line="-463"/>
+        <location line="-474"/>
         <source>%s, you must set a rpcpassword in the configuration file:
  %s
 It is recommended you use the following random password:
@@ -6468,12 +7460,12 @@ Por ejemplo: alertnotify=echo %%s | mail -s &quot;Alerta de Gridcoin&quot; admin
     </message>
     <message>
         <location line="-3"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6483,12 +7475,12 @@ Por ejemplo: alertnotify=echo %%s | mail -s &quot;Alerta de Gridcoin&quot; admin
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+19"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6508,21 +7500,7 @@ Por ejemplo: alertnotify=echo %%s | mail -s &quot;Alerta de Gridcoin&quot; admin
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6548,11 +7526,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6572,7 +7545,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6612,7 +7585,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6648,11 +7621,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6692,12 +7660,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6771,7 +7734,7 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6783,11 +7746,6 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6858,16 +7816,6 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6986,11 +7934,6 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7013,16 +7956,6 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7101,7 +8034,7 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>Error al comprobar la sanidad de inicialización. Gridcoin se está cerrando.</translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>El monedero %s reside fuera del directorio de datos %s.</translation>
     </message>
@@ -7111,12 +8044,85 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>Verificando la integridad de la base de datos...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Error al inicializar el entorno de base de datos %s! Para recuperar, HAGA UNA COPIA DE SEGURIDAD DEL DIRECTORIO, a continuación, elimine todo de ella excepto el archivo wallet.dat.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7207,6 +8213,16 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7241,7 +8257,7 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>wallet.dat corrupto, ha fallado la recuperación</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Dirección -proxy inválida: &apos;%s&apos;</translation>
     </message>
@@ -7251,7 +8267,7 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>Dirección -tor inválida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>No se puede resolver la dirección de -bind: &apos;%s&apos;</translation>
     </message>
@@ -7261,12 +8277,12 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>No se puede resolver la dirección de -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Cantidad no válida para -reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Error al cargar blkindex.dat</translation>
     </message>
@@ -7281,7 +8297,7 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>Error cargando wallet.dat: El monedero requiere una nueva versión de Gridcoin</translation>
     </message>
     <message>
-        <location line="+41"/>
+        <location line="+38"/>
         <source>Invalid amount for -peertimeout=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7293,16 +8309,6 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     <message>
         <location line="+1"/>
         <source>Is Superblock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7328,11 +8334,6 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7376,18 +8377,12 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">N/D</translation>
+        <translation type="obsolete">N/D</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7408,6 +8403,11 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7631,78 +8631,8 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7757,16 +8687,6 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7816,7 +8736,7 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7826,37 +8746,37 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>El monedero necesita ser reescrito: reinicie Gridcoin para completar</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Error al cargar wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Importando el archivo de datos de arranque de la cadena de bloques.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Cargando direcciones...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Error: no se pudo iniciar el nodo</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>No se puede enlazar a %s en este equipo. Gridcoin probablemente ya esté en funcionamiento.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>No es posible conectar con %s en este sistema (bind ha dado el error %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Error: Monedero bloqueado, no es posible crear una transacción</translation>
     </message>
@@ -7871,37 +8791,36 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>Error: Esta transacción requiere una tarifa de transacción de al menos %s debido a su cantidad, complejidad o uso de los fondos recibidos recientemente</translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Enviando...</translation>
+        <translation type="vanished">Enviando...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Cuantía no válida</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Advertencia: Verifique que la fecha y hora del equipo sean correctas! Si su reloj es erróneo Gridcoin no funcionará correctamente.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Advertencia: Espacio en disco bajo!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>La red especificada en -onlynet &apos;%s&apos; es desconocida</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Fondos insuficientes</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Cargando el índice de bloques...</translation>
     </message>
@@ -7911,17 +8830,17 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>Cargando monedero...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>No se puede escribir la dirección predeterminada</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Reexplorando...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Se terminó de cargar</translation>
     </message>

--- a/src/qt/locale/bitcoin_es_CL.ts
+++ b/src/qt/locale/bitcoin_es_CL.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copia &amp;etiqueta</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Introduce la contraseña anterior y la nueva de cartera</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirma la codificación de cartera</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Billetera codificada</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: Cualquier versión anterior que hayas realizado de tu archivo de billetera será reemplazada por el nuevo archivo de billetera encriptado. Por razones de seguridad, los respaldos anteriores de los archivos de billetera se volverán inútiles en tanto comiences a usar la nueva billetera encriptada.</translation>
+        <translation type="vanished">IMPORTANTE: Cualquier versión anterior que hayas realizado de tu archivo de billetera será reemplazada por el nuevo archivo de billetera encriptado. Por razones de seguridad, los respaldos anteriores de los archivos de billetera se volverán inútiles en tanto comiences a usar la nueva billetera encriptada.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Falló la codificación de la billetera</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>La codificación de la billetera falló debido a un error interno. Tu billetera no ha sido codificada.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Las contraseñas no coinciden.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Ha fallado el desbloqueo de la billetera</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña introducida para decodificar la billetera es incorrecta.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>La contraseña de billetera ha sido cambiada con éxito.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Cartera</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista general</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Salir</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Verificar mensaje....</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Abre consola de depuración y diagnóstico</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuración</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[red-de-pruebas]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transacción enviada</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>La billetera esta &lt;b&gt;codificada&lt;/b&gt; y actualmente &lt;b&gt;bloqueda&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alerta de Red</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1156,7 +1325,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1211,37 +1380,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Cantidad</translation>
+        <translation type="vanished">Cantidad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Fecha</translation>
+        <translation type="vanished">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmaciones</translation>
+        <translation type="vanished">Confirmaciones</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmado</translation>
+        <translation type="vanished">Confirmado</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Dirección</translation>
+        <translation type="vanished">Dirección</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copia dirección</translation>
     </message>
@@ -1252,17 +1415,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copiar Cantidad</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1292,17 +1455,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1342,20 +1505,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Cantidad</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmaciones</translation>
     </message>
 </context>
 <context>
@@ -1381,7 +1581,7 @@ Expires: %3
         <translation type="unfinished">Dirección</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1443,7 +1643,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1478,37 +1678,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Cantidad</translation>
+        <translation type="obsolete">Cantidad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Dirección</translation>
+        <translation type="obsolete">Dirección</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Fecha</translation>
+        <translation type="obsolete">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Confirmaciones</translation>
+        <translation type="obsolete">Confirmaciones</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="obsolete">Confirmado</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1543,7 +1737,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1553,25 +1747,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(sin etiqueta)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1721,7 +1904,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1746,7 +1934,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1922,7 +2110,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1937,6 +2125,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1945,7 +2138,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1973,7 +2166,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2045,22 +2247,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2124,7 +2326,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2243,6 +2445,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;Borra todos</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Ha fallado el desbloqueo de la billetera</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2559,7 +3125,7 @@ Expires: %3
         <translation>&amp;Cancela</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>predeterminado</translation>
     </message>
@@ -2574,7 +3140,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2802,18 +3368,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copiar Cantidad</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2824,9 +3395,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Estado</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Cantidad</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2940,7 +3725,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2980,6 +3765,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3015,7 +3805,7 @@ Expires: %3
         <translation type="unfinished">Formulario</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3025,7 +3815,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3038,7 +3838,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3090,6 +3890,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3175,12 +4052,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3205,12 +4087,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3297,7 +4179,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3335,7 +4217,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,14 +4327,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3462,7 +4378,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3477,12 +4393,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3492,7 +4431,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3554,6 +4493,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3679,7 +4623,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3795,7 +4739,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3968,7 +4912,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3983,7 +4927,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4041,12 +4985,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4138,40 +5076,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4629,7 +5564,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4750,7 +5685,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4864,7 +5799,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4887,7 +5822,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4899,7 +5834,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5024,7 +5959,7 @@ Expires: %3
         <translation>&amp;Envía</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5084,7 +6019,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>La dirección de destinatarion no es valida, comprueba otra vez.</translation>
     </message>
@@ -5124,8 +6059,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
@@ -5232,7 +6167,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Dirección</translation>
     </message>
@@ -5370,42 +6305,42 @@ Expires: %3
         <translation>Click en &quot;Firmar Mensage&quot; para conseguir firma</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>La dirección introducida no es válida.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Por favor, revise la dirección Bitcoin e inténtelo denuevo</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Ha fallado el desbloqueo de la billetera</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Firma fallida</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Mensaje firmado</translation>
     </message>
@@ -5416,7 +6351,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5467,7 +6402,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5475,32 +6410,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Abierto hasta %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/fuera de linea</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/no confirmado</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmaciónes</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
@@ -5523,74 +6458,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -5601,13 +6536,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>propia dirección</translation>
@@ -5618,16 +6553,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Credito</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5640,31 +6575,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>no aceptada</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debito</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Comisión transacción</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Cantidad total</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
@@ -5674,38 +6609,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
@@ -5737,11 +6672,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
@@ -5761,7 +6701,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantidad</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5789,12 +6729,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmaciones)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6019,7 +6959,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estado de transacción. Pasa el raton sobre este campo para ver el numero de confirmaciónes.</translation>
     </message>
@@ -6047,7 +7022,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6102,7 +7077,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantidad minima</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copia dirección</translation>
     </message>
@@ -6132,7 +7112,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mostrar detalles de la transacción</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6143,7 +7123,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
@@ -6188,7 +7168,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Rango:</translation>
     </message>
@@ -6224,19 +7204,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Salir</translation>
+        <translation type="obsolete">&amp;Salir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Salir del programa</translation>
+        <translation type="obsolete">Salir del programa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Archivo</translation>
+        <translation type="obsolete">&amp;Archivo</translation>
     </message>
 </context>
 <context>
@@ -6250,7 +7227,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6276,18 +7253,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6362,49 +7339,114 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+488"/>
+        <location filename="../bitcoinstrings.cpp" line="+499"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Muestra comandos
 </translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Recibir ayuda para un comando
 </translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Precaución: -paytxfee es muy alta. Esta es la comisión que pagarás si envias una transacción.</translation>
     </message>
     <message>
-        <location line="+294"/>
+        <location line="+265"/>
         <source>To use the %s option</source>
         <translation>Para utilizar la opción %s</translation>
     </message>
     <message>
-        <location line="-107"/>
+        <location line="-86"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidad inválida para -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="-375"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6461,6 +7503,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6570,6 +7617,16 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6604,12 +7661,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>wallet.dat corrompió, guardado fallido</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Dirección -proxy invalida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-38"/>
+        <location line="-35"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Error cargando wallet.dat: Billetera corrupta</translation>
     </message>
@@ -6619,18 +7676,13 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Error cargando wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Cargando direcciónes...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6675,17 +7727,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6709,7 +7751,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>No wallet available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6930,82 +7972,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7060,16 +8027,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7079,18 +8036,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>No es posible escuchar en el %s en este ordenador (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Cantidad inválida</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+344"/>
+        <location line="-394"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7115,12 +8072,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7130,7 +8087,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+9"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7150,21 +8107,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7205,11 +8148,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7229,7 +8167,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7269,7 +8207,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7310,11 +8248,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7355,11 +8288,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7446,7 +8374,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7458,11 +8386,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7533,16 +8456,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7702,11 +8615,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7733,16 +8641,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7851,16 +8749,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7891,17 +8779,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Cargando cartera...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>No se pudo escribir la dirección por defecto</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Rescaneando...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Carga completa</translation>
     </message>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">si</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Eliminar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar &amp;etiqueta</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Introduzca la contraseña anterior de la cartera y la nueva. </translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar cifrado de la cartera</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Monedero cifrado</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: Cualquier copia de seguridad que haya realizado previamente de su archivo de monedero debe reemplazarse con el nuevo archivo de monedero cifrado. Por razones de seguridad, las copias de seguridad previas del archivo de monedero no cifradas serán inservibles en cuanto comience a usar el nuevo monedero cifrado.</translation>
+        <translation type="vanished">IMPORTANTE: Cualquier copia de seguridad que haya realizado previamente de su archivo de monedero debe reemplazarse con el nuevo archivo de monedero cifrado. Por razones de seguridad, las copias de seguridad previas del archivo de monedero no cifradas serán inservibles en cuanto comience a usar el nuevo monedero cifrado.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Ha fallado el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Ha fallado el cifrado del monedero debido a un error interno. El monedero no ha sido cifrado.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Las contraseñas no coinciden.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Ha fallado el desbloqueo del monedero</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña introducida para descifrar el monedero es incorrecta.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Se ha cambiado correctamente la contraseña del monedero.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Monedero</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista general</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Salir</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verificar mensaje...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Abrir la consola de depuración y diagnóstico</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuración</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transacción enviada</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alerta de red</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Cantidad</translation>
+        <translation type="vanished">Cantidad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Fecha</translation>
+        <translation type="vanished">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmaciones</translation>
+        <translation type="vanished">Confirmaciones</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmado</translation>
+        <translation type="vanished">Confirmado</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Dirección</translation>
+        <translation type="vanished">Dirección</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copiar cantidad</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copiar identificador de transacción</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidad</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Copiar cambio</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>si</translation>
     </message>
@@ -1341,20 +1504,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>Enviar desde %1 (%2)</translation>
+        <translation type="vanished">Enviar desde %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(cambio)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">Enviar desde %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(cambio)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Cantidad</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(cambio)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmaciones</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1588,7 @@ Expires: %3
         <translation type="unfinished">Dirección</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1650,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1685,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Cantidad</translation>
+        <translation type="obsolete">Cantidad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Dirección</translation>
+        <translation type="obsolete">Dirección</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Fecha</translation>
+        <translation type="obsolete">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Confirmaciones</translation>
+        <translation type="obsolete">Confirmaciones</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="obsolete">Confirmado</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1744,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1754,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">Enviar desde %1 (%2)</translation>
+        <translation type="obsolete">Enviar desde %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(cambio)</translation>
+        <translation type="obsolete">(cambio)</translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1919,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1949,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2125,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2140,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2153,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2181,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2262,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2341,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2460,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Limpiar &amp;todo</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">si</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Se ha cancelado el desbloqueo del monedero. </translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3139,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>predeterminado</translation>
     </message>
@@ -2572,7 +3154,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2800,18 +3382,23 @@ Expires: %3
         <translation>Su balance actual total</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3409,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Estado</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Cantidad</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3739,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3779,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3819,7 @@ Expires: %3
         <translation type="unfinished">Desde</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3829,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3852,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3904,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">si</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4066,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4101,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4193,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4231,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">N/D</translation>
     </message>
@@ -3443,14 +4341,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4392,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4407,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4445,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4507,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3647,7 +4607,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>N/D</translation>
     </message>
@@ -3768,7 +4728,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4926,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4941,7 @@ Expires: %3
         <translation>Escriba &lt;b&gt;help&lt;/b&gt; para ver un resumen de los comandos disponibles.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4999,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5090,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5578,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5699,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5813,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5836,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5848,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5972,7 @@ Expires: %3
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidad</translation>
     </message>
@@ -5081,7 +6032,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>La dirección de recepción no es válida, compruébela de nuevo.</translation>
     </message>
@@ -5121,8 +6072,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
@@ -5229,7 +6180,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Dirección</translation>
     </message>
@@ -5367,42 +6318,42 @@ Expires: %3
         <translation>Haga clic en &quot;Firmar mensaje&quot; para generar la firma</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>La dirección introducida es inválida.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Verifique la dirección e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>La dirección introducida no corresponde a una clave.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Se ha cancelado el desbloqueo del monedero. </translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>No se dispone de la clave privada para la dirección introducida.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Ha fallado la firma del mensaje.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Mensaje firmado.</translation>
     </message>
@@ -5413,7 +6364,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Compruebe la firma e inténtelo de nuevo.</translation>
     </message>
@@ -5464,7 +6415,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6423,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Abierto hasta %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/fuera de línea</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/no confirmado</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmaciones</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
@@ -5520,74 +6471,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -5598,13 +6549,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>dirección propia</translation>
@@ -5615,16 +6566,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Crédito</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6588,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>no aceptada</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Débito</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Comisión de transacción</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Cantidad neta</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
@@ -5671,38 +6622,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
@@ -5734,11 +6685,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
@@ -5758,7 +6714,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantidad</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6742,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmaciones)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6972,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estado de transacción. Pasa el ratón sobre este campo para ver el número de confirmaciones.</translation>
     </message>
@@ -6044,7 +7035,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7090,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantidad mínima</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
@@ -6129,7 +7125,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mostrar detalles de la transacción</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7136,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
@@ -6185,7 +7181,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Rango:</translation>
     </message>
@@ -6221,19 +7217,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Salir</translation>
+        <translation type="obsolete">&amp;Salir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Salir de la aplicación</translation>
+        <translation type="obsolete">Salir de la aplicación</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Archivo</translation>
+        <translation type="obsolete">&amp;Archivo</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7240,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7266,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,17 +7352,9 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ha ocurrido un error al configurar el puerto RPC %u para escuchar mediante IPv6. Recurriendo a IPv4: %s</translation>
     </message>
@@ -6379,29 +7364,29 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ha ocurrido un error al configurar el puerto RPC %u para escucha en IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Muestra comandos
 </translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Recibir ayuda para un comando
 </translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Aviso: ¡-paytxfee tiene un valor muy alto! Esta es la comisión que pagará si envía una transacción.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Aviso: ¡Recuperados datos de wallet.dat corrupto! El wallet.dat original se ha guardado como wallet.{timestamp}.bak en %s; si hubiera errores en su saldo o transacciones, deberá restaurar una copia de seguridad.</translation>
     </message>
@@ -6411,32 +7396,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Aviso: ¡Error al leer wallet.dat! Todas las claves se han leído correctamente, pero podrían faltar o ser incorrectos los datos de transacciones o las entradas de la libreta de direcciones.</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-191"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+149"/>
         <source>The wallet will now shutdown. Please start your wallet to begin sync from zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+168"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6492,11 +7462,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ha fallado la escucha en todos los puertos. Use -listen=0 si desea esto.</translation>
     </message>
@@ -6523,16 +7488,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6636,16 +7591,6 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -6668,11 +7613,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6716,18 +7656,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">N/D</translation>
+        <translation type="obsolete">N/D</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6751,7 +7685,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>No wallet available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6972,82 +7906,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7102,16 +7961,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7121,7 +7970,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Para utilizar la opción %s</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7130,12 +7979,85 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Si el archivo no existe, créelo con permiso de lectura solamente del propietario.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="-224"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+79"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidad inválida para -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+28"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7187,6 +8109,11 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7296,6 +8223,16 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7330,18 +8267,18 @@ Si el archivo no existe, créelo con permiso de lectura solamente del propietari
         <translation>wallet.dat corrupto. Ha fallado la recuperación.</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Dirección -proxy inválida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7366,12 +8303,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+19"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7386,21 +8323,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7441,11 +8364,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7465,7 +8383,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7505,7 +8423,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7541,11 +8459,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7586,11 +8499,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7660,7 +8568,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7675,7 +8583,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Authorized</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7745,7 +8653,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>No se puede resolver la dirección de -bind: &apos;%s&apos;</translation>
     </message>
@@ -7855,32 +8763,32 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Error al cargar wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Cargando direcciones...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>No es posible conectar con %s en este sistema (bind ha dado el error %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Cuantía no válida</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+87"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>La red especificada en -onlynet &apos;%s&apos; es desconocida</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Fondos insuficientes</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Cargando el índice de bloques...</translation>
     </message>
@@ -7890,17 +8798,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Cargando monedero...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>No se puede escribir la dirección predeterminada</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Reexplorando...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Generado pero no aceptado</translation>
     </message>

--- a/src/qt/locale/bitcoin_es_MX.ts
+++ b/src/qt/locale/bitcoin_es_MX.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ingrese la antugüa y nueva contraseña de la cartera</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar la encriptación de cartera</translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Cartera encriptada</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>La encriptación de la cartera falló</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>La encriptación de la cartera falló debido a un error interno. Su cartera no fue encriptada.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Las contraseñas dadas no coinciden</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>El desbloqueo de la cartera Fallo</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña ingresada para la des encriptación de la cartera es incorrecto</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Cartera</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista previa</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>S&amp;alir</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verificar mensaje...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Abrir consola de depuración y diagnostico</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuraciones</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Enviar Transacción</translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>La cartera esta &lt;b&gt;encriptada&lt;/b&gt; y &lt;b&gt;bloqueada&lt;/b&gt; actualmente </translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Monto</translation>
+        <translation type="vanished">Monto</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Fecha</translation>
+        <translation type="vanished">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmado </translation>
+        <translation type="vanished">Confirmado </translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Domicilio</translation>
+        <translation type="vanished">Domicilio</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copiar dirección </translation>
     </message>
@@ -1251,17 +1406,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>copiar monto</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>copiar cantidad</translation>
     </message>
@@ -1291,17 +1446,17 @@ Expires: %3
         <translation>copiar cambio</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,19 +1496,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Monto</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Domicilio</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1380,7 +1572,7 @@ Expires: %3
         <translation type="unfinished">Domicilio</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1634,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1669,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Monto</translation>
+        <translation type="obsolete">Monto</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Domicilio</translation>
+        <translation type="obsolete">Domicilio</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Fecha</translation>
+        <translation type="obsolete">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado </translation>
+        <translation type="obsolete">Confirmado </translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1724,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1734,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(sin etiqueta)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1891,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1921,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2097,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2112,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2125,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2153,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2234,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2313,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2432,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3111,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2572,7 +3126,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2800,18 +3354,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">copiar monto</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3381,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Monto</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3711,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3751,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3791,7 @@ Expires: %3
         <translation type="unfinished">Formulario</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3801,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3824,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3876,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4038,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4073,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4165,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4203,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4313,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4364,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4379,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4417,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4479,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4594,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3803,7 +4735,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4898,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4913,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4971,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5062,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5550,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5671,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5785,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5808,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5820,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5944,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>copiar cantidad</translation>
     </message>
@@ -5081,7 +6004,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6044,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
@@ -5229,7 +6152,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Domicilio</translation>
     </message>
@@ -5367,42 +6290,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6336,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6387,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6395,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Abrir hasta %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/No confirmado</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmaciones</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6443,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6521,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6538,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6560,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6594,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Monto</translation>
     </message>
@@ -5734,11 +6657,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
@@ -5758,7 +6686,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Monto</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6714,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confimado (%1 confirmaciones)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6944,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +7007,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7062,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Monto minimo </translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copiar dirección </translation>
     </message>
@@ -6129,7 +7097,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7108,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmado </translation>
     </message>
@@ -6185,7 +7153,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6221,19 +7189,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">S&amp;alir</translation>
+        <translation type="obsolete">S&amp;alir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Salir de la aplicación</translation>
+        <translation type="obsolete">Salir de la aplicación</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Archivo</translation>
+        <translation type="obsolete">&amp;Archivo</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7212,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7238,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,33 +7324,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+488"/>
+        <location filename="../bitcoinstrings.cpp" line="+499"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lista de comandos</translation>
     </message>
     <message>
-        <location line="-367"/>
-        <location line="+344"/>
+        <location line="-397"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6411,17 +7368,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6445,21 +7422,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6500,11 +7463,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6524,7 +7482,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6564,7 +7522,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6605,11 +7563,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6655,11 +7608,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6746,7 +7694,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6758,11 +7706,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6833,16 +7776,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7017,11 +7950,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7048,16 +7976,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7186,16 +8104,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7233,11 +8141,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7282,21 +8185,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7313,6 +8254,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7542,82 +8488,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7668,16 +8539,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7753,6 +8614,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7862,6 +8728,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7896,7 +8772,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-200"/>
+        <location line="-179"/>
         <source>Done loading</source>
         <translation>Carga completa</translation>
     </message>

--- a/src/qt/locale/bitcoin_es_UY.ts
+++ b/src/qt/locale/bitcoin_es_UY.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(Sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ingrese la contraseña anterior y la nueva de acceso a el monedero</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirme el cifrado del monedero</translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Monedero cifrado</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Fallo en el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Fallo en el cifrado del monedero a causa de un error interno. Su monedero no esta cifrado</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Las contraseñas suministradas no coinciden.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Fallo en el desbloqueo del mondero</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña introducida para el descifrado del monedero es incorrecta.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Billetera</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista previa</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Salida</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuracion </translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[prueba_de_red]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transaccion enviada</translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>El Monedero esta &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Fecha</translation>
+        <translation type="vanished">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmado</translation>
+        <translation type="vanished">Confirmado</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Direccion </translation>
+        <translation type="vanished">Direccion </translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1251,17 +1402,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1442,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,19 +1492,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(Sin etiqueta)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(Sin etiqueta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Direccion </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1380,7 +1568,7 @@ Expires: %3
         <translation type="unfinished">Direccion </translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1630,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1665,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Direccion </translation>
+        <translation type="obsolete">Direccion </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Fecha</translation>
+        <translation type="obsolete">Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="obsolete">Confirmado</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1716,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1726,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(Sin etiqueta)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1883,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1913,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2089,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2104,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2117,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2145,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2226,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2305,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2424,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3103,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2572,7 +3118,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2800,18 +3346,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3373,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3703,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3743,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3783,7 @@ Expires: %3
         <translation type="unfinished">Formulario</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3793,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3816,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3868,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4030,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4065,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4157,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4195,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4305,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4356,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4371,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4409,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4471,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4586,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3803,7 +4727,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4890,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4905,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4963,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5054,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5542,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5663,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5777,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5800,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5812,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5936,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +5996,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6036,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(Sin etiqueta)</translation>
     </message>
@@ -5229,7 +6144,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Direccion </translation>
     </message>
@@ -5367,42 +6282,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6328,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6379,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6387,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Abrir hasta %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6435,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6513,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6530,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6552,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6586,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,11 +6649,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
@@ -5758,7 +6678,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6706,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6936,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +6999,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7054,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6129,7 +7089,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7100,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">Confirmado</translation>
     </message>
@@ -6185,7 +7145,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6221,19 +7181,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Salida</translation>
+        <translation type="obsolete">Salida</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Salir de la aplicacion </translation>
+        <translation type="obsolete">Salir de la aplicacion </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Archivo</translation>
+        <translation type="obsolete">&amp;Archivo</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7204,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7230,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,23 +7316,15 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
         <location filename="../bitcoinstrings.cpp" line="+12"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6401,17 +7350,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6435,21 +7404,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6490,11 +7445,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6514,7 +7464,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6554,7 +7504,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6595,11 +7545,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6645,11 +7590,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6736,7 +7676,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6748,11 +7688,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6823,16 +7758,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7012,11 +7937,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7043,16 +7963,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7182,16 +8092,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7237,11 +8137,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Magnitude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7282,21 +8177,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7313,6 +8246,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7542,82 +8480,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7668,16 +8531,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7758,6 +8611,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7863,6 +8721,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>poll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_et.ts
+++ b/src/qt/locale/bitcoin_et.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">jah</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ei</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Kustuta</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopeeri &amp;Silt</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Muuda</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Märge</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(märge puudub)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Sisesta uus salafraas rahakotti.&lt;br/&gt;Kasuta salafraasi millles on&lt;b&gt;kümme või rohkem juhuslikku sümbolit&lt;b&gt;,või&lt;b&gt;kaheksa või rohkem sõna&lt;b/&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Sisesta rahakoti vana ning uus salafraas.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Kinnita rahakoti krüpteerimine.</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Rahakott krüpteeritud</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>TÄHTIS: Kõik varasemad rahakoti varundfailid tuleks üle kirjutada äsja loodud krüpteeritud rahakoti failiga. Turvakaalutlustel tühistatakse krüpteerimata rahakoti failid alates uue, krüpteeritud rahakoti, kasutusele võtust.</translation>
+        <translation type="vanished">TÄHTIS: Kõik varasemad rahakoti varundfailid tuleks üle kirjutada äsja loodud krüpteeritud rahakoti failiga. Turvakaalutlustel tühistatakse krüpteerimata rahakoti failid alates uue, krüpteeritud rahakoti, kasutusele võtust.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Rahakoti krüpteerimine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Rahakoti krüpteerimine ebaõnnestus sisemise tõrke tõttu. Sinu rahakott ei ole krüpteeritud.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Sisestatud salafraasid ei kattu.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Rahakoti lahtilukustamine ebaõnnestus</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Rahakoti dekrüpteerimiseks sisestatud salafraas ei ole õige.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Rahakoti salafraas on edukalt vahetatud.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Rahakott</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Ülevaade</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>V&amp;älju</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Kontrolli sõnumit...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ava debugimise ja diagnostika konsool</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fail</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Seaded</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Saadetud tehing</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Rahakott on &lt;b&gt;krüpteeritud&lt;/b&gt; ning hetkel &lt;b&gt;suletud&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Võrgu Häire</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Kogus</translation>
+        <translation type="vanished">Kogus</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Kuupäev</translation>
+        <translation type="vanished">Kuupäev</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Kinnitused</translation>
+        <translation type="vanished">Kinnitused</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Kinnitatud</translation>
+        <translation type="vanished">Kinnitatud</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Aadress</translation>
+        <translation type="vanished">Aadress</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopeeri aadress</translation>
     </message>
@@ -1251,17 +1410,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopeeri summa</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopeeri tehingu ID</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopeeri kogus</translation>
     </message>
@@ -1291,17 +1450,17 @@ Expires: %3
         <translation>Kopeeri vahetusraha</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>jah</translation>
     </message>
@@ -1341,20 +1500,61 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(märgis puudub)</translation>
     </message>
     <message>
-        <location line="-10"/>
+        <source>(change)</source>
+        <translation type="vanished">(vahetusraha)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
-        <translation>(vahetusraha)</translation>
+        <translation type="unfinished">(vahetusraha)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Aadress</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Kuupäev</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Kinnitused</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1580,7 @@ Expires: %3
         <translation type="unfinished">Aadress</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1642,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1677,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Aadress</translation>
+        <translation type="obsolete">Aadress</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Kuupäev</translation>
+        <translation type="obsolete">Kuupäev</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Kinnitused</translation>
+        <translation type="obsolete">Kinnitused</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Kinnitatud</translation>
+        <translation type="obsolete">Kinnitatud</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1728,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1738,18 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(vahetusraha)</translation>
+        <translation type="obsolete">(vahetusraha)</translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1899,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1929,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2105,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2120,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2133,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2161,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2242,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2321,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2440,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Puhasta &amp;Kõik</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">jah</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">ei</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Rahakoti lahtilukustamine on katkestatud.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3119,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>vaikeväärtus</translation>
     </message>
@@ -2572,7 +3134,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Tõrge</translation>
@@ -2800,18 +3362,23 @@ Expires: %3
         <translation>Kokku:</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopeeri summa</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3389,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Olek</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3719,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3759,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3799,7 @@ Expires: %3
         <translation type="unfinished">Vorm</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3809,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3832,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,6 +3885,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">jah</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ei</translation>
     </message>
 </context>
 <context>
@@ -3173,12 +4046,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4081,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4173,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4211,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4321,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4372,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4387,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4425,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4487,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3687,7 +4627,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3788,7 +4728,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4906,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4921,7 @@ Expires: %3
         <translation>Ülevaateks võimalikest käsklustest trüki &lt;b&gt;help&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4979,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5070,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5558,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5679,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5793,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5816,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5828,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5952,7 @@ Expires: %3
         <translation>S&amp;aada</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopeeri kogus</translation>
     </message>
@@ -5081,7 +6012,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Saaja aadress ei ole kehtiv, palun kontrolli.</translation>
     </message>
@@ -5121,8 +6052,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(märgis puudub)</translation>
     </message>
@@ -5229,7 +6160,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Aadress</translation>
     </message>
@@ -5367,42 +6298,42 @@ Expires: %3
         <translation>Allkirja loomiseks vajuta &quot;Allkirjasta Sõnum&quot;</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Sisestatud aadress ei ole korrektne</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Palun kontrolli aadressi ja proovi uuesti.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Sisestatud aadress ei viita võtmele.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Rahakoti lahtilukustamine on katkestatud.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Sisestatud aadressi privaatvõti pole saadaval.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Sõnumi allkirjastamine ebaõnnestus.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Sõnum allkirjastatud</translation>
     </message>
@@ -5413,7 +6344,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Palun kontrolli allkirja ja proovi uuesti.</translation>
     </message>
@@ -5464,7 +6395,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6403,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Avatud kuni %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline&apos;is</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/kinnitamata</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 kinnitust</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Olek</translation>
     </message>
@@ -5520,74 +6451,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kuupäev</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Allikas</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Saatja</translation>
     </message>
@@ -5598,13 +6529,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Saaja</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>oma aadress</translation>
@@ -5615,16 +6546,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>märgis</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Krediit</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6568,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>pole vastu võetud</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Deebet</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Tehingutasu</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Neto summa</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Sõnum</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Kommentaar</translation>
     </message>
@@ -5671,38 +6602,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Summa</translation>
     </message>
@@ -5734,11 +6665,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Kuupäev</translation>
     </message>
@@ -5758,7 +6694,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kogus</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6722,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Kinnitatud (%1 kinnitust)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6952,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Tehingu staatus. Kinnituste arvu kuvamiseks liigu hiire noolega selle peale.</translation>
     </message>
@@ -6044,7 +7015,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7070,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minimaalne summa</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopeeri aadress</translation>
     </message>
@@ -6129,7 +7105,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kuva tehingu detailid</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7116,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Kinnitatud</translation>
     </message>
@@ -6185,7 +7161,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Ulatus:</translation>
     </message>
@@ -6221,19 +7197,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">V&amp;älju</translation>
+        <translation type="obsolete">V&amp;älju</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Väljumine</translation>
+        <translation type="obsolete">Väljumine</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fail</translation>
+        <translation type="obsolete">&amp;Fail</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7220,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7246,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6361,15 +7334,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation type="unfinished">Saatmine...</translation>
+        <translation type="obsolete">Saatmine...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>RPC pordi %u kuulamiseks seadistamisel ilmnes viga IPv6&apos;l, lülitumine tagasi IPv4&apos;le : %s</translation>
     </message>
@@ -6379,27 +7351,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>RPC pordi %u kuulamiseks seadistamisel ilmnes viga IPv4&apos;l: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Kasutus:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Käskluste loetelu</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Käskluste abiinfo</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Hoiatus: -paytxfee on seatud väga kõrgeks! See on sinu poolt makstav tehingu lisatasu.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Hoiatus: toimus wallet.dat faili andmete päästmine! Originaal wallet.dat nimetati kaustas %s ümber wallet.{ajatempel}.bak&apos;iks, jäägi või tehingute ebakõlade puhul tuleks teha backup&apos;ist taastamine.</translation>
     </message>
@@ -6409,17 +7381,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Hoiatus: ilmnes tõrge wallet.dat faili lugemisel! Võtmed on terved, kuid tehingu andmed või aadressiraamatu kirjed võivad olla kadunud või vigased.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+137"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Pordi kuulamine nurjus. Soovikorral kasuta -listen=0.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>%s valiku kasutamine</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -6428,14 +7400,87 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Kui seda faili ei ole, loo see ainult-omanikule-lugemiseks faili õigustes.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="-224"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+79"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-paytxfee=&lt;amount&gt; jaoks vigane kogus: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+121"/>
+        <location line="+100"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Rahakott %s paikenb väljaspool kataloogi %s.</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
@@ -6534,6 +7579,16 @@ Kui seda faili ei ole, loo see ainult-omanikule-lugemiseks faili õigustes.</tra
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6568,18 +7623,18 @@ Kui seda faili ei ole, loo see ainult-omanikule-lugemiseks faili õigustes.</tra
         <translation>wallet.dat fail on katki, päästmine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Vigane -proxi aadress: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6604,12 +7659,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6629,21 +7684,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6684,11 +7725,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,7 +7744,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6748,7 +7784,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6789,11 +7825,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6834,11 +7865,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6908,7 +7934,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6920,11 +7946,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6995,16 +8016,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7163,11 +8174,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7190,16 +8196,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7303,16 +8299,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7335,11 +8321,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7384,17 +8365,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7415,6 +8386,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7638,78 +8614,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7760,16 +8666,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7828,7 +8724,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7838,42 +8734,41 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Rahakott on vaja üle kirjutada: käivita Gridcoin uuesti toimingu lõpetamiseks</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Viga wallet.dat käivitamisel</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Aadresside laadimine...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Selle arvutiga ei ole võimalik siduda %s külge (katse nurjus %d, %s tõttu)</translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Sending...</source>
-        <translation>Saatmine...</translation>
+        <translation type="vanished">Saatmine...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Kehtetu summa</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+87"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Kirjeldatud tundmatu võrgustik -onlynet&apos;is: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Liiga suur summa</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Klotside indeksi laadimine...</translation>
     </message>
@@ -7883,17 +8778,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Rahakoti laadimine...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Tõrge vaikimisi aadressi kirjutamisel</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Üleskaneerimine...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Laetud</translation>
     </message>

--- a/src/qt/locale/bitcoin_eu_ES.ts
+++ b/src/qt/locale/bitcoin_eu_ES.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Ezabatu</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopiatu &amp;Etiketa</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Editatu</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiketa</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(etiketarik ez)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Sartu zorroaren pasahitz zaharra eta berria.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Berretsi zorroaren enkriptazioa</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Zorroa enkriptatuta</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>GARRANTZITSUA: Aurreko seguritate-kopiak ordeztuko dire berriekin, enkriptatutak. Segurtasun arrazoigaitik, aurreko kopiak ezin dira erabili hasiko zarenean zure diruzorro enkriptatu berriarekin.</translation>
+        <translation type="vanished">GARRANTZITSUA: Aurreko seguritate-kopiak ordeztuko dire berriekin, enkriptatutak. Segurtasun arrazoigaitik, aurreko kopiak ezin dira erabili hasiko zarenean zure diruzorro enkriptatu berriarekin.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Zorroaren enkriptazioak huts egin du</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Zorroaren enkriptazioak huts egin du barne-errore baten ondorioz. Zure zorroa ez da enkriptatu.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Eman dituzun pasahitzak ez datoz bat.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Zorroaren desblokeoak huts egin du</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Zorroa desenkriptatzeko sartutako pasahitza okerra da.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Gainbegiratu</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Irten</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Artxiboa</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ezarpenak</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Bidalitako transakzioa</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Zorroa &lt;b&gt;enkriptatuta&lt;/b&gt; eta &lt;b&gt;blokeatuta&lt;/b&gt; dago une honetan</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Kopurua</translation>
+        <translation type="vanished">Kopurua</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiketa</translation>
+        <translation type="obsolete">Etiketa</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Helbidea</translation>
+        <translation type="vanished">Helbidea</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopiatu helbidea</translation>
     </message>
@@ -1251,17 +1406,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1446,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,19 +1496,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(etiketarik ez)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(etiketarik ez)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Kopurua</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Etiketa</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Helbidea</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1380,7 +1572,7 @@ Expires: %3
         <translation type="unfinished">Helbidea</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1634,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1669,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Kopurua</translation>
+        <translation type="obsolete">Kopurua</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiketa</translation>
+        <translation type="obsolete">Etiketa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Helbidea</translation>
+        <translation type="obsolete">Helbidea</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1720,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1730,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(etiketarik ez)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1887,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1917,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2093,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2108,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2121,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2149,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2230,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2309,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2428,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3107,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2572,7 +3122,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2800,18 +3350,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3377,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Kopurua</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3707,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3747,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3787,7 @@ Expires: %3
         <translation type="unfinished">Inprimakia</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3797,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3820,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3872,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4034,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4069,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4161,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4199,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4309,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4360,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4375,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4413,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4475,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4590,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3803,7 +4731,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4894,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4909,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4967,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5058,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5546,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5667,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5781,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5804,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5816,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5940,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +6000,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6040,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(etiketarik ez)</translation>
     </message>
@@ -5229,7 +6148,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Helbidea</translation>
     </message>
@@ -5367,42 +6286,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6332,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6383,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6391,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Zabalik %1 arte</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/konfirmatu gabe</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 konfirmazioak</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6439,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6517,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6534,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6556,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Mezua</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6590,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Kopurua</translation>
     </message>
@@ -5734,11 +6653,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5758,7 +6682,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kopurua</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6710,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Konfirmatuta (%1 konfirmazio)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6940,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transakzioaren egoera. Pasatu sagua gainetik konfirmazio kopurua ikusteko.</translation>
     </message>
@@ -6044,7 +7003,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7058,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kopuru minimoa</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopiatu helbidea</translation>
     </message>
@@ -6129,7 +7093,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7104,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6185,7 +7149,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6221,19 +7185,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Irten</translation>
+        <translation type="obsolete">Irten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Irten aplikaziotik</translation>
+        <translation type="obsolete">Irten aplikaziotik</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Artxiboa</translation>
+        <translation type="obsolete">&amp;Artxiboa</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7208,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7234,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,33 +7320,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+379"/>
+        <location filename="../bitcoinstrings.cpp" line="+409"/>
         <source>List commands</source>
         <translation>Komandoen lista</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Laguntza komando batean</translation>
     </message>
     <message>
-        <location line="-339"/>
-        <location line="+344"/>
+        <location line="-371"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6411,17 +7364,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6445,21 +7418,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6500,11 +7459,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6524,7 +7478,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6564,7 +7518,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6605,11 +7559,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6655,11 +7604,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6746,7 +7690,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6758,11 +7702,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6833,16 +7772,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7017,11 +7946,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7048,16 +7972,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7181,16 +8095,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7228,11 +8132,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7277,21 +8176,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7308,6 +8245,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7537,82 +8479,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7663,16 +8530,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7753,6 +8610,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7862,6 +8724,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7896,7 +8768,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-200"/>
+        <location line="-179"/>
         <source>Done loading</source>
         <translation>Zamaketa amaitua</translation>
     </message>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">بله</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">خیر</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;حذف</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>کپی و برچسب‌&amp;گذاری</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;ویرایش</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>برچسب</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(بدون برچسب)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>تأیید رمزنگاری کیف پول</translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>کیف پول رمزنگاری شد</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>رمزنگاری کیف پول با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>رمزنگاری کیف پول بنا به یک خطای داخلی با شکست مواجه شد. کیف پول شما رمزنگاری نشد.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>بازگشایی قفل کیف‌پول با شکست مواجه شد</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>گذرواژهٔ کیف پول با موفقیت عوض شد.</translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>کیف پول</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;بررسی اجمالی</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;خروج</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>با&amp;زبینی پیام...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>باز کردن کنسول خطایابی و اشکال‌زدایی</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;فایل</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;تنظیمات</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -796,17 +957,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>تراکنش ارسال شد</translation>
     </message>
@@ -824,17 +985,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -854,7 +1005,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -872,7 +1023,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1050,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -904,12 +1065,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>کیف پول &lt;b&gt;رمزنگاری شده&lt;/b&gt; است و هم‌اکنون &lt;b&gt;قفل&lt;/b&gt; است</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -920,18 +1081,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -941,7 +1101,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1028,7 +1193,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1077,7 +1242,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,12 +1250,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1314,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1369,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>مبلغ</translation>
+        <translation type="vanished">مبلغ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">برچسب</translation>
+        <translation type="obsolete">برچسب</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">آدرس</translation>
+        <translation type="obsolete">آدرس</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>تاریخ</translation>
+        <translation type="vanished">تاریخ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>تاییدیه ها</translation>
+        <translation type="vanished">تاییدیه ها</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>تأیید شده</translation>
+        <translation type="vanished">تأیید شده</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1245,17 +1404,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>کپی مقدار</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>کپی شناسهٔ تراکنش</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>کپی تعداد</translation>
     </message>
@@ -1285,17 +1444,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>بله</translation>
     </message>
@@ -1335,20 +1494,61 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(بدون برچسب)</translation>
     </message>
     <message>
-        <location line="-10"/>
+        <source>(change)</source>
+        <translation type="vanished">(تغییر)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(بدون برچسب)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
-        <translation>(تغییر)</translation>
+        <translation type="unfinished">(تغییر)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">مبلغ</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">برچسب</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">آدرس</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">تاریخ</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">تاییدیه ها</translation>
     </message>
 </context>
 <context>
@@ -1374,7 +1574,7 @@ Expires: %3
         <translation type="unfinished">آدرس</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,7 +1636,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1471,37 +1671,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">مبلغ</translation>
+        <translation type="obsolete">مبلغ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">برچسب</translation>
+        <translation type="obsolete">برچسب</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">آدرس</translation>
+        <translation type="obsolete">آدرس</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">تاریخ</translation>
+        <translation type="obsolete">تاریخ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">تاییدیه ها</translation>
+        <translation type="obsolete">تاییدیه ها</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">تأیید شده</translation>
+        <translation type="obsolete">تأیید شده</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1536,7 +1730,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,25 +1740,18 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(بدون برچسب)</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(تغییر)</translation>
+        <translation type="obsolete">(تغییر)</translation>
     </message>
 </context>
 <context>
@@ -1714,7 +1901,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,7 +1931,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1915,7 +2107,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,6 +2122,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1938,7 +2135,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1966,7 +2163,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2035,22 +2241,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,7 +2320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2233,6 +2439,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">بله</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">خیر</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2548,7 +3115,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>پیش‌فرض</translation>
     </message>
@@ -2563,7 +3130,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">خطا</translation>
@@ -2791,18 +3358,23 @@ Expires: %3
         <translation>تراز کل فعلی شما</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">کپی مقدار</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2813,9 +3385,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">مبلغ</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2929,7 +3711,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2969,6 +3751,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3004,7 +3791,7 @@ Expires: %3
         <translation type="unfinished">فرم</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,7 +3801,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3027,7 +3824,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3080,6 +3877,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">بله</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">خیر</translation>
     </message>
 </context>
 <context>
@@ -3164,12 +4038,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3194,12 +4073,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3286,7 +4165,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3324,7 +4203,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">ناموجود</translation>
     </message>
@@ -3428,14 +4307,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,7 +4358,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,12 +4373,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4411,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,6 +4473,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3632,7 +4573,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>ناموجود</translation>
     </message>
@@ -3773,7 +4714,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3951,7 +4892,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4907,7 @@ Expires: %3
         <translation>برای نمایش یک مرور کلی از دستورات ممکن، عبارت &lt;b&gt;help&lt;/b&gt; را بنویسید.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation>%1 بایت</translation>
     </message>
@@ -4024,12 +4965,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4121,40 +5056,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,7 +5544,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4733,7 +5665,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4847,7 +5779,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4870,7 +5802,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4882,7 +5814,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,7 +5938,7 @@ Expires: %3
         <translation>&amp;ارسال</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>کپی تعداد</translation>
     </message>
@@ -5066,7 +5998,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5106,8 +6038,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(بدون برچسب)</translation>
     </message>
@@ -5214,7 +6146,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">آدرس</translation>
     </message>
@@ -5352,42 +6284,42 @@ Expires: %3
         <translation>بازنشانی تمام فیلدهای پیام</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5398,7 +6330,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5449,39 +6381,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5503,74 +6435,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">تاریخ</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5581,13 +6513,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5598,16 +6530,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5619,31 +6551,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5653,38 +6585,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">مبلغ</translation>
     </message>
@@ -5716,11 +6648,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
     </message>
@@ -5740,7 +6677,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">مبلغ</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5767,12 +6704,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5997,7 +6934,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6025,7 +6997,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6080,7 +7052,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6110,7 +7087,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6121,7 +7098,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">تأیید شده</translation>
     </message>
@@ -6166,7 +7143,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6202,19 +7179,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;خروج</translation>
+        <translation type="obsolete">&amp;خروج</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">خروج از برنامه</translation>
+        <translation type="obsolete">خروج از برنامه</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;فایل</translation>
+        <translation type="obsolete">&amp;فایل</translation>
     </message>
 </context>
 <context>
@@ -6228,7 +7202,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6254,18 +7228,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6340,38 +7314,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>شنیدن هر گونه درگاه انجام پذیر نیست. ازlisten=0  برای اینکار استفاده کیند.</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>آدرس پراکسی اشتباه %s</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>بار گیری آدرس ها</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6415,18 +7376,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">ناموجود</translation>
+        <translation type="obsolete">ناموجود</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6447,6 +7402,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6661,42 +7621,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6750,7 +7675,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6780,18 +7705,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>شبکه مشخص شده غیرقابل شناسایی در onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>بود جه نا کافی </translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6817,17 +7742,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6851,21 +7796,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6906,11 +7837,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6927,6 +7853,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6971,6 +7907,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7011,11 +7952,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7061,11 +7997,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7153,6 +8084,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7164,11 +8100,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7239,16 +8170,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7412,11 +8333,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7439,16 +8355,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7568,16 +8474,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7612,7 +8508,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>بار گیری والت</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7622,57 +8518,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+20"/>
         <source>Unknown poll response type.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7719,6 +8565,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7828,6 +8679,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7862,17 +8723,45 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>آدرس پیش فرض قابل ذخیره نیست</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+383"/>
         <source>Rescanning...</source>
         <translation>اسکان مجدد</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>بار گیری انجام شده است</translation>
     </message>

--- a/src/qt/locale/bitcoin_fa_IR.ts
+++ b/src/qt/locale/bitcoin_fa_IR.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>حذف</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>کیف پول</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>و بازبینی</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>خروج</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>و فایل</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>و تنظیمات</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -796,17 +957,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>ارسال تراکنش</translation>
     </message>
@@ -824,17 +985,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -854,7 +1005,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -872,7 +1023,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1050,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -904,12 +1065,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>wallet رمزگذاری شد و در حال حاضر قفل است</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -920,18 +1081,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -941,7 +1101,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1028,7 +1193,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1077,7 +1242,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,12 +1250,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1314,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1369,19 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>میزان</translation>
+        <translation type="vanished">میزان</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>تاریخ</translation>
+        <translation type="vanished">تاریخ</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>تایید شده</translation>
+        <translation type="vanished">تایید شده</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1245,17 +1392,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1285,17 +1432,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1335,19 +1482,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">میزان</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">تاریخ</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1374,7 +1558,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,7 +1620,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1471,37 +1655,19 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">میزان</translation>
+        <translation type="obsolete">میزان</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">تاریخ</translation>
+        <translation type="obsolete">تاریخ</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">تایید شده</translation>
+        <translation type="obsolete">تایید شده</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1536,7 +1702,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,24 +1712,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1714,7 +1869,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,7 +1899,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1915,7 +2075,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,6 +2090,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1938,7 +2103,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1966,7 +2131,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2035,22 +2209,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,7 +2288,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2233,6 +2407,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2548,7 +3083,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>پیش فرض</translation>
     </message>
@@ -2563,7 +3098,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">خطا</translation>
@@ -2791,18 +3326,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2813,9 +3353,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">میزان</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2929,7 +3679,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2969,6 +3719,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3004,7 +3759,7 @@ Expires: %3
         <translation type="unfinished">فرم</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,7 +3769,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3027,7 +3792,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3079,6 +3844,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3164,12 +4006,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3194,12 +4041,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3286,7 +4133,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3324,7 +4171,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3428,14 +4275,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,7 +4326,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,12 +4341,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4379,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,6 +4441,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3657,7 +4566,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3783,7 +4692,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3951,7 +4860,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4875,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4024,12 +4933,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4121,40 +5024,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,7 +5512,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4733,7 +5633,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4847,7 +5747,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4870,7 +5770,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4882,7 +5782,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,7 +5906,7 @@ Expires: %3
         <translation>و ارسال</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5066,7 +5966,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5106,8 +6006,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,7 +6114,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5352,42 +6252,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5398,7 +6298,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5449,39 +6349,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5503,74 +6403,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">تاریخ</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5581,13 +6481,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5598,16 +6498,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5619,31 +6519,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5653,38 +6553,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">میزان</translation>
     </message>
@@ -5716,11 +6616,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
     </message>
@@ -5740,7 +6645,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">میزان</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5767,12 +6672,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5997,7 +6902,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6025,7 +6965,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6080,7 +7020,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6110,7 +7055,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6121,7 +7066,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">تایید شده</translation>
     </message>
@@ -6166,7 +7111,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6202,19 +7147,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">خروج</translation>
+        <translation type="obsolete">خروج</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">از &quot;درخواست نامه&quot;/ application خارج شو</translation>
+        <translation type="obsolete">از &quot;درخواست نامه&quot;/ application خارج شو</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">و فایل</translation>
+        <translation type="obsolete">و فایل</translation>
     </message>
 </context>
 <context>
@@ -6228,7 +7170,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6254,18 +7196,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6340,33 +7282,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+381"/>
+        <location filename="../bitcoinstrings.cpp" line="+411"/>
         <source>Loading addresses...</source>
         <translation>لود شدن آدرسها..</translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="-14"/>
         <source>Insufficient funds</source>
         <translation>وجوه ناکافی</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6392,17 +7326,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6426,21 +7380,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6481,11 +7421,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6502,6 +7437,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6546,6 +7491,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6586,11 +7536,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6636,11 +7581,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6728,6 +7668,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6739,11 +7684,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6814,16 +7754,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6988,11 +7918,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7019,16 +7944,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7153,16 +8068,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7197,7 +8102,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>wallet در حال لود شدن است...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7218,82 +8123,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7344,16 +8174,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7434,6 +8254,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7543,6 +8368,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7577,18 +8412,41 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>آدرس پیش فرض قابل ذخیره نیست</translation>
     </message>
     <message>
-        <location line="+78"/>
-        <source>Local version: </source>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>MB/s</source>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+328"/>
+        <source>Local version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7633,17 +8491,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7664,6 +8512,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7872,7 +8725,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>اسکنِ دوباره...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>اتمام لود شدن</translation>
     </message>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">kyllä</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ei</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Poista</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopioi &amp;nimi</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Muokkaa</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Vie osoitekirjasta tietoja</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Nimi</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ei nimeä)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Vain osakkuutta varten</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Anna vanha ja uusi tunnuslause.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Vahvista lompakon salaus</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Haluatko varmasti salata lompakkosi?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Lompakko salattu</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin-ohjelma sulkee itsensä päättääkseen salauksen luonnin. Muista, että lompakon salaaminen ei täysin turvaa kolikoitasi haittaohjelmien aiheuttamien varkauksien uhalta.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>TÄRKEÄÄ: Kaikki vanhat lompakon varmuuskopiot tulisi korvata uusilla suojatuilla varmuuskopioilla. Turvallisuussyistä edelliset varmuuskopiot muuttuvat käyttökelvottomiksi, kun aloitat uuden salatun lompakon käytön.</translation>
+        <translation type="vanished">TÄRKEÄÄ: Kaikki vanhat lompakon varmuuskopiot tulisi korvata uusilla suojatuilla varmuuskopioilla. Turvallisuussyistä edelliset varmuuskopiot muuttuvat käyttökelvottomiksi, kun aloitat uuden salatun lompakon käytön.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Lompakon salaus epäonnistui</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Lompakon salaaminen epäonnistui sisäisen virheen vuoksi. Lompakkoasi ei salattu.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Annetut tunnuslauseet eivät täsmää.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Lompakon avaaminen epäonnistui.</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Annettu tunnuslause oli väärä.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Lompakon tunnuslause vaihdettiin onnistuneesti.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Vakava virhe kohdattu. Gridcoin-ohjelma ei voi enää jatkaa turvallisesti ja sulkee itsensä.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Lompakko</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Yleisnäkymä</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>L&amp;opeta</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Varmista &amp;viesti...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>Vie...</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Avaa debuggaus- ja diagnostiikkakonsoli</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Tiedosto</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Asetukset</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin-asiakas</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +972,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Viimeinen vastaanotettu lohko generoitu %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Tämä rahansiirto ylittää siirtorajan. Voit silti lähettää sen %1 rahansiirtopalkkiota vastaan, joka siirretään rahansiirtoasi käsitteleville solmuille jotta se auttaisi ja tukisi verkkoa. Haluatko maksaa rahansiirtopalkkion?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Hyväksy rahansiirtopalkkio</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Lähetetyt rahansiirrot</translation>
     </message>
@@ -835,17 +1000,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -865,7 +1020,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -883,7 +1038,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>URI-merkkijonojen käsittely</translation>
@@ -900,7 +1065,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -915,12 +1080,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Lompakko on &lt;b&gt;salattu&lt;/b&gt; ja tällä hetkellä &lt;b&gt;lukittuna&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Varmuuskopioi lompakkosi</translation>
     </message>
@@ -931,18 +1096,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Varmuuskopion luonti epäonnistui</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Virhe tallentaessa lompakkotiedostoa uuteen sijaintiinsa.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,7 +1116,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1208,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Verkkohälytys</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Määrä</translation>
+        <translation type="vanished">Määrä</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Aika</translation>
+        <translation type="vanished">Aika</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Vahvistuksia</translation>
+        <translation type="vanished">Vahvistuksia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Vahvistettu</translation>
+        <translation type="vanished">Vahvistettu</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Nimike</translation>
+        <translation type="vanished">Nimike</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Osoite</translation>
+        <translation type="vanished">Osoite</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopioi osoite</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopioi määrä</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopioi siirtotunnus</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopioi määrä</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Kopioi vaihdos</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>pölyä</translation>
     </message>
@@ -1351,20 +1514,65 @@ Määrät alle 0.546 kertaa pienimmän rahansiirtokulun verran näytetään pöl
 Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(ei nimeä)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>vaihdos %1 (%2)</translation>
+        <translation type="vanished">vaihdos %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(vaihdos)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(ei nimeä)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">vaihdos %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(vaihdos)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Määrä</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(vaihdos)</translation>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Osoite</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Aika</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Vahvistuksia</translation>
     </message>
 </context>
 <context>
@@ -1390,7 +1598,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished">Osoite</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1660,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,37 +1695,27 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Määrä</translation>
+        <translation type="obsolete">Määrä</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Osoite</translation>
+        <translation type="obsolete">Osoite</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Aika</translation>
+        <translation type="obsolete">Aika</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Vahvistuksia</translation>
+        <translation type="obsolete">Vahvistuksia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Vahvistettu</translation>
+        <translation type="obsolete">Vahvistettu</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,7 +1750,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1562,25 +1760,22 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(ei nimeä)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">vaihdos %1 (%2)</translation>
+        <translation type="obsolete">vaihdos %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(vaihdos)</translation>
+        <translation type="obsolete">(vaihdos)</translation>
     </message>
 </context>
 <context>
@@ -1730,7 +1925,12 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1755,7 +1955,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1931,7 +2131,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1946,6 +2146,11 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1954,7 +2159,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versio</translation>
     </message>
@@ -1982,7 +2187,16 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2054,22 +2268,22 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2133,7 +2347,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2252,6 +2466,370 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">kyllä</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">ei</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Lompakon avaaminen peruttiin.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2567,7 +3145,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation>&amp;Peruuta</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>oletus</translation>
     </message>
@@ -2582,7 +3160,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
@@ -2810,18 +3388,23 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation>Tililläsi tällä hetkellä olevien Bitcoinien määrä</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopioi määrä</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2832,9 +3415,223 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Tila</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Määrä</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2948,7 +3745,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2988,6 +3785,11 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3023,7 +3825,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3033,7 +3835,17 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3046,7 +3858,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3099,6 +3911,83 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">kyllä</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ei</translation>
     </message>
 </context>
 <context>
@@ -3183,12 +4072,17 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3213,12 +4107,12 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3305,7 +4199,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3343,7 +4237,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">Ei saatavilla</translation>
     </message>
@@ -3453,14 +4347,48 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3470,7 +4398,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3485,12 +4413,35 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,7 +4451,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3562,6 +4513,11 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3657,7 +4613,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>Ei saatavilla</translation>
     </message>
@@ -3758,7 +4714,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3976,7 +4932,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3991,7 +4947,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation>Kirjoita &lt;b&gt;help&lt;/b&gt; nähdäksesi yleiskatsauksen käytettävissä olevista komennoista.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4049,12 +5005,6 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4146,40 +5096,37 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4637,7 +5584,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4758,7 +5705,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4872,7 +5819,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4895,7 +5842,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4907,7 +5854,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5031,7 +5978,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation>&amp;Lähetä</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopioi määrä</translation>
     </message>
@@ -5091,7 +6038,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation>ja</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Vastaanottajan osoite on virheellinen. Tarkista osoite.</translation>
     </message>
@@ -5131,8 +6078,8 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation>Virhe: Rahansiirto evätty. Tämä voi tapahtua kun jotkut kolikot lompakossasi ovat jo käytetty, kuten myös tilanteessa jos käytit wallet.dat-tiedoston kopiota ja rahat olivat käytetty kopiossa, mutta eivät ole merkitty käytetyiksi tässä.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(ei nimeä)</translation>
     </message>
@@ -5239,7 +6186,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Osoite</translation>
     </message>
@@ -5377,42 +6324,42 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
         <translation>Syötä Gridcoin-allekirjoitus</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Syötetty osoite on virheellinen.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Tarkista osoite ja yritä uudelleen.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Syötetyn osoitteen avainta ei löydy.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Lompakon avaaminen peruttiin.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Yksityistä avainta syötetylle osoitteelle ei ole saatavilla.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Viestin allekirjoitus epäonnistui.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Viesti allekirjoitettu.</translation>
     </message>
@@ -5423,7 +6370,7 @@ Tämä tarkoittaa, että ainakin %2 rahansiirtopalkkio tarvitaan.</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Tarkista allekirjoitus ja yritä uudelleen.</translation>
     </message>
@@ -5474,7 +6421,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5482,32 +6429,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Avoinna %1 asti</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>törmännyt</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/vahvistamaton</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 vahvistusta</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Tila</translation>
     </message>
@@ -5530,74 +6477,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Aika</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Lähde</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Lähettäjä</translation>
     </message>
@@ -5608,13 +6555,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Saaja</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>oma osoite</translation>
@@ -5625,16 +6572,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>nimi</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5647,31 +6594,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>ei hyväksytty</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Maksukulu</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Netto määrä</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Viesti</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Viesti</translation>
     </message>
@@ -5681,38 +6628,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
@@ -5744,11 +6691,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Aika</translation>
     </message>
@@ -5768,7 +6720,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Määrä</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5796,12 +6748,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Vahvistettu (%1 vahvistusta)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Törmännyt</translation>
     </message>
@@ -6026,7 +6978,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Rahansiirron tila. Siirrä osoitin kentän päälle nähdäksesi vahvistusten lukumäärä.</translation>
     </message>
@@ -6054,7 +7041,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6109,7 +7096,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minimimäärä</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopioi osoite</translation>
     </message>
@@ -6139,7 +7131,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Näytä rahansiirron yksityiskohdat</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Vie tiedot rahansiirrosta</translation>
     </message>
@@ -6150,7 +7142,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Vahvistettu</translation>
     </message>
@@ -6195,7 +7187,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ei voida kirjoittaa tiedostoon %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Alue:</translation>
     </message>
@@ -6231,19 +7223,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">L&amp;opeta</translation>
+        <translation type="obsolete">L&amp;opeta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Sulje ohjelma</translation>
+        <translation type="obsolete">Sulje ohjelma</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Tiedosto</translation>
+        <translation type="obsolete">&amp;Tiedosto</translation>
     </message>
 </context>
 <context>
@@ -6257,7 +7246,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6283,18 +7272,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6371,15 +7360,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Lähetetään...</translation>
+        <translation type="vanished">Lähetetään...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Virhe ilmennyt asetettaessa RPC-porttia %u IPv6:n kuuntelemiseksi, palataan takaisin IPv4:ään %s</translation>
     </message>
@@ -6389,27 +7377,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Virhe valmisteltaessa RPC-portin %u avaamista kuunneltavaksi: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Käyttö:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lista komennoista</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Hanki apua käskyyn</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Varoitus: -paytxfee on asetettu erittäin korkeaksi! Tämä on maksukulu jonka tulet maksamaan kun lähetät siirron.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Varoitus: wallet.dat-tiedosto on korruptoitunut, data pelastettu! Alkuperäinen wallet.dat on tallennettu nimellä wallet.{aikaleima}.bak kohteeseen %s; Jos saldosi tai rahansiirrot ovat väärät, sinun tulee palauttaa lompakko varmuuskopiosta.</translation>
     </message>
@@ -6419,7 +7407,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Varoitus: Virhe luettaessa wallet.dat-tiedostoa! Kaikki avaimet luettiin oikein, mutta rahansiirtodata tai osoitekirjan kentät voivat olla puuttuvat tai väärät.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Virhe: Rahansiirron luonti epäonnistui</translation>
     </message>
@@ -6429,17 +7417,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Virhe: Rahansiirto on evätty. Tämä voi tapahtua jos joitakin kolikoistasi lompakossasi on jo käytetty, tai jos olet käyttänyt wallet.dat-tiedoston kopiota ja rahat olivat käytetyt kopiossa, mutta ei merkitty käytetyksi tässä.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ei onnistuttu kuuntelemaan missään portissa. Käytä -listen=0 jos haluat tätä.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Käytä %s optiota</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -6448,7 +7436,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Jos tiedostoa ei ole, niin luo se ainoastaan omistajan kirjoitusoikeuksin.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Gridcoinin versio</translation>
     </message>
@@ -6463,7 +7451,7 @@ Jos tiedostoa ei ole, niin luo se ainoastaan omistajan kirjoitusoikeuksin.</tran
         <translation>Epäkelpo määrä parametrille -mininput=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+101"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Lompakko %s on datahakemiston %s ulkopuolella.</translation>
     </message>
@@ -6473,12 +7461,85 @@ Jos tiedostoa ei ole, niin luo se ainoastaan omistajan kirjoitusoikeuksin.</tran
         <translation>Tarkistetaan tietokannan eheyttä...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Virhe alustettaessa tietokantaympäristöä %s! Palauttaaksesi sen, TEE VARMUUSKOPIO HAKEMISTOSTA ja poista tämän jälkeen kaikki hakemiston tiedostot paitsi wallet.dat-tiedosto.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6569,6 +7630,16 @@ Jos tiedostoa ei ole, niin luo se ainoastaan omistajan kirjoitusoikeuksin.</tran
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6603,7 +7674,7 @@ Jos tiedostoa ei ole, niin luo se ainoastaan omistajan kirjoitusoikeuksin.</tran
         <translation>wallet.dat on korruptoitunut, pelastusyritys epäonnistui</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Virheellinen proxy-osoite &apos;%s&apos;</translation>
     </message>
@@ -6613,7 +7684,7 @@ Jos tiedostoa ei ole, niin luo se ainoastaan omistajan kirjoitusoikeuksin.</tran
         <translation>Epäkelpo -tor-osoite: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>-bind osoitteen &apos;%s&apos; selvittäminen epäonnistui</translation>
     </message>
@@ -6623,23 +7694,23 @@ Jos tiedostoa ei ole, niin luo se ainoastaan omistajan kirjoitusoikeuksin.</tran
         <translation>-externalip osoitteen &apos;%s&apos; selvittäminen epäonnistui</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Epäkelpo määrä -reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Virhe ladattaessa blkindex.dat-tiedostoa</translation>
     </message>
     <message>
-        <location line="-316"/>
-        <location line="+344"/>
+        <location line="-351"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6664,12 +7735,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6689,21 +7760,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6729,11 +7786,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6753,7 +7805,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6793,7 +7845,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6829,11 +7881,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6873,12 +7920,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6943,7 +7985,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6955,11 +7997,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7030,16 +8067,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7163,11 +8190,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7190,16 +8212,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7278,16 +8290,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7310,11 +8312,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7358,18 +8355,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">Ei saatavilla</translation>
+        <translation type="obsolete">Ei saatavilla</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7390,6 +8381,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7613,78 +8609,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7739,16 +8665,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7798,7 +8714,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7808,37 +8724,37 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Lompakko on kirjoitettava uudelleen: käynnistä Gridcoin-asiakasohjelma uudelleen päättääksesi toiminnon</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Virhe ladattaessa wallet.dat-tiedostoa</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Tuodaan esilatausohjelma lohkoketjun datatiedostolle.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Ladataan osoitteita...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Virhe: Ei voitu käynnistää noodia</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Ei voitu liittää %s tällä tietokoneella. Gridcoin-asiakasohjelma on jo ehkä päällä.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Kytkeytyminen %s tällä tietokonella ei onnistu (kytkeytyminen palautti virheen %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Virhe: Lompakko lukittu, rahansiirtoa ei voida luoda</translation>
     </message>
@@ -7853,37 +8769,36 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Virhe: Tämä rahansiirto tarvitsee rahansiirtopalkkion, kooltaan %s, kokonsa, monimutkaisuutensa tai aikaisemmin saatujen varojen käytön takia.</translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Lähetetään...</translation>
+        <translation type="vanished">Lähetetään...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Virheellinen määrä</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Varoitus: Tarkista, että tietokoneesi aika ja päivämäärä ovat oikeassa! Jos kellosi on väärässä, Gridcoin ei toimi oikein.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Varoitus: Kiintolevytila on vähissä!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Tuntematon verkko -onlynet parametrina: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Lompakon saldo ei riitä</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Ladataan lohkoindeksiä...</translation>
     </message>
@@ -7893,17 +8808,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Ladataan lompakkoa...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Oletusosoitetta ei voi kirjoittaa</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Skannataan uudelleen...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Lataus on valmis</translation>
     </message>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">oui</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">non</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Supprimer</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copier l&apos;é&amp;tiquette</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Modifier</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exporter votre répertoire d&apos;adresses</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(aucune étiquette)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Pour &quot;staking&quot; seulement</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Saisissez la nouvelle phrase de passe du porte-monnaie.&lt;br/&gt;Veuillez utiliser une phrase de passe composée de &lt;b&gt;dix caractères aléatoires ou plus&lt;/b&gt;, ou de &lt;b&gt;huit mots ou plus&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Saisir l’ancienne phrase de passe pour le portefeuille ainsi que la nouvelle.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmer le chiffrement du porte-monnaie</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Voulez-vous vraiment chiffrer votre porte-monnaie ?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Le porte-monnaie est chiffré</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>L&apos;application Gridcoin va désormais se terminer afin de finaliser le processus de chiffrage. Merci de noter que le chiffrage du portefeuille ne garantit pas de se prémunir du vol via utilisation de malware, qui auraient pu infecter votre ordinateur.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANT : toutes les sauvegardes précédentes du fichier de votre porte-monnaie devraient être remplacées par le fichier du porte-monnaie chiffré nouvellement généré. Pour des raisons de sécurité, les sauvegardes précédentes de votre fichier de porte-monnaie non chiffré deviendront inutilisables dès que vous commencerez à utiliser le nouveau porte-monnaie chiffré.</translation>
+        <translation type="vanished">IMPORTANT : toutes les sauvegardes précédentes du fichier de votre porte-monnaie devraient être remplacées par le fichier du porte-monnaie chiffré nouvellement généré. Pour des raisons de sécurité, les sauvegardes précédentes de votre fichier de porte-monnaie non chiffré deviendront inutilisables dès que vous commencerez à utiliser le nouveau porte-monnaie chiffré.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Échec de chiffrement du porte-monnaie</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Le chiffrement du porte-monnaie a échoué en raison d&apos;une erreur interne. Votre porte-monnaie n&apos;a pas été chiffré.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Les phrases de passe saisies ne correspondent pas.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Échec de déverrouillage du porte-monnaie</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La phrase de passe saisie pour déchiffrer le porte-monnaie était erronée.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>La phrase de passe du porte-monnaie a été modifiée avec succès.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Une erreur fatale a été rencontrée. L&apos;application Gridcoin ne peut plus être s&apos;exécuter de façon correcte et va se terminer.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Porte-monnaie</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vue d&apos;ensemble</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Q&amp;uitter</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Vérifier un message...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Exporter...</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ouvrir une console de débogage et de diagnostic</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Paramètres</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Client Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +972,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Le dernier block reçu à été généré %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Cette transaction dépasse la limite autorisée. Vous pouvez tout de même effectuer cette opération, moyennant %1 de frais, qui seront envoyés aux noeuds qui valideront cette transaction, et dont l&apos;objectif vise à supporter le réseau. Souhaitez-vous payer ces frais ?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Confirmer le paiement des frais de transaction</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transaction envoyée</translation>
     </message>
@@ -835,17 +1000,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -865,7 +1020,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -883,7 +1038,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Prise en charge de l&apos;URL</translation>
@@ -900,7 +1065,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -915,12 +1080,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Le porte-monnaie est &lt;b&gt;chiffré&lt;/b&gt; et actuellement &lt;b&gt;verrouillé&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Sauvegarder le portefeuille</translation>
     </message>
@@ -931,18 +1096,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Echec de la sauvegarde</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Une erreur a été rencontrée lors de la  sauvegarde du portefeuille vers la nouvelle destination.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,7 +1116,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1208,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alerte réseau</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Montant</translation>
+        <translation type="vanished">Montant</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmée</translation>
+        <translation type="vanished">Confirmée</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Étiquette</translation>
+        <translation type="vanished">Étiquette</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Adresse</translation>
+        <translation type="vanished">Adresse</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copier l’adresse</translation>
     </message>
@@ -1251,17 +1406,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copier le montant</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copier l&apos;ID de la transaction</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copier la quantité</translation>
     </message>
@@ -1291,17 +1446,17 @@ Expires: %3
         <translation>Copier la monnaie</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>oui</translation>
     </message>
@@ -1351,20 +1506,65 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
 Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(aucune étiquette)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>monnaie de %1 (%2)</translation>
+        <translation type="vanished">monnaie de %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(monnaie)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(aucune étiquette)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">monnaie de %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(monnaie)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Montant</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(monnaie)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Étiquette</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresse</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1390,7 +1590,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished">Adresse</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1652,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,37 +1687,23 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Montant</translation>
+        <translation type="obsolete">Montant</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Étiquette</translation>
+        <translation type="obsolete">Étiquette</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adresse</translation>
+        <translation type="obsolete">Adresse</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmée</translation>
+        <translation type="obsolete">Confirmée</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,7 +1738,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1562,25 +1748,22 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(aucune étiquette)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">monnaie de %1 (%2)</translation>
+        <translation type="obsolete">monnaie de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(monnaie)</translation>
+        <translation type="obsolete">(monnaie)</translation>
     </message>
 </context>
 <context>
@@ -1730,7 +1913,12 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1755,7 +1943,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1931,7 +2119,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1946,6 +2134,11 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1954,7 +2147,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1982,7 +2175,16 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2054,22 +2256,22 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2133,7 +2335,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2252,6 +2454,370 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;Tout effacer</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">oui</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">non</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Le déverrouillage du porte-monnaie a été annulé.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2567,7 +3133,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation>A&amp;nnuler</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>par défaut</translation>
     </message>
@@ -2582,7 +3148,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation>Léger</translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
@@ -2810,18 +3376,23 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copier le montant</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2832,9 +3403,223 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">État</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Montant</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2948,7 +3733,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2988,6 +3773,11 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3023,7 +3813,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished">Formulaire</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3033,7 +3823,17 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3046,7 +3846,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3099,6 +3899,83 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">oui</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">non</translation>
     </message>
 </context>
 <context>
@@ -3183,12 +4060,17 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3213,12 +4095,12 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3305,7 +4187,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3343,7 +4225,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">N.D</translation>
     </message>
@@ -3453,14 +4335,48 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3470,7 +4386,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3485,12 +4401,35 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,7 +4439,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3562,6 +4501,11 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3657,7 +4601,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>N.D</translation>
     </message>
@@ -3753,7 +4697,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3976,7 +4920,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation>Bienvenue dans la console RPC Gridcoin! </translation>
     </message>
@@ -3991,7 +4935,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation>Taper &lt;b&gt;help&lt;/b&gt; pour afficher une vue générale des commandes proposées.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation>%1 o</translation>
     </message>
@@ -4049,12 +4993,6 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4146,40 +5084,37 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4637,7 +5572,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4758,7 +5693,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4872,7 +5807,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4895,7 +5830,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4907,7 +5842,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5031,7 +5966,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation>Entrez une adresse Gridcoin (e.g. S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copier la quantité</translation>
     </message>
@@ -5091,7 +6026,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation> et </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>L&apos;adresse du destinataire n’est pas valide, veuillez la vérifier.</translation>
     </message>
@@ -5131,8 +6066,8 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation>Erreur: La transaction a été rejetée. Cela peut se produire si une quantité d&apos;argent de votre portefeuille a déjà été dépensée, comme dans le cas où une copie du fichier wallet.dat aurait été utilisée afin d&apos;effectuer des dépenses, à la place du fichier courant.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(aucune étiquette)</translation>
     </message>
@@ -5239,7 +6174,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresse</translation>
     </message>
@@ -5377,42 +6312,42 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
         <translation>Entrer une signature Gridcoin</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>L&apos;adresse saisie est invalide.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Veuillez vérifier l&apos;adresse et ressayer.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>L&apos;adresse saisie ne fait pas référence à une clé.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Le déverrouillage du porte-monnaie a été annulé.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La clé privée n&apos;est pas disponible pour l&apos;adresse saisie.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Échec de signature du message.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Le message a été signé.</translation>
     </message>
@@ -5423,7 +6358,7 @@ Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Veuillez vérifier la signature et ressayer.</translation>
     </message>
@@ -5474,7 +6409,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5482,32 +6417,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Ouvert jusqu&apos;à %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>en conflit</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/hors ligne</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/non confirmée</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>État</translation>
     </message>
@@ -5530,74 +6465,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -5608,13 +6543,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>À</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>votre adresse</translation>
@@ -5625,16 +6560,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>étiquette</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Crédit</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5647,31 +6582,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>refusé</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Débit</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Frais de transaction</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Montant net</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Commentaire</translation>
     </message>
@@ -5681,38 +6616,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Les Gridcoins générés doivent passer 110 blocks pour être matures et pouvoir être dépensés. Quand vous avez généré ce block il a été diffusé sur le réseau pour être ajouté à la block chain. S&apos;il ne rentre pas dans la chaîne, son état va passer à &quot;refusé&quot; et les Gridcoin ne seront pas utilisables. Celà peut arriver si un autre nœud génère un block à quelques secondes d&apos;intervalle du votre.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
@@ -5744,11 +6679,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation>F&amp;ermer</translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
@@ -5768,7 +6708,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5796,12 +6736,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Confirmation (%1 confirmations sur %2 recommandées)&lt;br&gt;</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmée (%1 confirmations)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>En conflit</translation>
     </message>
@@ -6026,7 +6966,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>État de la transaction. Survoler ce champ avec la souris pour afficher le nombre de confirmations.</translation>
     </message>
@@ -6054,7 +7029,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6109,7 +7084,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Montant min</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copier l’adresse</translation>
     </message>
@@ -6139,7 +7119,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Afficher les détails de la transaction</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exporter les données de la transaction</translation>
     </message>
@@ -6150,7 +7130,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmée</translation>
     </message>
@@ -6195,7 +7175,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Impossible d&apos;écrire dans le fichier %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Plage :</translation>
     </message>
@@ -6231,19 +7211,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Q&amp;uitter</translation>
+        <translation type="obsolete">Q&amp;uitter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Quitter l’application</translation>
+        <translation type="obsolete">Quitter l’application</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fichier</translation>
+        <translation type="obsolete">&amp;Fichier</translation>
     </message>
 </context>
 <context>
@@ -6257,7 +7234,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6283,18 +7260,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6371,15 +7348,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Envoi...</translation>
+        <translation type="vanished">Envoi...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Une erreur est survenue lors du réglage du port RPC %u pour écouter sur IPv6, retour à IPv4 : %s</translation>
     </message>
@@ -6389,27 +7365,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Une erreur est survenue lors du positionnement du port RPC %u pour écouter sur une adresse IPv4 : %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Utilisation:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lister les commandes</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Obtenir de l’aide pour une commande</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Attention : -paytxfee est réglée sur un montant très élevé ! Il s&apos;agit des frais de transaction que vous payerez si vous envoyez une transaction.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Avertissement : wallet.dat corrompu, données récupérées ! Le fichier wallet.dat original a été enregistré en tant que wallet.{timestamp}.bak dans %s ; si votre solde ou transactions sont incorrects vous devriez effectuer une restauration depuis une sauvegarde.</translation>
     </message>
@@ -6419,7 +7395,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Avertissement : une erreur est survenue lors de la lecture de wallet.dat ! Toutes les clefs ont été lues correctement mais les données de transaction ou les entrées du carnet d&apos;adresses sont peut-être incorrectes ou manquantes.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Erreur: La création de cette transaction a échoué  </translation>
     </message>
@@ -6429,17 +7405,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Erreur: La transaction a été rejetée. Cela peut se produire si une quantité d&apos;argent de votre portefeuille a déjà été dépensée, comme dans le cas où une copie du fichier wallet.dat aurait été utilisée afin d&apos;effectuer des dépenses, à la place du fichier courant.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Échec d&apos;écoute sur un port quelconque. Utiliser -listen=0 si vous le voulez.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Pour utiliser l&apos;option %s</translation>
     </message>
     <message>
-        <location line="-463"/>
+        <location line="-474"/>
         <source>%s, you must set a rpcpassword in the configuration file:
  %s
 It is recommended you use the following random password:
@@ -6465,12 +7441,12 @@ par exemple: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="-3"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6480,12 +7456,12 @@ par exemple: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+19"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6505,21 +7481,7 @@ par exemple: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6545,11 +7507,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6569,7 +7526,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6609,7 +7566,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6645,11 +7602,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6689,12 +7641,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6768,7 +7715,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6780,11 +7727,6 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6855,16 +7797,6 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6978,11 +7910,6 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7005,16 +7932,6 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7093,7 +8010,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Initialisation du &quot;sanity-check&quot; échoué. Arrêt de Gridcoin.</translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Le portefeuille %s est situé en dehors du répertoire de données %s.</translation>
     </message>
@@ -7103,12 +8020,85 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Vérification d&apos;intégrité de la base de données...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Erreur lors de l&apos;initialisation de l&apos;environnement de base de données %s! Afin de procéder à la récupération, une SAUVEGARDE DE CE REPERTOIRE est nécessaire, puis, supprimez le contenu entier de ce répertoire, à l&apos;exception du fichier wallet.dat.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7199,6 +8189,16 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7233,7 +8233,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>wallet.dat corrompu, la récupération a échoué</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Adresse -proxy invalide : « %s »</translation>
     </message>
@@ -7243,7 +8243,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Adresse -tor invalide: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Impossible de résoudre l&apos;adresse -bind : « %s »</translation>
     </message>
@@ -7253,12 +8253,12 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Impossible de résoudre l&apos;adresse -externalip : « %s »</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Montant incorrect pour -reservebalance=&lt;montant&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Erreur de chargement du fichier blkindex.dat</translation>
     </message>
@@ -7273,7 +8273,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Erreur de chargement du fichier wallet.dat: le portefeuille nécessite une version plus récente de l&apos;application Gridcoin</translation>
     </message>
     <message>
-        <location line="+41"/>
+        <location line="+38"/>
         <source>Invalid amount for -peertimeout=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7285,16 +8285,6 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     <message>
         <location line="+1"/>
         <source>Is Superblock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7320,11 +8310,6 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7368,18 +8353,12 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">N.D</translation>
+        <translation type="obsolete">N.D</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7400,6 +8379,11 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7623,78 +8607,8 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7749,16 +8663,6 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7808,7 +8712,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7818,37 +8722,37 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Le portefeuille nécessite d&apos;être réédité : Merci de relancer l&apos;application Gridcoin</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Erreur lors du chargement du fichier wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Import en masse du fichier de chaîne bloc.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Chargement des adresses…</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Erreur: Impossible de démarrer le noeud</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Connexion au port %s impossible. L&apos;application Gridcoin est probablement déjà en cours d&apos;exécution.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Impossible de se lier à %s sur cet ordinateur (bind a retourné l&apos;erreur %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Erreur: Portefeuille verrouillé, impossible d&apos;effectuer cette transaction  </translation>
     </message>
@@ -7863,37 +8767,36 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Erreur: Cette transaction requière des frais minimum de  %s a cause de son montant, de sa complexité ou de l&apos;utilisation de fonds récemment reçus  </translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Envoi...</translation>
+        <translation type="vanished">Envoi...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Montant invalide</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Avertissement: Veuillez vérifier la date et l&apos;heure de votre ordinateur. Gridcoin ne pourra pas fonctionner correctement si l&apos;horloge est réglée de façon incorrecte.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Avertissement: Espace disque faible!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Réseau inconnu spécifié dans -onlynet : « %s »</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Fonds insuffisants</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Chargement de l’index des blocs…</translation>
     </message>
@@ -7903,17 +8806,17 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Chargement du porte-monnaie…</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Impossible d&apos;écrire l&apos;adresse par défaut</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Nouvelle analyse…</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Chargement terminé</translation>
     </message>

--- a/src/qt/locale/bitcoin_fr_CA.ts
+++ b/src/qt/locale/bitcoin_fr_CA.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">oui</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">non</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Supprimer</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copier l&apos;&amp;Étiquette</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Modifier</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exporter votre répertoire d&apos;adresses</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(aucune étiquette)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Pour &quot;staking&quot; seulement</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Saisir l’ancienne et la nouvelle phrase de passe du portefeuille</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmer le cryptage du portefeuille</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Êtes-vous sûr de vouloir crypter votre portefeuille ?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Portefeuille crypté</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>L&apos;application Gridcoin va désormais se terminer afin de finaliser le processus de cryptage. Merci de noter que le cryptage du portefeuille ne garantit pas de se prémunir du vol via l&apos;utilisation de malware, qui auraient pu infecter votre ordinateur. </translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANT : Toute sauvegarde précédente de votre fichier de portefeuille devrait être remplacée par le nouveau fichier de portefeuille crypté. Pour des raisons de sécurité, les sauvegardes précédentes de votre fichier de portefeuille non crypté deviendront inutilisables dès lors que vous commencerez à utiliser le nouveau portefeuille crypté.</translation>
+        <translation type="vanished">IMPORTANT : Toute sauvegarde précédente de votre fichier de portefeuille devrait être remplacée par le nouveau fichier de portefeuille crypté. Pour des raisons de sécurité, les sauvegardes précédentes de votre fichier de portefeuille non crypté deviendront inutilisables dès lors que vous commencerez à utiliser le nouveau portefeuille crypté.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Le cryptage du portefeuille a échoué</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Le cryptage du portefeuille a échoué en raison d&apos;une erreur interne. Votre portefeuille n&apos;a pas été crypté.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Les mots de passe saisies ne correspondent pas.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Le déverrouillage du portefeuille a échoué</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Le mot de passe saisie pour décrypter le portefeuille était incorrecte.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Le mot de passe du portefeuille a été modifiée avec succès.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Une erreur fatale a été rencontrée. L&apos;application Gridcoin ne peut plus être s&apos;exécuter de façon correcte et doit se terminer.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Portefeuille</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vue d&apos;ensemble</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Q&amp;uitter</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Vérifier un message...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ouvrir une console de débogage et de diagnostic</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Réglages</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Client Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +972,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Le dernier block reçu à été généré %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Cette transaction dépasse la limite autorisée. Vous pouvez tout de même effectuer cette opération, moyennant %1 de frais, qui seront envoyés aux noeuds qui valideront cette transaction, et dont l&apos;objectif vise à supporter le réseau. Etes-vous d&apos;accord pour payer ces frais ?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Confirmer le Paiement des frais de transaction</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transaction envoyée</translation>
     </message>
@@ -835,17 +1000,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -865,7 +1020,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -883,7 +1038,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Prise en charge de l&apos;URL</translation>
@@ -900,7 +1065,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -915,12 +1080,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Le portefeuille est &lt;b&gt;crypté&lt;/b&gt; et actuellement &lt;b&gt;verrouillé&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Sauvegarder le portefeuille</translation>
     </message>
@@ -931,18 +1096,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Echec de la sauvegarde</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Une erreur a été rencontrée lors de la tentative de sauvegarde du portefeuille vers la nouvelle destination.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,7 +1116,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1208,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alerte réseau</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Montant</translation>
+        <translation type="vanished">Montant</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmée</translation>
+        <translation type="vanished">Confirmée</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Intitulé</translation>
+        <translation type="vanished">Intitulé</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Adresse</translation>
+        <translation type="vanished">Adresse</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copier l’adresse</translation>
     </message>
@@ -1251,17 +1406,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copier le montant</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copier l&apos;ID de la transaction</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copier la quantité</translation>
     </message>
@@ -1291,17 +1446,17 @@ Expires: %3
         <translation>Copier la monnaie</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>oui</translation>
     </message>
@@ -1351,20 +1506,65 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
  Cela implique que des frais à hauteur d&apos;au moins %2 seront nécessaires.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(aucune étiquette)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>monnaie de %1 (%2)</translation>
+        <translation type="vanished">monnaie de %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(monnaie)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">monnaie de %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(monnaie)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Montant</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(monnaie)</translation>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresse</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1390,7 +1590,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished">Adresse</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1652,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,37 +1687,19 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Montant</translation>
+        <translation type="obsolete">Montant</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adresse</translation>
+        <translation type="obsolete">Adresse</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmée</translation>
+        <translation type="obsolete">Confirmée</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,7 +1734,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1562,25 +1744,22 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">monnaie de %1 (%2)</translation>
+        <translation type="obsolete">monnaie de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(monnaie)</translation>
+        <translation type="obsolete">(monnaie)</translation>
     </message>
 </context>
 <context>
@@ -1730,7 +1909,12 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1755,7 +1939,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1931,7 +2115,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1946,6 +2130,11 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1954,7 +2143,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1982,7 +2171,16 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2054,22 +2252,22 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2133,7 +2331,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2252,6 +2450,370 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;Tout nettoyer</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">oui</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">non</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Le déverrouillage du portefeuille a été annulé.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2567,7 +3129,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation>&amp;Annuler</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>par défaut</translation>
     </message>
@@ -2582,7 +3144,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
@@ -2810,18 +3372,23 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copier le montant</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2832,9 +3399,223 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">État</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Montant</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2948,7 +3729,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2988,6 +3769,11 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3023,7 +3809,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished">Formulaire</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3033,7 +3819,17 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3046,7 +3842,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3099,6 +3895,83 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">oui</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">non</translation>
     </message>
 </context>
 <context>
@@ -3183,12 +4056,17 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3213,12 +4091,12 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3305,7 +4183,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3343,7 +4221,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">N.D.</translation>
     </message>
@@ -3453,14 +4331,48 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3470,7 +4382,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3485,12 +4397,35 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,7 +4435,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3562,6 +4497,11 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3657,7 +4597,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>N.D.</translation>
     </message>
@@ -3783,7 +4723,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3976,7 +4916,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3991,7 +4931,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation>Taper &lt;b&gt;help&lt;/b&gt; pour afficher une vue générale des commandes disponibles.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4049,12 +4989,6 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4146,40 +5080,37 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4637,7 +5568,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4758,7 +5689,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4872,7 +5803,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4895,7 +5826,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4907,7 +5838,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5031,7 +5962,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation>E&amp;nvoyer</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copier la quantité</translation>
     </message>
@@ -5091,7 +6022,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation>et</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>L&apos;adresse du destinataire n’est pas valide, veuillez la vérifier.</translation>
     </message>
@@ -5131,8 +6062,8 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation>Erreur: La transaction a été rejetée. Cela peut se produire si une quantité d&apos;argent de votre portefeuille a déjà été dépensée, comme dans le cas où une copie du fichier wallet.dat aurait été utilisée afin d&apos;effectuer des dépenses, à la place du fichier courant.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(pas d&apos;étiquette)</translation>
     </message>
@@ -5239,7 +6170,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresse</translation>
     </message>
@@ -5377,42 +6308,42 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
         <translation>Entrer une signature Gridcoin</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>L&apos;adresse saisie est invalide.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Veuillez vérifier l&apos;adresse et réessayer.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>L&apos;adresse saisie ne fait pas référence à une clef.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Le déverrouillage du portefeuille a été annulé.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La clef privée pour l&apos;adresse indiquée n&apos;est pas disponible.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>La signature du message a échoué.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Le message a été signé.</translation>
     </message>
@@ -5423,7 +6354,7 @@ Les montants inférieurs à  0.546 fois les frais minimum de relais apparaissent
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Veuillez vérifier la signature et réessayer.</translation>
     </message>
@@ -5474,7 +6405,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5482,32 +6413,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Ouvert jusqu&apos;à %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>en conflit</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/hors ligne</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/non confirmée</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>État</translation>
     </message>
@@ -5530,74 +6461,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -5608,13 +6539,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>À</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>votre propre adresse</translation>
@@ -5625,16 +6556,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>étiquette</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Crédit</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5647,31 +6578,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>refusé</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Débit</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Frais de transaction</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Montant net</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Commentaire</translation>
     </message>
@@ -5681,38 +6612,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
@@ -5744,11 +6675,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
@@ -5768,7 +6704,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5796,12 +6732,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmée (%1 confirmations)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>En conflit</translation>
     </message>
@@ -6026,7 +6962,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>État de la transaction. Laissez le pointeur de la souris sur ce champ pour voir le nombre de confirmations.</translation>
     </message>
@@ -6054,7 +7025,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6109,7 +7080,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Montant min.</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copier l’adresse</translation>
     </message>
@@ -6139,7 +7115,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Afficher les détails de la transaction</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exporter les données de la transaction</translation>
     </message>
@@ -6150,7 +7126,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmée</translation>
     </message>
@@ -6195,7 +7171,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Impossible d&apos;écrire dans le fichier %1</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Intervalle&#xa0;:</translation>
     </message>
@@ -6231,19 +7207,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Q&amp;uitter</translation>
+        <translation type="obsolete">Q&amp;uitter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Quitter l’application</translation>
+        <translation type="obsolete">Quitter l’application</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fichier</translation>
+        <translation type="obsolete">&amp;Fichier</translation>
     </message>
 </context>
 <context>
@@ -6257,7 +7230,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6283,18 +7256,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6371,15 +7344,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Envoi...</translation>
+        <translation type="vanished">Envoi...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Une erreur est survenue lors du réglage du port RPC %u pour écouter sur IPv6, retour à IPv4 : %s</translation>
     </message>
@@ -6389,27 +7361,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Une erreur est survenue lors du réglage du port RPC %u pour écouter sur IPv4 : %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Utilisation&#xa0;:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lister les commandes</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Obtenir de l’aide pour une commande</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Attention : -paytxfee est réglée sur un montant très élevé ! Il s&apos;agit des frais de transaction que vous payerez si vous envoyez une transaction.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Avertissement : wallet.dat corrompu, données récupérées ! Le fichier wallet.dat original a été enregistré en tant que wallet.{timestamp}.bak dans %s ; si votre solde ou transactions sont incorrects vous devriez effectuer une restauration depuis une sauvegarde.</translation>
     </message>
@@ -6419,7 +7391,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Avertissement : une erreur est survenue lors de la lecture de wallet.dat ! Toutes les clefs ont été lues correctement mais les données de transaction ou les entrées du carnet d&apos;adresses sont peut-être incorrectes ou manquantes.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Erreur: La création de cette transaction à échouée</translation>
     </message>
@@ -6429,17 +7401,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Erreur: La transaction a été rejetée. Cela peut se produire si une quantité d&apos;argent de votre portefeuille a déjà été dépensée, comme dans le cas où une copie du fichier wallet.dat aurait été utilisée afin d&apos;effectuer des dépenses, à la place du fichier courant.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Échec de l&apos;écoute sur un port quelconque. Utilisez -listen=0 si vous voulez ceci.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Pour utiliser l&apos;option %s</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -6448,7 +7420,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule accordés au propriétaire.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Version Gridcoin</translation>
     </message>
@@ -6463,7 +7435,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Montant invalide pour -mininput=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+101"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Le portefeuille %s réside en dehors répertoire de données %s</translation>
     </message>
@@ -6473,12 +7445,85 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Vérification d&apos;intégrité de la base de données...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Erreur lors de l&apos;initialisation de l&apos;environnement de base de données %s! Afin de procéder à la récupération, une SAUVEGARDE DE CE REPERTOIRE est nécessaire, puis, supprimez le contenu entier de ce répertoire, à l&apos;exception du fichier wallet.dat </translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6569,6 +7614,16 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6603,7 +7658,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>wallet.dat corrompu, la récupération a échoué</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Adresse -proxy invalide&#xa0;: «&#xa0;%s&#xa0;»</translation>
     </message>
@@ -6613,7 +7668,7 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Adresse -tor invalide: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Impossible de résoudre l&apos;adresse -bind&#xa0;: «&#xa0;%s&#xa0;»</translation>
     </message>
@@ -6623,23 +7678,23 @@ Si le fichier n&apos;existe pas, créez-le avec les droits de lecture seule acco
         <translation>Impossible de résoudre l&apos;adresse -externalip&#xa0;: «&#xa0;%s&#xa0;»</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Montant incorrect pour -reservebalance=&lt;montant&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Erreur de chargement du fichier blkindex.dat</translation>
     </message>
     <message>
-        <location line="-316"/>
-        <location line="+344"/>
+        <location line="-351"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6664,12 +7719,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6689,21 +7744,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6729,11 +7770,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6753,7 +7789,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6793,7 +7829,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6829,11 +7865,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6873,12 +7904,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6943,7 +7969,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6955,11 +7981,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7030,16 +8051,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7163,11 +8174,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7190,16 +8196,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7278,16 +8274,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7310,11 +8296,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7358,18 +8339,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">N.D.</translation>
+        <translation type="obsolete">N.D.</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7390,6 +8365,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7613,78 +8593,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7739,16 +8649,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7798,7 +8698,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7808,37 +8708,37 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>le portefeuille nécessite d&apos;être réédité : Merci de relancer l&apos;application Gridcoin</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Erreur lors du chargement de wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Importation du fichier blockchain</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Chargement des adresses…</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Erreur: Impossible de démarrer le noeud</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Connexion au port %s impossible. L&apos;application Gridcoin est probablement déjà en cours d&apos;exécution</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Impossible de se lier à %s sur cet ordinateur (bind a retourné l&apos;erreur %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Erreur: Portefeuille verrouillé, impossible d&apos;effectuer cette transaction</translation>
     </message>
@@ -7853,37 +8753,36 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Erreur: Cette transaction requière des frais minimum de  %s a cause de son montant, de sa complexité ou de l&apos;utilisation de fonds récemment reçus.</translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Envoi...</translation>
+        <translation type="vanished">Envoi...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Montant invalide</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Avertissement: Veuillez vérifier la date et l&apos;heure de votre ordinateur. Gridcoin ne pourra pas fonctionner correctement si l&apos;horloge est réglée de façon incorrecte</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Avertissement: Espace disque faible!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Réseau inconnu spécifié sur -onlynet&#xa0;: «&#xa0;%s&#xa0;»</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Fonds insuffisants</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Chargement de l’index des blocs…</translation>
     </message>
@@ -7893,17 +8792,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Chargement du portefeuille…</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Impossible d&apos;écrire l&apos;adresse par défaut</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Nouvelle analyse…</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Chargement terminé</translation>
     </message>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">Si</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">non</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar &amp;Etiqueta</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Modificar</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exportar datos da libreta de direccións.</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sen etiqueta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Para &quot;staking&quot; só</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Introduce o vello e novo contrasinais no moedeiro.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar encriptación de moedeiro</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Estás seguro de que desexas encriptar o teu moedeiro?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Moedeiro encriptado</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin pecharase agora para rematar o proceso de encriptación. Recorda que encriptar a túa carteira non te protexe na totalidade do roubo das tuas moedas por infeccións de malware no teu ordenador.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: Calquera copia de seguridade previa que fixeses do teu arquivo de moedeiro debería ser substituída polo recén xerado arquivo encriptado de moedeiro. Por razóns de seguridade, as copias de seguridade previas de un arquivo de moedeiro desencriptado tornaránse inútiles no momento no que comeces a emprega-lo novo, encriptado, moedeiro.</translation>
+        <translation type="vanished">IMPORTANTE: Calquera copia de seguridade previa que fixeses do teu arquivo de moedeiro debería ser substituída polo recén xerado arquivo encriptado de moedeiro. Por razóns de seguridade, as copias de seguridade previas de un arquivo de moedeiro desencriptado tornaránse inútiles no momento no que comeces a emprega-lo novo, encriptado, moedeiro.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Encriptación de moedeiro fallida</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>A encriptación do moedeiro fallou por mor dun erro interno. O teu moedeiro non foi encriptado.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Os contrasinais suministrados non coinciden.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Desbloqueo de moedeiro fallido</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>O contrasinal introducido para a desencriptación do moedeiro foi incorrecto.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Cambiouse con éxito o contrasinal do moedeiro.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Moedeiro</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista xeral</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Saír</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verificar mensaxe...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Exportar...</translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Abrir consola de depuración e diagnóstico</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Arquivo</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>Axus&amp;tes</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Cliente Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Último bloque recibido foi generado %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Confirmar cuota da transacción</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transacción enviada</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>O moedeiro está &lt;b&gt;encriptado&lt;/b&gt; e actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alerta de Rede</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Cantidade</translation>
+        <translation type="vanished">Cantidade</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmacións</translation>
+        <translation type="vanished">Confirmacións</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmado</translation>
+        <translation type="vanished">Confirmado</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Dirección</translation>
+        <translation type="vanished">Dirección</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copiar cantidade</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID de transacción</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidade</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Copiar cambio</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>Si</translation>
     </message>
@@ -1341,20 +1504,61 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(sen etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
+        <source>(change)</source>
+        <translation type="vanished">(cambio)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(sen etiqueta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
-        <translation>(cambio)</translation>
+        <translation type="unfinished">(cambio)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Cantidade</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmacións</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1584,7 @@ Expires: %3
         <translation type="unfinished">Dirección</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1646,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1681,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Cantidade</translation>
+        <translation type="obsolete">Cantidade</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiqueta</translation>
+        <translation type="obsolete">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Dirección</translation>
+        <translation type="obsolete">Dirección</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Confirmacións</translation>
+        <translation type="obsolete">Confirmacións</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="obsolete">Confirmado</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1740,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1750,18 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(sen etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(cambio)</translation>
+        <translation type="obsolete">(cambio)</translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1911,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1941,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2117,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2132,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2145,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2173,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2254,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2333,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2452,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Limpar &amp;Todo</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">Si</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">non</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Cancelouse o desbloqueo do moedeiro.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3131,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>por defecto</translation>
     </message>
@@ -2572,7 +3146,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
@@ -2800,18 +3374,23 @@ Expires: %3
         <translation>O teu balance actual total</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copiar cantidade</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3401,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Estado</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Cantidade</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3731,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3771,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3811,7 @@ Expires: %3
         <translation type="unfinished">Formulario</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3821,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3844,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,6 +3897,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">Si</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">non</translation>
     </message>
 </context>
 <context>
@@ -3173,12 +4058,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4093,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4185,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4223,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4333,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4384,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4399,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4437,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4499,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3687,7 +4639,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3768,7 +4720,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4918,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4933,7 @@ Expires: %3
         <translation>Escribe &lt;b&gt;axuda&lt;/b&gt; para unha vista xeral dos comandos dispoñibles.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4991,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5082,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5570,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5691,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5805,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5828,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5840,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5964,7 @@ Expires: %3
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidade</translation>
     </message>
@@ -5081,7 +6024,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>A dirección de recepción non é válida, por favor compróbea.</translation>
     </message>
@@ -5121,8 +6064,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(sen etiqueta)</translation>
     </message>
@@ -5229,7 +6172,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Dirección</translation>
     </message>
@@ -5367,42 +6310,42 @@ Expires: %3
         <translation>Click en &quot;Asinar Mensaxe&quot; para xerar sinatura</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>A dirección introducida é inválida.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Por favor comproba a dirección e proba de novo.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>A dirección introducida non se refire a ninguna clave.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Cancelouse o desbloqueo do moedeiro.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>A clave privada da dirección introducida non está dispoñible.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Fallou a sinatura da mensaxe.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Mensaxe asinada.</translation>
     </message>
@@ -5413,7 +6356,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Por favor revise a sinatura e probe de novo.</translation>
     </message>
@@ -5464,7 +6407,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6415,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Aberto ata %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/fóra de liña</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/sen confirmar</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmacións</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
@@ -5520,74 +6463,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Orixe</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Dende</translation>
     </message>
@@ -5598,13 +6541,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>dirección propia</translation>
@@ -5615,16 +6558,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Crédito</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6580,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>non aceptado</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Débito</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Tarifa de transacción</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Cantidade neta</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Mensaxe</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
@@ -5671,38 +6614,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Cantidade</translation>
     </message>
@@ -5734,11 +6677,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5758,7 +6706,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantidade</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6734,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmacións)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6964,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estado da transacción. Pasa por riba deste campo para amosar o número de confirmacións.</translation>
     </message>
@@ -6044,7 +7027,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7082,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantidade mínima</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
@@ -6129,7 +7117,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Amosar detalles da transacción</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7128,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
@@ -6185,7 +7173,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Non se puido escribir a arquivo %1</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Periodo:</translation>
     </message>
@@ -6221,19 +7209,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Saír</translation>
+        <translation type="obsolete">&amp;Saír</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Saír da aplicación</translation>
+        <translation type="obsolete">Saír da aplicación</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Arquivo</translation>
+        <translation type="obsolete">&amp;Arquivo</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7232,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7258,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,17 +7344,9 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ocorreu un erro mentres se establecía o porto RPC %u para escoitar sobre IPv6, voltando a IPv4: %s</translation>
     </message>
@@ -6379,27 +7356,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ocorreu un erro mentres se establecía o porto RPC %u para escoitar sobre IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Emprego:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Listar comandos</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Obter axuda para un comando</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Precaución: -paytxfee está posto moi algo! Esta é a tarifa de transacción que ti pagarás se envías unha transacción.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Precaución: wallet.dat corrupto, datos salvagardados! O wallet.dat orixinal foi gardado como wallet.{timestamp}.bak en %s; se o teu balance ou transaccións son incorrectas deberías restauralas dende unha copia de seguridade.</translation>
     </message>
@@ -6409,32 +7386,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Precaución: erro lendo wallet.dat! Tódalas claves lidas correctamente, pero os datos de transacción ou as entradas do libro de direccións podrían estar ausentes ou incorrectos.</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-191"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+149"/>
         <source>The wallet will now shutdown. Please start your wallet to begin sync from zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+168"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6485,11 +7447,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Fallou escoitar en calquera porto. Emprega -listen=0 se queres esto.</translation>
     </message>
@@ -6516,16 +7473,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6629,16 +7576,6 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -6661,11 +7598,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6710,17 +7642,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6744,7 +7666,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>No wallet available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6965,82 +7887,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7095,16 +7942,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7114,7 +7951,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Empregar a opción %s</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7123,12 +7960,85 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Se o arquivo non existe, debes crealo con permisos de so lectura para o propietario.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="-224"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+79"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidade inválida para -paytxfee=&lt;cantidade&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+28"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7180,6 +8090,11 @@ Se o arquivo non existe, debes crealo con permisos de so lectura para o propieta
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7289,6 +8204,16 @@ Se o arquivo non existe, debes crealo con permisos de so lectura para o propieta
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7323,18 +8248,18 @@ Se o arquivo non existe, debes crealo con permisos de so lectura para o propieta
         <translation>wallet.dat corrupto, fallou o gardado</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Dirección -proxy inválida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7359,12 +8284,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+19"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7379,21 +8304,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7434,11 +8345,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7458,7 +8364,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7498,7 +8404,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7534,11 +8440,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7579,11 +8480,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7653,7 +8549,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7668,7 +8564,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Authorized</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7738,7 +8634,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Non se pode resolver a dirección -bind: &apos;%s&apos;</translation>
     </message>
@@ -7848,32 +8744,32 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Erro cargando wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Cargando direccións...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Imposible enlazar con %s neste ordenador (enlace devolveu erro %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Cantidade inválida</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+87"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Rede descoñecida especificada en -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Fondos insuficientes</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Cargando índice de bloques...</translation>
     </message>
@@ -7883,17 +8779,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Cargando moedeiro...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Non se pode escribir a dirección por defecto</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Rescaneando...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Carga completa</translation>
     </message>

--- a/src/qt/locale/bitcoin_he.ts
+++ b/src/qt/locale/bitcoin_he.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>מ&amp;חיקה</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>העתק &amp;תוית</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;ערוך</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>תוית</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ללא תוית)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>ארנק</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;סקירה</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>י&amp;ציאה</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;אימות הודעה…</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>פתיחת לוח הבקרה לאבחון ולניפוי</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;קובץ</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>ה&amp;גדרות</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>העברת שליחה</translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>הארנק &lt;b&gt;מוצפן&lt;/b&gt; ו&lt;b&gt;נעול&lt;/b&gt; כרגע</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>כמות</translation>
+        <translation type="vanished">כמות</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">תוית</translation>
+        <translation type="obsolete">תוית</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">כתובת</translation>
+        <translation type="obsolete">כתובת</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>תאריך</translation>
+        <translation type="vanished">תאריך</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>אישורים</translation>
+        <translation type="vanished">אישורים</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>מאושר</translation>
+        <translation type="vanished">מאושר</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1251,17 +1410,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1450,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,20 +1500,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(ללא תוית)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(ללא תוית)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">כמות</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">תוית</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">כתובת</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">תאריך</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">אישורים</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1576,7 @@ Expires: %3
         <translation type="unfinished">כתובת</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1638,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1673,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">כמות</translation>
+        <translation type="obsolete">כמות</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">תוית</translation>
+        <translation type="obsolete">תוית</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">כתובת</translation>
+        <translation type="obsolete">כתובת</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">תאריך</translation>
+        <translation type="obsolete">תאריך</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">אישורים</translation>
+        <translation type="obsolete">אישורים</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">מאושר</translation>
+        <translation type="obsolete">מאושר</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1732,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1742,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(ללא תוית)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1899,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1929,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2105,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2120,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2133,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2161,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2242,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2321,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2440,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;ניקוי הכול</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3119,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>בררת מחדל</translation>
     </message>
@@ -2572,7 +3134,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">שגיאה</translation>
@@ -2800,18 +3362,23 @@ Expires: %3
         <translation>סך כל היתרה הנוכחית שלך</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3389,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">כמות</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3719,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3759,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3799,7 @@ Expires: %3
         <translation type="unfinished">טופס</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3809,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3832,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3884,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4046,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4081,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4173,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4211,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">לא זמין</translation>
     </message>
@@ -3443,14 +4321,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4372,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4387,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4425,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4487,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3647,7 +4587,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>לא זמין</translation>
     </message>
@@ -3778,7 +4718,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4906,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4921,7 @@ Expires: %3
         <translation>ניתן להקליד &lt;b&gt;help&lt;/b&gt; לקבלת סקירה של הפקודות הזמינות.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation>%1 ב׳</translation>
     </message>
@@ -4039,12 +4979,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5070,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5558,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5679,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5793,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5816,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5828,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5952,7 @@ Expires: %3
         <translation>&amp;שליחה</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +6012,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6052,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(ללא תוית)</translation>
     </message>
@@ -5229,7 +6160,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">כתובת</translation>
     </message>
@@ -5367,42 +6298,42 @@ Expires: %3
         <translation>איפוס כל שדות אימות ההודעה</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6344,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6395,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6403,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6451,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">תאריך</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6529,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6546,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6568,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6602,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">כמות</translation>
     </message>
@@ -5734,11 +6665,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">תאריך</translation>
     </message>
@@ -5758,7 +6694,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">כמות</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6722,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6952,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +7015,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7070,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6129,7 +7105,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7116,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">מאושר</translation>
     </message>
@@ -6185,7 +7161,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6221,19 +7197,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">י&amp;ציאה</translation>
+        <translation type="obsolete">י&amp;ציאה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">יציאה מהתכנית</translation>
+        <translation type="obsolete">יציאה מהתכנית</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;קובץ</translation>
+        <translation type="obsolete">&amp;קובץ</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7220,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7246,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,38 +7332,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>האזנה נכשלה בכל פורט. השתמש ב- -listen=0 אם ברצונך בכך.</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>כתובת ‎-proxy לא תקינה: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>הכתובות בטעינה…</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6434,18 +7394,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">לא זמין</translation>
+        <translation type="obsolete">לא זמין</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6466,6 +7420,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6680,42 +7639,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6769,7 +7693,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6799,18 +7723,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>רשת לא ידועה צוינה דרך ‎-onlynet:‏ &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>אין מספיק כספים</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6836,17 +7760,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6870,21 +7814,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6925,11 +7855,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6946,6 +7871,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6990,6 +7925,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7030,11 +7970,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7080,11 +8015,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7172,6 +8102,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7183,11 +8118,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7258,16 +8188,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7431,11 +8351,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7458,16 +8373,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7587,16 +8492,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7631,7 +8526,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>הארנק בטעינה…</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7641,57 +8536,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+20"/>
         <source>Unknown poll response type.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7738,6 +8583,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7847,6 +8697,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7881,17 +8741,45 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>לא ניתן לכתוב את כתובת בררת המחדל</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+383"/>
         <source>Rescanning...</source>
         <translation>סריקה מחדש…</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>טעינה הושלמה</translation>
     </message>

--- a/src/qt/locale/bitcoin_hi_IN.ts
+++ b/src/qt/locale/bitcoin_hi_IN.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;मिटाए !!</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>वॉलेट</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;विवरण</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>बाहर जायें</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;फाइल</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;सेट्टिंग्स</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>भेजी ट्रांजक्शन</translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>वॉलेट एन्क्रिप्टेड है तथा अभी लॉक्ड है</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,19 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>राशि</translation>
+        <translation type="vanished">राशि</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>taareek</translation>
+        <translation type="vanished">taareek</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>पक्का</translation>
+        <translation type="vanished">पक्का</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1251,17 +1398,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1438,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,19 +1488,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">राशि</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">taareek</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1380,7 +1564,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1626,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1661,19 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">राशि</translation>
+        <translation type="obsolete">राशि</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">taareek</translation>
+        <translation type="obsolete">taareek</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">पक्का</translation>
+        <translation type="obsolete">पक्का</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1708,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,24 +1718,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1720,7 +1875,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1746,7 +1906,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1922,7 +2082,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1937,6 +2097,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1945,7 +2110,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1973,7 +2138,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2045,22 +2219,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2124,7 +2298,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2244,6 +2418,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2559,7 +3097,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2574,7 +3112,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">भूल</translation>
@@ -2802,18 +3340,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2824,9 +3367,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">राशि</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2940,7 +3697,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2980,6 +3737,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3015,7 +3777,7 @@ Expires: %3
         <translation type="unfinished">फार्म</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3025,7 +3787,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3038,7 +3810,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3090,6 +3862,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3175,12 +4024,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3205,12 +4059,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3297,7 +4151,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3335,7 +4189,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">लागू नही
 </translation>
@@ -3446,14 +4300,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3463,7 +4351,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3478,12 +4366,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3493,7 +4404,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3555,6 +4466,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3660,7 +4576,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>लागू नही
 </translation>
@@ -3802,7 +4718,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3970,7 +4886,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3985,7 +4901,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4043,12 +4959,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4140,40 +5050,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4631,7 +5538,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4752,7 +5659,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4866,7 +5773,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4889,7 +5796,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4901,7 +5808,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5025,7 +5932,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5085,7 +5992,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5125,8 +6032,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5233,7 +6140,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5371,42 +6278,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5417,7 +6324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5468,7 +6375,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5476,32 +6383,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5524,74 +6431,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">taareek</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5602,13 +6509,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5619,16 +6526,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5641,31 +6548,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5675,38 +6582,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">राशि</translation>
     </message>
@@ -5738,11 +6645,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">taareek</translation>
     </message>
@@ -5762,7 +6674,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">राशि</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5790,12 +6702,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6020,7 +6932,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,7 +6995,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6103,7 +7050,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6133,7 +7085,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6144,7 +7096,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">पक्का</translation>
     </message>
@@ -6189,7 +7141,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6225,19 +7177,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">बाहर जायें</translation>
+        <translation type="obsolete">बाहर जायें</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">अप्लिकेशन से बाहर निकलना !</translation>
+        <translation type="obsolete">अप्लिकेशन से बाहर निकलना !</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;फाइल</translation>
+        <translation type="obsolete">&amp;फाइल</translation>
     </message>
 </context>
 <context>
@@ -6251,7 +7200,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6277,18 +7226,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6363,17 +7312,9 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+381"/>
+        <location filename="../bitcoinstrings.cpp" line="+411"/>
         <source>Loading addresses...</source>
         <translation>पता पुस्तक आ रही है...</translation>
     </message>
@@ -6405,11 +7346,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6453,9 +7389,8 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">लागू नही
+        <translation type="obsolete">लागू नही
 </translation>
     </message>
     <message>
@@ -6464,12 +7399,55 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6486,6 +7464,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6694,18 +7677,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>रि-स्केनी-इंग...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>लोड हो गया|</translation>
     </message>
     <message>
-        <location line="-308"/>
-        <location line="+344"/>
+        <location line="-343"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6731,17 +7714,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6765,21 +7768,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6820,11 +7809,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6844,7 +7828,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6884,7 +7868,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6925,11 +7909,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6975,11 +7954,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7066,7 +8040,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7078,11 +8052,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7153,16 +8122,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7337,11 +8296,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7368,16 +8322,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7507,16 +8451,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7526,7 +8460,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+63"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7547,82 +8481,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7673,16 +8532,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7763,6 +8612,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7868,6 +8722,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>poll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_hr.ts
+++ b/src/qt/locale/bitcoin_hr.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Iz&amp;briši</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopirati &amp;oznaku</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Izmjeniti</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(bez oznake)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Unesite staru i novu lozinku za nov?anik.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Potvrdi šifriranje nov?anika</translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Nov?anik šifriran</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Šifriranje nov?anika nije uspjelo</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Šifriranje nov?anika nije uspjelo zbog interne pogreške. Vaš nov?anik nije šifriran.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Priložene lozinke se ne podudaraju.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Otklju?avanje nov?anika nije uspjelo</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Lozinka za dešifriranje nov?anika nije to?na.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Lozinka nov?anika je uspješno promijenjena.</translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Novčanik</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Pregled</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Izlaz</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Potvrdite poruku...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Otvori konzolu za dijagnostiku</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Datoteka</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Postavke</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,17 +969,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Poslana transakcija</translation>
     </message>
@@ -836,17 +997,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -866,7 +1017,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -884,7 +1035,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -901,7 +1062,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +1077,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Novčanik je &lt;b&gt;šifriran&lt;/b&gt; i trenutno &lt;b&gt;zaključan&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -932,18 +1093,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +1113,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1040,7 +1205,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1089,7 +1254,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,12 +1262,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,7 +1326,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1216,37 +1381,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Iznos</translation>
+        <translation type="vanished">Iznos</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Oznaka</translation>
+        <translation type="obsolete">Oznaka</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Datum</translation>
+        <translation type="vanished">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Broj potvrda</translation>
+        <translation type="vanished">Broj potvrda</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Potvrđeno</translation>
+        <translation type="vanished">Potvrđeno</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Adresa</translation>
+        <translation type="vanished">Adresa</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopirati adresu</translation>
     </message>
@@ -1257,17 +1416,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopiraj iznos</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1297,17 +1456,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1347,20 +1506,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(bez oznake)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(bez oznake)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Iznos</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Oznaka</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresa</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Broj potvrda</translation>
     </message>
 </context>
 <context>
@@ -1386,7 +1582,7 @@ Expires: %3
         <translation type="unfinished">Adresa</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1448,7 +1644,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,37 +1679,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Iznos</translation>
+        <translation type="obsolete">Iznos</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Oznaka</translation>
+        <translation type="obsolete">Oznaka</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adresa</translation>
+        <translation type="obsolete">Adresa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Datum</translation>
+        <translation type="obsolete">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Broj potvrda</translation>
+        <translation type="obsolete">Broj potvrda</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1548,7 +1734,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,25 +1744,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(bez oznake)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1726,7 +1901,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1751,7 +1931,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1927,7 +2107,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,6 +2122,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1950,7 +2135,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1978,7 +2163,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2053,22 +2247,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2132,7 +2326,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2251,6 +2445,373 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Obriši &amp;sve</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Otklju?avanje nov?anika je otkazano.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2566,7 +3127,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>standardne vrijednosti</translation>
     </message>
@@ -2581,7 +3142,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Greška</translation>
@@ -2809,18 +3370,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopiraj iznos</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2831,9 +3397,227 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Iznos</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2947,7 +3731,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2987,6 +3771,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3022,7 +3811,7 @@ Expires: %3
         <translation type="unfinished">Oblik</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3032,7 +3821,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,7 +3844,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3097,6 +3896,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3182,12 +4058,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3212,12 +4093,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3304,7 +4185,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3342,7 +4223,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3458,14 +4339,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4390,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,12 +4405,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,7 +4443,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3567,6 +4505,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3697,7 +4640,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3798,7 +4741,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4924,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3996,7 +4939,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4054,12 +4997,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4151,40 +5088,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4642,7 +5576,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4763,7 +5697,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4877,7 +5811,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4900,7 +5834,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4912,7 +5846,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5036,7 +5970,7 @@ Expires: %3
         <translation>&amp;Pošalji</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5096,7 +6030,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresa primatelja je nevaljala, molimo provjerite je ponovo.</translation>
     </message>
@@ -5136,8 +6070,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(bez oznake)</translation>
     </message>
@@ -5244,7 +6178,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresa</translation>
     </message>
@@ -5382,42 +6316,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Otklju?avanje nov?anika je otkazano.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Poruka je potpisana.</translation>
     </message>
@@ -5428,7 +6362,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5479,7 +6413,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5488,32 +6422,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Otvoren do %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1 nije dostupan</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepotvr?eno</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potvrda</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5537,74 +6471,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Izvor</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
@@ -5615,13 +6549,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Za</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>vlastita adresa</translation>
@@ -5632,16 +6566,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>oznaka</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Upla?eno</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5655,31 +6589,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Nije prihva?eno</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Zaduženje</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Naknada za transakciju</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Neto iznos</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Poruka</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Komentar</translation>
     </message>
@@ -5689,38 +6623,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Iznos</translation>
     </message>
@@ -5752,11 +6686,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -5776,7 +6715,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Iznos</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5805,12 +6744,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Potvr?en (%1 potvrda)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6035,7 +6974,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status transakcije</translation>
     </message>
@@ -6063,7 +7037,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,7 +7092,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Min iznos</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopirati adresu</translation>
     </message>
@@ -6148,7 +7127,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6159,7 +7138,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Potvr?eno</translation>
     </message>
@@ -6204,7 +7183,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Raspon:</translation>
     </message>
@@ -6240,19 +7219,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Izlaz</translation>
+        <translation type="obsolete">&amp;Izlaz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Izlazak iz programa</translation>
+        <translation type="obsolete">Izlazak iz programa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Datoteka</translation>
+        <translation type="obsolete">&amp;Datoteka</translation>
     </message>
 </context>
 <context>
@@ -6266,7 +7242,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6292,18 +7268,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6378,37 +7354,29 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+488"/>
+        <location filename="../bitcoinstrings.cpp" line="+499"/>
         <source>Usage:</source>
         <translation>Upotreba:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Prikaži komande</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Potraži pomo? za komandu</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Upozorenje: -paytxfee je podešen na preveliki iznos.  To je iznos koji ?ete platiti za obradu transakcije.</translation>
     </message>
     <message>
-        <location line="+187"/>
+        <location line="+179"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nevaljali iznos za opciju -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
@@ -6418,7 +7386,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Nevaljala -proxy adresa: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-38"/>
+        <location line="-35"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Greška kod u?itavanja wallet.dat: Nov?anik pokvaren</translation>
     </message>
@@ -6428,18 +7396,41 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Greška kod u?itavanja wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="-304"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+322"/>
         <source>Loading addresses...</source>
         <translation>Učitavanje adresa...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6484,17 +7475,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6515,6 +7496,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6729,42 +7715,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6818,7 +7769,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6833,18 +7784,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Program ne može koristiti %s na ovom ra?unalu (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Nevaljali iznos za opciju</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+344"/>
+        <location line="-394"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6870,17 +7821,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6904,21 +7875,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6959,11 +7916,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6980,6 +7932,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7024,6 +7986,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7064,11 +8031,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7109,11 +8071,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7201,6 +8158,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7212,11 +8174,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7287,16 +8244,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7451,11 +8398,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7482,16 +8424,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7600,16 +8532,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7640,7 +8562,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Učitavanje novčanika...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7650,57 +8572,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
+        <location line="+17"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7757,6 +8629,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7866,6 +8743,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7900,17 +8787,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>Nije moguće upisati zadanu adresu.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Ponovno pretraživanje...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Učitavanje gotovo</translation>
     </message>

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -14,7 +14,7 @@
         <translation>&lt;b&gt;Gridcoin &lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Törlés</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Címke &amp;Másolása</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Sz&amp;erkesztés</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Címjegyzék Exportálása</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Címke</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(nincs címke)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Csak kamatoztatásra</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Írd be a tárca régi és új jelszavát.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Biztosan kódolni akarod a tárcát?</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Biztosan kódolni akarod a tárcát?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Tárca kódolva</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>FONTOS: A pénztárca-fájl korábbi mentéseit ezzel az új, titkosított pénztárca-fájllal kell helyettesíteni. Biztonsági okokból a pénztárca-fájl korábbi titkosítás nélküli mentései haszontalanná válnak amint elkezdi használni az új, titkosított pénztárcát.</translation>
+        <translation type="vanished">FONTOS: A pénztárca-fájl korábbi mentéseit ezzel az új, titkosított pénztárca-fájllal kell helyettesíteni. Biztonsági okokból a pénztárca-fájl korábbi titkosítás nélküli mentései haszontalanná válnak amint elkezdi használni az új, titkosított pénztárcát.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Tárca kódolása sikertelen.</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Tárca kódolása belső hiba miatt sikertelen. A tárcád nem lett kódolva.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>A megadott jelszavak nem egyeznek.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Tárca megnyitása sikertelen</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Hibás jelszó.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Jelszó megváltoztatva.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Tárca</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Áttekintés</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Kilépés</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Üzenet &amp;valódiságának ellenőrzése</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Hibakereső és diagnosztikai konzol megnyitása</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fájl</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Beállítások</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[teszthálózat]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin kliens</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -796,17 +961,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Tranzakció elküldve.</translation>
     </message>
@@ -824,17 +989,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -854,7 +1009,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -872,7 +1027,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1054,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -904,12 +1069,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Tárca &lt;b&gt;kódolva&lt;/b&gt; és jelenleg &lt;b&gt;zárva&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -920,18 +1085,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -941,7 +1105,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1028,7 +1197,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1077,7 +1246,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,12 +1254,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Hálózati figyelmeztetés</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1318,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1373,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Összeg</translation>
+        <translation type="vanished">Összeg</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Címke</translation>
+        <translation type="obsolete">Címke</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Dátum</translation>
+        <translation type="vanished">Dátum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Megerősítések</translation>
+        <translation type="vanished">Megerősítések</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Megerősítve</translation>
+        <translation type="vanished">Megerősítve</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Cím</translation>
+        <translation type="vanished">Cím</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Cím másolása</translation>
     </message>
@@ -1245,17 +1408,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Összeg másolása</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Tranzakcióazonosító másolása</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1285,17 +1448,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1335,20 +1498,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(nincs címke)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(nincs címke)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Összeg</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Címke</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Cím</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Dátum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Megerősítések</translation>
     </message>
 </context>
 <context>
@@ -1374,7 +1574,7 @@ Expires: %3
         <translation type="unfinished">Cím</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,7 +1636,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1471,37 +1671,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Összeg</translation>
+        <translation type="obsolete">Összeg</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Címke</translation>
+        <translation type="obsolete">Címke</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Cím</translation>
+        <translation type="obsolete">Cím</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Dátum</translation>
+        <translation type="obsolete">Dátum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Megerősítések</translation>
+        <translation type="obsolete">Megerősítések</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Megerősítve</translation>
+        <translation type="obsolete">Megerősítve</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1536,7 +1730,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,25 +1740,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(nincs címke)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1714,7 +1897,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,7 +1927,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1915,7 +2103,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,6 +2118,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1938,7 +2131,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1966,7 +2159,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2035,22 +2237,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,7 +2316,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2233,6 +2435,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Mindent &amp;töröl</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2548,7 +3111,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>alapértelmezett</translation>
     </message>
@@ -2563,7 +3126,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Hiba</translation>
@@ -2791,18 +3354,23 @@ Expires: %3
         <translation>Aktuális egyenleged</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Összeg másolása</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2813,9 +3381,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Állapot</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Összeg</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2929,7 +3707,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2969,6 +3747,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3004,7 +3787,7 @@ Expires: %3
         <translation type="unfinished">Űrlap</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,7 +3797,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3027,7 +3820,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3079,6 +3872,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3164,12 +4034,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3194,12 +4069,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3286,7 +4161,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3324,7 +4199,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">Nem elérhető</translation>
     </message>
@@ -3428,14 +4303,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,7 +4354,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,12 +4369,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4407,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,6 +4469,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3632,7 +4569,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>Nem elérhető</translation>
     </message>
@@ -3753,7 +4690,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3951,7 +4888,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4903,7 @@ Expires: %3
         <translation>Írd be azt, hogy &lt;b&gt;help&lt;/b&gt; az elérhető parancsok áttekintéséhez.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4024,12 +4961,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4121,40 +5052,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,7 +5540,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4733,7 +5661,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4847,7 +5775,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4870,7 +5798,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4882,7 +5810,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,7 +5934,7 @@ Expires: %3
         <translation>&amp;Küldés</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5066,7 +5994,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>A címzett címe érvénytelen, kérlek, ellenőrizd.</translation>
     </message>
@@ -5106,8 +6034,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(nincs címke)</translation>
     </message>
@@ -5215,7 +6143,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Cím</translation>
     </message>
@@ -5353,42 +6281,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>A megadott cím nem érvényes.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Ellenőrizze a címet és próbálja meg újra.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Üzenet aláírása nem sikerült.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Üzenet aláírva.</translation>
     </message>
@@ -5399,7 +6327,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Ellenőrizd az aláírást és próbáld újra.</translation>
     </message>
@@ -5450,39 +6378,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Megnyitva %1-ig</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/megerősítetlen</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 megerősítés</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Állapot</translation>
     </message>
@@ -5504,74 +6432,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Űrlap</translation>
     </message>
@@ -5582,13 +6510,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Címzett</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>saját cím</translation>
@@ -5599,16 +6527,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>címke</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Jóváírás</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5620,31 +6548,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>elutasítva</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Terhelés</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Tranzakciós díj</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Nettó összeg</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Üzenet</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Megjegyzés</translation>
     </message>
@@ -5654,38 +6582,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Összeg</translation>
     </message>
@@ -5717,11 +6645,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
@@ -5741,7 +6674,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Összeg</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5768,12 +6701,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Megerősítve (%1 megerősítés)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5998,7 +6931,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Tranzakció állapota. Húzd ide a kurzort, hogy lásd a megerősítések számát.</translation>
     </message>
@@ -6026,7 +6994,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6081,7 +7049,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minimális összeg</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Cím másolása</translation>
     </message>
@@ -6111,7 +7084,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Tranzakciós részletek megjelenítése</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6122,7 +7095,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Megerősítve</translation>
     </message>
@@ -6167,7 +7140,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Nem lehetett írni a fájlt a következő helyen: %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Tartomány:</translation>
     </message>
@@ -6203,19 +7176,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Kilépés</translation>
+        <translation type="obsolete">&amp;Kilépés</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Kilépés az alkalmazásból</translation>
+        <translation type="obsolete">Kilépés az alkalmazásból</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fájl</translation>
+        <translation type="obsolete">&amp;Fájl</translation>
     </message>
 </context>
 <context>
@@ -6229,7 +7199,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6255,18 +7225,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6341,45 +7311,37 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+488"/>
+        <location filename="../bitcoinstrings.cpp" line="+499"/>
         <source>Usage:</source>
         <translation>Használat:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Parancsok kilistázása
 </translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Segítség egy parancsról
 </translation>
     </message>
     <message>
-        <location line="-39"/>
+        <location line="-36"/>
         <source>Client Version</source>
         <translation>Kliens verzió</translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+344"/>
+        <location line="-335"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6405,17 +7367,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6439,21 +7421,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6494,11 +7462,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6515,6 +7478,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6559,6 +7532,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6599,11 +7577,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6649,11 +7622,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6734,6 +7702,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6745,11 +7718,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6820,16 +7788,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6969,11 +7927,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Egyik hálózati porton sem sikerül hallgatni. Használja a -listen=0 kapcsolót, ha ezt szeretné.</translation>
     </message>
@@ -7000,16 +7953,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7113,16 +8056,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7145,11 +8078,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7193,18 +8121,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">Nem elérhető</translation>
+        <translation type="obsolete">Nem elérhető</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7225,6 +8147,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7449,82 +8376,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7575,16 +8427,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7640,6 +8482,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7749,6 +8596,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7783,7 +8640,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-305"/>
+        <location line="-282"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7792,7 +8649,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Ha a fájl nem létezik, hozd létre &apos;csak a felhasználó által olvasható&apos; fájl engedéllyel</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="+151"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Étvénytelen -paytxfee=&lt;összeg&gt; összeg: &apos;%s&apos;</translation>
     </message>
@@ -7802,7 +8659,35 @@ Ha a fájl nem létezik, hozd létre &apos;csak a felhasználó által olvashat�
         <translation>Érvénytelen -proxy cím: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-340"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+253"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Csatlakozási cím (-bind address) feloldása nem sikerült: &apos;%s&apos;</translation>
     </message>
@@ -7822,22 +8707,22 @@ Ha a fájl nem létezik, hozd létre &apos;csak a felhasználó által olvashat�
         <translation>Hiba az wallet.dat betöltése közben</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Címek betöltése...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>A %s nem elérhető ezen a gépen (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Étvénytelen összeg</translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+85"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7852,12 +8737,12 @@ Ha a fájl nem létezik, hozd létre &apos;csak a felhasználó által olvashat�
         <translation>Ismeretlen hálózat lett megadva -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Nincs elég bitcoinod.</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Blokkindex betöltése...</translation>
     </message>
@@ -7867,17 +8752,17 @@ Ha a fájl nem létezik, hozd létre &apos;csak a felhasználó által olvashat�
         <translation>Tárca betöltése...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Nem sikerült az alapértelmezett címet írni.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Újraszkennelés...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Betöltés befejezve.</translation>
     </message>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ya</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">tidak</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Hapus</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Salin &amp;Label</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Ubah</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Hanya untuk staking</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Masukkan kata kunci lama dan baru ke dompet ini.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Menkonfirmasi enkripsi dompet</translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Dompet terenkripsi</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin akan ditutup untuk menyelesaikan proses enkripsi. Ingat bahwa dompet Anda tidak bisa di lindungi dengan enkripsi sepenuhny dari pencurian melalui infeksi malware di komputer Anda.</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Enkripsi dompet gagal</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Enkripsi dompet gagal karena kesalahan internal. Dompet Anda tidak dienkripsi.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Kata kunci yang dimasukkan tidak cocok.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Gagal buka dompet</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Kata kunci yang dimasukkan untuk dekripsi dompet tidak cocok.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Passphrase dompet telah berhasil diubah.</translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Gridcoin</source>
         <translation>Gridcoin (CoinHitam)</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Dompet</translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Kilasan</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>K&amp;eluar</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifikasi pesan...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Ekspor...</translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Buka konsol debug dan diagnosa</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Berkas</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Pengaturan</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Klien Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -796,17 +957,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transaksi terkirim</translation>
     </message>
@@ -824,17 +985,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -854,7 +1005,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -872,7 +1023,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1050,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -904,12 +1065,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Dompet saat ini &lt;b&gt;terenkripsi&lt;/b&gt; dan &lt;b&gt;terkunci&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -920,18 +1081,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Back-up Gagal</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -941,7 +1101,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1028,7 +1193,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1077,7 +1242,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,12 +1250,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Notifikasi Jaringan</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1314,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1369,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Jumlah</translation>
+        <translation type="vanished">Jumlah</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Tanggal</translation>
+        <translation type="vanished">Tanggal</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Konfirmasi</translation>
+        <translation type="vanished">Konfirmasi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Terkonfirmasi</translation>
+        <translation type="vanished">Terkonfirmasi</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Alamat</translation>
+        <translation type="vanished">Alamat</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Salin alamat</translation>
     </message>
@@ -1245,17 +1400,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Salin jumlah</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Salikan jumlah</translation>
     </message>
@@ -1285,17 +1440,17 @@ Expires: %3
         <translation>Salinkan perubahan</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>ya</translation>
     </message>
@@ -1335,20 +1490,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>perubahan dari %1 (%2)</translation>
+        <translation type="vanished">perubahan dari %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(perubahan)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(tidak ada label)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">perubahan dari %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(perubahan)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Jumlah</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(perubahan)</translation>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Alamat</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Tanggal</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Konfirmasi</translation>
     </message>
 </context>
 <context>
@@ -1374,7 +1574,7 @@ Expires: %3
         <translation type="unfinished">Alamat</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,7 +1636,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1471,37 +1671,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Jumlah</translation>
+        <translation type="obsolete">Jumlah</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Alamat</translation>
+        <translation type="obsolete">Alamat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Tanggal</translation>
+        <translation type="obsolete">Tanggal</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Konfirmasi</translation>
+        <translation type="obsolete">Konfirmasi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Terkonfirmasi</translation>
+        <translation type="obsolete">Terkonfirmasi</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1536,7 +1726,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,25 +1736,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(tidak ada label)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">perubahan dari %1 (%2)</translation>
+        <translation type="obsolete">perubahan dari %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(perubahan)</translation>
+        <translation type="obsolete">(perubahan)</translation>
     </message>
 </context>
 <context>
@@ -1714,7 +1901,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,7 +1931,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1915,7 +2107,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,6 +2122,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1938,7 +2135,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versi</translation>
     </message>
@@ -1966,7 +2163,16 @@ Expires: %3
         <translation type="unfinished">Gridcoin (CoinHitam)</translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2035,22 +2241,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,7 +2320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2233,6 +2439,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Hapus &amp;Semua</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">ya</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">tidak</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2548,7 +3115,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>standar</translation>
     </message>
@@ -2563,7 +3130,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Gagal</translation>
@@ -2791,18 +3358,23 @@ Expires: %3
         <translation>Jumlah saldo Anda sekarang</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Salin jumlah</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2813,9 +3385,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Jumlah</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2929,7 +3711,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2969,6 +3751,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3004,7 +3791,7 @@ Expires: %3
         <translation type="unfinished">Formulir</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,7 +3801,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3027,7 +3824,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3080,6 +3877,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ya</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">tidak</translation>
     </message>
 </context>
 <context>
@@ -3164,12 +4038,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3194,12 +4073,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3286,7 +4165,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3324,7 +4203,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">T/S</translation>
     </message>
@@ -3428,14 +4307,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,7 +4358,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,12 +4373,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4411,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,6 +4473,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3632,7 +4573,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>T/S</translation>
     </message>
@@ -3748,7 +4689,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3951,7 +4892,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4907,7 @@ Expires: %3
         <translation>Ketik &lt;b&gt;help&lt;/b&gt; untuk menampilkan perintah tersedia.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4024,12 +4965,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4121,40 +5056,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,7 +5544,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4733,7 +5665,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4847,7 +5779,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4870,7 +5802,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4882,7 +5814,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,7 +5938,7 @@ Expires: %3
         <translation>K&amp;irim</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished">Salikan jumlah</translation>
     </message>
@@ -5066,7 +5998,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5106,8 +6038,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
     </message>
@@ -5214,7 +6146,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Alamat</translation>
     </message>
@@ -5352,42 +6284,42 @@ Expires: %3
         <translation>Hapus semua bidang verifikasi pesan</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Alamat yang dimasukkan tidak sesuai.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Silahkan periksa alamat dan coba lagi.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5398,7 +6330,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5449,39 +6381,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Buka hingga %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/tidak terkonfirmasi</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 konfirmasi</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5503,74 +6435,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Tanggal</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Dari</translation>
     </message>
@@ -5581,13 +6513,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Untuk</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5598,16 +6530,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5619,31 +6551,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Pesan:</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5653,38 +6585,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Jumlah</translation>
     </message>
@@ -5716,11 +6648,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
@@ -5740,7 +6677,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Jumlah</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5767,12 +6704,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Terkonfirmasi (%1 konfirmasi)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5997,7 +6934,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status transaksi. Arahkan ke bagian ini untuk menampilkan jumlah konfrimasi.</translation>
     </message>
@@ -6025,7 +6997,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6080,7 +7052,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Jumlah min</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Salin alamat</translation>
     </message>
@@ -6110,7 +7087,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Tampilkan rincian transaksi</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6121,7 +7098,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Terkonfirmasi</translation>
     </message>
@@ -6166,7 +7143,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Penulisan data ke file gagal %1</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Jarak:</translation>
     </message>
@@ -6202,19 +7179,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">K&amp;eluar</translation>
+        <translation type="obsolete">K&amp;eluar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Keluar dari aplikasi</translation>
+        <translation type="obsolete">Keluar dari aplikasi</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Berkas</translation>
+        <translation type="obsolete">&amp;Berkas</translation>
     </message>
 </context>
 <context>
@@ -6228,7 +7202,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6254,18 +7228,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6342,50 +7316,62 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation type="unfinished">Mengirim...</translation>
+        <translation type="obsolete">Mengirim...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+488"/>
+        <location filename="../bitcoinstrings.cpp" line="+499"/>
         <source>Usage:</source>
         <translation>Penggunaan:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Daftar perintah</translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-360"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+11"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+109"/>
         <source>The wallet will now shutdown. Please start your wallet to begin sync from zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+168"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6431,11 +7417,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6462,16 +7443,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6580,16 +7551,6 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -6612,11 +7573,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6660,18 +7616,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">T/S</translation>
+        <translation type="obsolete">T/S</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6692,6 +7642,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6915,78 +7870,8 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7037,16 +7922,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7102,6 +7977,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7211,6 +8091,16 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7245,7 +8135,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-305"/>
+        <location line="-282"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7254,7 +8144,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Jika berkas tidak ada, buatlah dengan permisi berkas hanya-dapat-dibaca-oleh-pemilik.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="+151"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Jumlah salah untuk -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
@@ -7264,13 +8154,13 @@ Jika berkas tidak ada, buatlah dengan permisi berkas hanya-dapat-dibaca-oleh-pem
         <translation>Alamat -proxy salah: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished">Gridcoin (CoinHitam)</translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7296,17 +8186,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7325,21 +8235,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7380,11 +8276,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7401,6 +8292,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7445,6 +8346,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7480,11 +8386,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7530,11 +8431,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7615,6 +8511,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7629,7 +8530,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Authorized</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7699,7 +8600,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Tidak dapat menyelesaikan alamat -bind: &apos;%s&apos;</translation>
     </message>
@@ -7809,32 +8710,31 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Gagal memuat wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Memuat alamat...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Tidak dapat mengikat ke %s dengan komputer ini (ikatan gagal %d, %s)</translation>
     </message>
     <message>
-        <location line="-142"/>
+        <location line="-118"/>
         <source>Error: Wallet unlocked for staking only, unable to create transaction.</source>
         <translation>Eror: Dompet hanya di-buka hanya untuk staking, transaksi gagal dilaksanakan</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Sending...</source>
-        <translation>Mengirim...</translation>
+        <translation type="vanished">Mengirim...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+34"/>
         <source>Invalid amount</source>
         <translation>Jumlah salah</translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="+85"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7849,12 +8749,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Jaringan tidak diketahui yang ditentukan dalam -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Saldo tidak mencukupi</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Memuat indeks blok...</translation>
     </message>
@@ -7864,17 +8764,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Memuat dompet...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Tidak dapat menyimpan alamat standar</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Memindai ulang...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Memuat selesai</translation>
     </message>

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">si</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Elimina</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copia &amp;Etichetta</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Modifica</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Esporta Dati Rubrica</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etichetta</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(nessuna etichetta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Solo per lo staking</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Inserisci la nuova passphrase per il portamonete.&lt;br/&gt;Si consiglia di utilizzare &lt;b&gt;almeno dieci caratteri casuali&lt;/b&gt; oppure &lt;b&gt;otto o più parole&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Inserisci la vecchia e la nuova passphrase per il portamonete.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Conferma la cifratura del portamonete</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Si è sicuri di voler cifrare il portamonete?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Portamonete cifrato</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin ora si chiuderà per concludere il processo di cifratura. Ricorda che cifrare il portamonete non protegge il tuo denaro dal furto ad opera di malware che infettano il tuo computer.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: qualsiasi backup del portamonete effettuato precedentemente dovrebbe essere sostituito con il file del portamonete criptato appena generato. Per ragioni di sicurezza, i backup precedenti del file del portamonete non criptato diventeranno inutili non appena inizierai ad utilizzare il nuovo portamonete criptato.</translation>
+        <translation type="vanished">IMPORTANTE: qualsiasi backup del portamonete effettuato precedentemente dovrebbe essere sostituito con il file del portamonete criptato appena generato. Per ragioni di sicurezza, i backup precedenti del file del portamonete non criptato diventeranno inutili non appena inizierai ad utilizzare il nuovo portamonete criptato.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Il processo di cifratura del tuo portafogli è fallito</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Cifratura del portamonete fallita a causa di un errore interno. Il portamonete non è stato cifrato.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Le passphrase inserite non corrispondono.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Sbloccaggio del portafoglio fallito</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La frase inserita per decriptare il tuo portamonete non è corretta.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Passphrase del portamonete modificata con successo.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Si è verificato un errore irreversibile. Gridcoin non può più continuare in sicurezza e verrà chiuso.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Portamonete</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Sintesi</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Esci</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifica messaggio...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Esporta...</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Apri la console di debug e diagnostica</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Impostazioni</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Client Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +972,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>L&apos;ultimo blocco ricevuto è stato generato %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Questa transazione supera il limite di dimensioni.  Puoi comunque inviarla ad un costo di %1, che andranno ai nodi che elaboreranno la tua transazione e aiuteranno a supportare la rete.  Vuoi pagare la commissione?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Conferma la commissione di transazione</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transazione inviata</translation>
     </message>
@@ -835,17 +1000,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -865,7 +1020,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -883,7 +1038,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Gestione URI</translation>
@@ -900,7 +1065,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -915,12 +1080,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Il portamonete è &lt;b&gt;cifrato&lt;/b&gt; ed attualmente &lt;b&gt;bloccato&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Backup Portamonete</translation>
     </message>
@@ -931,18 +1096,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Backup Fallito</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Si è verificato un errore durante il tentativo di salvare i dati del portafogli nella nuova posizione.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,7 +1116,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1208,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Avviso di rete</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1150,7 +1319,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1205,42 +1374,36 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Importo</translation>
+        <translation type="vanished">Importo</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Conferme</translation>
+        <translation type="vanished">Conferme</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confermato</translation>
+        <translation type="vanished">Confermato</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Etichetta</translation>
+        <translation type="vanished">Etichetta</translation>
     </message>
     <message>
-        <location line="-424"/>
+        <location line="-376"/>
         <source>Coin Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+429"/>
         <source>Address</source>
-        <translation>Indirizzo</translation>
+        <translation type="vanished">Indirizzo</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copia l&apos;indirizzo</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copia l&apos;importo</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copia l&apos;ID transazione</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copia quantità</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Copia resto</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>si</translation>
     </message>
@@ -1351,20 +1514,65 @@ Expires: %3
  Ciò significa che è richiesta una commissione di almeno %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(nessuna etichetta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>resto da %1 (%2)</translation>
+        <translation type="vanished">resto da %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(resto)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(nessuna etichetta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">resto da %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(resto)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Importo</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(resto)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etichetta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Indirizzo</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Conferme</translation>
     </message>
 </context>
 <context>
@@ -1390,7 +1598,7 @@ Expires: %3
         <translation type="unfinished">Indirizzo</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1660,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,37 +1695,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Importo</translation>
+        <translation type="obsolete">Importo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etichetta</translation>
+        <translation type="obsolete">Etichetta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Indirizzo</translation>
+        <translation type="obsolete">Indirizzo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Conferme</translation>
+        <translation type="obsolete">Conferme</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confermato</translation>
+        <translation type="obsolete">Confermato</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,7 +1754,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1562,25 +1764,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(nessuna etichetta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">resto da %1 (%2)</translation>
+        <translation type="obsolete">resto da %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(resto)</translation>
+        <translation type="obsolete">(resto)</translation>
     </message>
 </context>
 <context>
@@ -1730,7 +1929,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1755,7 +1959,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1931,7 +2135,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1946,6 +2150,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1954,7 +2163,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versione</translation>
     </message>
@@ -1982,7 +2191,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2054,22 +2272,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2133,7 +2351,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2252,6 +2470,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">si</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Sblocco del portamonete annullato.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2567,7 +3149,7 @@ Expires: %3
         <translation>&amp;Annulla</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>predefinito</translation>
     </message>
@@ -2582,7 +3164,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
@@ -2810,18 +3392,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2832,9 +3419,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Stato</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Importo</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2948,7 +3749,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2988,6 +3789,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3023,7 +3829,7 @@ Expires: %3
         <translation type="unfinished">Modulo</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3033,7 +3839,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3046,7 +3862,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3098,6 +3914,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">si</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3183,12 +4076,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3213,12 +4111,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3305,7 +4203,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3343,7 +4241,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">N/D</translation>
     </message>
@@ -3453,14 +4351,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3470,7 +4402,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3485,12 +4417,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,7 +4455,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3562,6 +4517,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3657,7 +4617,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>N/D</translation>
     </message>
@@ -3758,7 +4718,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3976,7 +4936,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation>Benvenuto nella console RPC di Gridcoin! </translation>
     </message>
@@ -3991,7 +4951,7 @@ Expires: %3
         <translation>Scrivi &lt;b&gt;help&lt;/b&gt; per un riassunto dei comandi disponibili.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4049,12 +5009,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4146,40 +5100,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4637,7 +5588,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4758,7 +5709,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4872,7 +5823,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4895,7 +5846,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4907,7 +5858,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5031,7 +5982,7 @@ Expires: %3
         <translation>Inserisci un indirizzo Gridcoin (es. S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copia quantità</translation>
     </message>
@@ -5091,7 +6042,7 @@ Expires: %3
         <translation> e </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>L&apos;indirizzo del beneficiario non è valido, per cortesia ricontrolla.</translation>
     </message>
@@ -5131,8 +6082,8 @@ Expires: %3
         <translation>Errore: la transazione è stata rifiutata. Questo può accadere se alcune monete nel tuo portafoglio sono già state spese, ad esempio se hai usato una copia di wallet.dat e le monete sono state spese nella copia ma non sono state contrassegnate come spese qui.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(nessuna etichetta)</translation>
     </message>
@@ -5239,7 +6190,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Indirizzo</translation>
     </message>
@@ -5377,42 +6328,42 @@ Expires: %3
         <translation>Inserisci la firma di Gridcoin</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>L&apos;indirizzo inserito non è valido.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Per favore controlla l&apos;indirizzo e riprova.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>L&apos;indirizzo Gridcoin inserito non è associato a nessuna chiave.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Sblocco del portamonete annullato.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La chiave privata per l&apos;indirizzo inserito non è disponibile.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Firma messaggio fallita.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Messaggio firmato.</translation>
     </message>
@@ -5423,7 +6374,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Per favore controlla la firma e riprova.</translation>
     </message>
@@ -5474,7 +6425,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5482,32 +6433,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Aperto fino a %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>in conflitto</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/non confermato</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 conferme</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
@@ -5530,74 +6481,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Sorgente</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Da</translation>
     </message>
@@ -5608,13 +6559,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>proprio indirizzo</translation>
@@ -5625,16 +6576,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etichetta</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Credito</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5647,31 +6598,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>non accettato</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debito</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Commissione transazione</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Importo netto</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Messaggio</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Commento</translation>
     </message>
@@ -5681,38 +6632,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Le monete generate da Gridcoin devono maturare 110 blocchi prima che possano essere spese. Quando hai generato questo blocco, è stato trasmesso alla rete per essere aggiunto alla catena di blocchi. Se non riuscirà ad entrare nella catena, il suo stato cambierà in &quot;non accettato&quot; e non sarà spendibile. Questo può accadere occasionalmente se un altro nodo genera un blocco entro pochi secondi dal tuo.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Importo</translation>
     </message>
@@ -5744,11 +6695,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation>C&amp;hiudi</translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5768,7 +6724,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Importo</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5796,12 +6752,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>In conferma (%1 su %2 conferme raccomandate)&lt;br&gt;</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confermato (%1 conferme)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>In conflitto</translation>
     </message>
@@ -6026,7 +6982,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Stato della transazione. Passare con il mouse su questo campo per vedere il numero di conferme.</translation>
     </message>
@@ -6054,7 +7045,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6109,7 +7100,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Importo minimo</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copia l&apos;indirizzo</translation>
     </message>
@@ -6139,7 +7135,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mostra i dettagli della transazione</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Esporta dati transazione</translation>
     </message>
@@ -6150,7 +7146,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confermato</translation>
     </message>
@@ -6195,7 +7191,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Impossibile scrivere sul file %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Intervallo:</translation>
     </message>
@@ -6231,19 +7227,12 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Esci</translation>
+        <translation type="obsolete">&amp;Esci</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Chiudi applicazione</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Chiudi applicazione</translation>
     </message>
 </context>
 <context>
@@ -6257,7 +7246,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6283,18 +7272,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6371,15 +7360,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Invio...</translation>
+        <translation type="vanished">Invio...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Errore riscontrato durante l&apos;impostazione della porta RPC %u per l&apos;ascolto su IPv6, torno su IPv4: %s</translation>
     </message>
@@ -6389,29 +7377,29 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Errore riscontrato durante l&apos;impostazione della porta RPC %u per l&apos;ascolto su IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Utilizzo:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lista comandi
 </translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Aiuto su un comando
 </translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Attenzione: -paytxfee è molto alta. Questa è la commissione che si paga quando si invia una transazione.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Attenzione: wallet.dat corrotto, dati salvati! Il wallet.dat originale salvato come wallet.{timestamp}.bak in %s; se il tuo bilancio o le transazioni non sono corrette dovresti ripristinare da un backup.</translation>
     </message>
@@ -6421,7 +7409,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Attenzione: errore di lettura di wallet.dat!  Tutte le chiavi lette correttamente, ma i dati delle transazioni o le voci in rubrica potrebbero mancare o non essere corretti.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Errore: creazione della transazione fallita  </translation>
     </message>
@@ -6431,17 +7419,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Errore: la transazione è stata rifiutata. Questo può accadere se alcune monete nel tuo portafoglio sono già state spese, ad esempio se hai usato una copia di wallet.dat e le monete sono state spese nella copia ma non sono state contrassegnate come spese qui.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Nessuna porta disponibile per l&apos;ascolto. Usa -listen=0 se vuoi procedere comunque.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Per usare l&apos;opzione %s</translation>
     </message>
     <message>
-        <location line="-463"/>
+        <location line="-474"/>
         <source>%s, you must set a rpcpassword in the configuration file:
  %s
 It is recommended you use the following random password:
@@ -6467,12 +7455,12 @@ per esempio: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="-3"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6482,12 +7470,12 @@ per esempio: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+19"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6507,21 +7495,7 @@ per esempio: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6547,11 +7521,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6571,7 +7540,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6611,7 +7580,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6647,11 +7616,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6691,12 +7655,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6768,7 +7727,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6780,11 +7739,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6855,16 +7809,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6978,11 +7922,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7005,16 +7944,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7093,7 +8022,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Verifica d&apos;integrita di inizializzazione fallita. Gridcoin verrà chiuso.</translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Il portamonete %s è fuori dalla cartella dati %s.</translation>
     </message>
@@ -7103,12 +8032,85 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Verifica dell&apos;integrità del database...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Errore durante l&apos;inizializzazione dell&apos;ambiente del database %s! Per ripristinare, FARE IL BACKUP DI QUELLA CARTELLA, poi rimuoverne tutto il contenuto tranne wallet.dat.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7199,6 +8201,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7233,7 +8245,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>wallet.dat corrotto, salvataggio fallito</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Indirizzo -proxy non valido: &apos;%s&apos;</translation>
     </message>
@@ -7243,7 +8255,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Indirizzo -tor non valido: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Impossibile risolvere indirizzo -bind: &apos;%s&apos;</translation>
     </message>
@@ -7253,12 +8265,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Impossibile risolvere indirizzo -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Importo non valido per -reservebalance=&lt;importo&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Errore durante il caricamento di blkindex.dat</translation>
     </message>
@@ -7273,7 +8285,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Errore durante il caricamento di wallet.dat: il portamonete richiede una versione più recente di Gridcoin</translation>
     </message>
     <message>
-        <location line="+41"/>
+        <location line="+38"/>
         <source>Invalid amount for -peertimeout=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7285,16 +8297,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Is Superblock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7320,11 +8322,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7368,18 +8365,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">N/D</translation>
+        <translation type="obsolete">N/D</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7400,6 +8391,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7623,78 +8619,8 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7749,16 +8675,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7808,7 +8724,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7818,37 +8734,37 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Il portamonete doveva essere riscritto: riavviare Gridcoin per completare</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Errore caricamento wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Importazione del file di dati bootstrap blockchain.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Caricamento indirizzi...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Errore: impossibile avviare il nodo</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Impossibile collegarsi alla %s su questo computer. Gridcoin è probabilmente già in esecuzione.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Impossibile collegarsi alla %s su questo computer (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Errore: portamonete bloccato, impossibile creare la transazione  </translation>
     </message>
@@ -7863,37 +8779,36 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Errore: questa transazione richiede una commissione di transazione di almeno %s a causa del suo importo, della sua complessità o dell&apos;utilizzo di fondi ricevuti di recente  </translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Invio...</translation>
+        <translation type="vanished">Invio...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Importo non valido</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Attenzione: verificare che la data e l&apos;ora del computer siano corrette! Se il tuo orologio è sbagliato, Gridcoin non funzionerà correttamente.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Attenzione: lo spazio su disco è ridotto!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Rete sconosciuta specificata in -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Fondi insufficienti</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Caricamento dell&apos;indice dei blocchi...</translation>
     </message>
@@ -7903,17 +8818,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Caricamento portamonete...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Non è possibile scrivere l&apos;indirizzo predefinito</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Ripetizione scansione...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Caricamento completato</translation>
     </message>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">はい</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">いいえ</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>削除(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>ラベルをコピー (&amp;L)</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>編集 (&amp;E)</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>ラベル</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ラベル無し)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>ウォレットの新しいパスフレーズを入力してください。&lt;br/&gt;&lt;b&gt;10文字以上のランダムな文字&lt;/b&gt;で構成されたものか、&lt;b&gt;8単語以上の単語&lt;/b&gt;で構成されたパスフレーズを使用してください。</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>ウォレットの暗号化を確認する</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>ウォレットは暗号化されました</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>重要: 過去のウォレット ファイルのバックアップは、暗号化された新しいウォレット ファイルに取り替える必要があります。セキュリティ上の理由により、暗号化された新しいウォレットを使い始めると、暗号化されていないウォレット ファイルのバックアップはすぐに使えなくなります。</translation>
+        <translation type="vanished">重要: 過去のウォレット ファイルのバックアップは、暗号化された新しいウォレット ファイルに取り替える必要があります。セキュリティ上の理由により、暗号化された新しいウォレットを使い始めると、暗号化されていないウォレット ファイルのバックアップはすぐに使えなくなります。</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>ウォレットの暗号化に失敗しました</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>内部エラーによりウォレットの暗号化が失敗しました。ウォレットは暗号化されませんでした。</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>パスフレーズが同じではありません。</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>ウォレットのアンロックに失敗しました</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>ウォレットの暗号化解除のパスフレーズが正しくありません。</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>ウォレットのパスフレーズの変更が成功しました。</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>ウォレット</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>概要(&amp;O)</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>終了(&amp;E)</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>メッセージの検証... (&amp;V)</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>デバッグと診断コンソールを開く</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>ファイル(&amp;F)</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>設定(&amp;S)</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -796,17 +961,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>送金取引</translation>
     </message>
@@ -824,17 +989,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -854,7 +1009,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -872,7 +1027,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1054,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -904,12 +1069,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>ウォレットは&lt;b&gt;暗号化されて、ロックされています&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -920,18 +1085,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -941,7 +1105,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1028,7 +1197,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1077,7 +1246,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,12 +1254,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1318,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1373,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>総額</translation>
+        <translation type="vanished">総額</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">ラベル</translation>
+        <translation type="obsolete">ラベル</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">アドレス</translation>
+        <translation type="obsolete">アドレス</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>日付</translation>
+        <translation type="vanished">日付</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>検証数</translation>
+        <translation type="vanished">検証数</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>検証済み</translation>
+        <translation type="vanished">検証済み</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>アドレスをコピーする</translation>
     </message>
@@ -1245,17 +1408,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>総額のコピー</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>取引 ID をコピー</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>数量をコピーする</translation>
     </message>
@@ -1285,17 +1448,17 @@ Expires: %3
         <translation>釣り銭をコピー</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>はい</translation>
     </message>
@@ -1335,20 +1498,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>（ラベル無し）</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>%1 (%2) からのおつり</translation>
+        <translation type="vanished">%1 (%2) からのおつり</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(おつり)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">%1 (%2) からのおつり</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(おつり)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">総額</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(おつり)</translation>
+        <source>Label</source>
+        <translation type="unfinished">ラベル</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">アドレス</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">日付</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">検証数</translation>
     </message>
 </context>
 <context>
@@ -1374,7 +1582,7 @@ Expires: %3
         <translation type="unfinished">アドレス</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,7 +1644,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1471,37 +1679,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">総額</translation>
+        <translation type="obsolete">総額</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">ラベル</translation>
+        <translation type="obsolete">ラベル</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">アドレス</translation>
+        <translation type="obsolete">アドレス</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">日付</translation>
+        <translation type="obsolete">日付</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">検証数</translation>
+        <translation type="obsolete">検証数</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">検証済み</translation>
+        <translation type="obsolete">検証済み</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1536,7 +1738,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,25 +1748,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">%1 (%2) からのおつり</translation>
+        <translation type="obsolete">%1 (%2) からのおつり</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(おつり)</translation>
+        <translation type="obsolete">(おつり)</translation>
     </message>
 </context>
 <context>
@@ -1714,7 +1913,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,7 +1943,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1915,7 +2119,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,6 +2134,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1938,7 +2147,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1966,7 +2175,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2035,22 +2253,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,7 +2332,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2233,6 +2451,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">すべてクリア (&amp;A)</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">はい</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">いいえ</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">ウォレットのアンロックはキャンセルされました。</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2548,7 +3127,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>初期値</translation>
     </message>
@@ -2563,7 +3142,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
@@ -2791,18 +3370,23 @@ Expires: %3
         <translation>あなたの現在の残高</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">総額のコピー</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2813,9 +3397,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">ステータス</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">総額</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2929,7 +3723,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2969,6 +3763,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3004,7 +3803,7 @@ Expires: %3
         <translation type="unfinished">フォーム</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,7 +3813,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3027,7 +3836,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3080,6 +3889,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">はい</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">いいえ</translation>
     </message>
 </context>
 <context>
@@ -3164,12 +4050,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3194,12 +4085,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3286,7 +4177,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3324,7 +4215,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3428,14 +4319,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,7 +4370,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,12 +4385,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4423,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,6 +4485,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3672,7 +4625,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3763,7 +4716,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3951,7 +4904,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4919,7 @@ Expires: %3
         <translation>使用可能なコマンドを見るには &lt;b&gt;help&lt;/b&gt; と入力します。</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4024,12 +4977,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4121,40 +5068,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,7 +5556,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4733,7 +5677,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4847,7 +5791,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4870,7 +5814,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4882,7 +5826,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,7 +5950,7 @@ Expires: %3
         <translation>送金 (&amp;E)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>数量をコピーする</translation>
     </message>
@@ -5066,7 +6010,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5106,8 +6050,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>（ラベル無し）</translation>
     </message>
@@ -5214,7 +6158,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">アドレス</translation>
     </message>
@@ -5352,42 +6296,42 @@ Expires: %3
         <translation>署名を作成するには&quot;メッセージの署名&quot;をクリック</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>不正なアドレスが入力されました。</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>アドレスを確かめてからもう一度試してください。</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>入力されたアドレスに関連するキーがありません。</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>ウォレットのアンロックはキャンセルされました。</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>入力されたアドレスのプライベート キーが無効です。</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>メッセージの署名に失敗しました。</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>メッセージに署名しました。</translation>
     </message>
@@ -5398,7 +6342,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>署名を確認してからもう一度試してください。</translation>
     </message>
@@ -5449,39 +6393,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>ユニット %1 を開く</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/オフライン</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/未検証</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 確認</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>ステータス</translation>
     </message>
@@ -5503,74 +6447,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>日付</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>ソース</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>送信</translation>
     </message>
@@ -5581,13 +6525,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>受信</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>自分のアドレス</translation>
@@ -5598,16 +6542,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>ラベル</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>クレジット</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5619,31 +6563,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>承認されなかった</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>引き落とし額</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>取引手数料</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>正味金額</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>メッセージ</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>コメント</translation>
     </message>
@@ -5653,38 +6597,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>総額</translation>
     </message>
@@ -5716,11 +6660,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
@@ -5740,7 +6689,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">総額</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5767,12 +6716,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>検証されました (%1 検証済み)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>衝突</translation>
     </message>
@@ -5997,7 +6946,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>取引の状況。このフィールドの上にカーソルを置くと検証の数を表示します。</translation>
     </message>
@@ -6025,7 +7009,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6080,7 +7064,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>最小の額</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>アドレスをコピーする</translation>
     </message>
@@ -6110,7 +7099,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>取引の詳細を表示</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6121,7 +7110,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>検証済み</translation>
     </message>
@@ -6166,7 +7155,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>期間:</translation>
     </message>
@@ -6202,19 +7191,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">終了(&amp;E)</translation>
+        <translation type="obsolete">終了(&amp;E)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">アプリケーションを終了</translation>
+        <translation type="obsolete">アプリケーションを終了</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">ファイル(&amp;F)</translation>
+        <translation type="obsolete">ファイル(&amp;F)</translation>
     </message>
 </context>
 <context>
@@ -6228,7 +7214,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6254,18 +7240,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6340,38 +7326,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>ポートのリスンに失敗しました。必要であれば -listen=0 を使用してください。</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>無効な -proxy アドレス: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>アドレスを読み込んでいます...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6416,17 +7389,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6447,6 +7410,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6661,42 +7629,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6750,7 +7683,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6780,18 +7713,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>-onlynet で指定された &apos;%s&apos; は未知のネットワークです</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>残高不足</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6817,17 +7750,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6851,21 +7804,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6906,11 +7845,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6927,6 +7861,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6971,6 +7915,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7011,11 +7960,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7061,11 +8005,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7153,6 +8092,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7164,11 +8108,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7239,16 +8178,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7412,11 +8341,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7439,16 +8363,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7568,16 +8482,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7612,7 +8516,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>ウォレットを読み込んでいます...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7622,57 +8526,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+20"/>
         <source>Unknown poll response type.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7719,6 +8573,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7828,6 +8687,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7862,17 +8731,45 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>初期値のアドレスを書き込むことができません</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+383"/>
         <source>Rescanning...</source>
         <translation>再スキャン中...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>読み込み完了</translation>
     </message>

--- a/src/qt/locale/bitcoin_ka.ts
+++ b/src/qt/locale/bitcoin_ka.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;წაშლა</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>საფულე</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>მიმ&amp;ოხილვა</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;გასვლა</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;ვერიფიკაცია</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>დახვეწისა და გიაგნოსტიკის კონსოლის გაშვება</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;ფაილი</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;პარამეტრები</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>გაგზავნილი ტრანსაქციები</translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>საფულე &lt;b&gt;დაშიფრულია&lt;/b&gt; და ამჟამად &lt;b&gt;დაბლოკილია&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>თანხა</translation>
+        <translation type="vanished">თანხა</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>თარიღი</translation>
+        <translation type="vanished">თარიღი</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>დადასტურება</translation>
+        <translation type="vanished">დადასტურება</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>დადასტურებულია</translation>
+        <translation type="vanished">დადასტურებულია</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1251,17 +1402,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1442,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,20 +1492,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">თანხა</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">თარიღი</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">დადასტურება</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1568,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1630,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1665,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">თანხა</translation>
+        <translation type="obsolete">თანხა</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">თარიღი</translation>
+        <translation type="obsolete">თარიღი</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">დადასტურება</translation>
+        <translation type="obsolete">დადასტურება</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">დადასტურებულია</translation>
+        <translation type="obsolete">დადასტურებულია</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1716,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,24 +1726,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1720,7 +1883,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1913,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2089,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2104,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2117,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2145,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2226,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2305,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2424,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">გ&amp;ასუფთავება</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3103,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>ნაგულისხმევი</translation>
     </message>
@@ -2572,7 +3118,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">შეცდომა</translation>
@@ -2800,18 +3346,23 @@ Expires: %3
         <translation>თქვენი სრული მიმდინარე ბალანსი</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3373,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">თანხა</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3703,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3743,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3783,7 @@ Expires: %3
         <translation type="unfinished">ფორმა</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3793,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3816,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3868,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4030,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4065,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4157,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4195,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">მიუწვდ.</translation>
     </message>
@@ -3443,14 +4305,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4356,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4371,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4409,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4471,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3647,7 +4571,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>მიუწვდ.</translation>
     </message>
@@ -3778,7 +4702,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4890,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4905,7 @@ Expires: %3
         <translation>აკრიფეთ &lt;b&gt;help&lt;/b&gt; ფაშვებული ბრძანებების სანახავად.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4963,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5054,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5542,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5663,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5777,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5800,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5812,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5936,7 @@ Expires: %3
         <translation>გაგ&amp;ზავნა</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +5996,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6036,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5229,7 +6144,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5367,42 +6282,42 @@ Expires: %3
         <translation>ვერიფიკაციის ყველა ველის წაშლა</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6328,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6379,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6387,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6435,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">თარიღი</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6513,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6530,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6552,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6586,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">თანხა</translation>
     </message>
@@ -5734,11 +6649,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">თარიღი</translation>
     </message>
@@ -5758,7 +6678,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">თანხა</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6706,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6936,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +6999,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7054,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6129,7 +7089,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7100,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">დადასტურებულია</translation>
     </message>
@@ -6185,7 +7145,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6221,19 +7181,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;გასვლა</translation>
+        <translation type="obsolete">&amp;გასვლა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">გასვლა</translation>
+        <translation type="obsolete">გასვლა</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;ფაილი</translation>
+        <translation type="obsolete">&amp;ფაილი</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7204,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7230,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,38 +7316,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>ვერ ხერხდება პორტების მიყურადება. თუ გსურთ, გამოიყენეთ -listen=0.</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>არასწორია მისამართი -proxy: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>მისამართების ჩატვირთვა...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6434,18 +7378,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">მიუწვდ.</translation>
+        <translation type="obsolete">მიუწვდ.</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6466,6 +7404,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6680,42 +7623,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6769,7 +7677,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6799,18 +7707,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>-onlynet-ში მითითებულია უცნობი ქსელი: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>არ არის საკმარისი თანხა</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6836,17 +7744,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6870,21 +7798,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6925,11 +7839,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6946,6 +7855,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6990,6 +7909,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7030,11 +7954,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7080,11 +7999,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7172,6 +8086,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7183,11 +8102,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7258,16 +8172,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7431,11 +8335,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7458,16 +8357,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7587,16 +8476,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7631,7 +8510,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>საფულის ჩატვირთვა...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7641,57 +8520,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+20"/>
         <source>Unknown poll response type.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7738,6 +8567,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7847,6 +8681,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7881,17 +8725,45 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>ვერ ხერხდება ნაგულისხმევი მისამართის ჩაწერა</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+383"/>
         <source>Rescanning...</source>
         <translation>სკანირება...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>ჩატვირთვა დასრულებულია</translation>
     </message>

--- a/src/qt/locale/bitcoin_kk_KZ.ts
+++ b/src/qt/locale/bitcoin_kk_KZ.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Жою</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Әмиян</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Шығу</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>Файл</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Саны</translation>
+        <translation type="vanished">Саны</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>Күні</translation>
+        <translation type="vanished">Күні</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Растау саны</translation>
+        <translation type="vanished">Растау саны</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Растық</translation>
+        <translation type="vanished">Растық</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1251,17 +1402,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1442,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,20 +1492,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Саны</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Күні</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Растау саны</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1568,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1630,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1665,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Саны</translation>
+        <translation type="obsolete">Саны</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Күні</translation>
+        <translation type="obsolete">Күні</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Растау саны</translation>
+        <translation type="obsolete">Растау саны</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Растық</translation>
+        <translation type="obsolete">Растық</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1716,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,24 +1726,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1720,7 +1883,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1913,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2089,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2104,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2117,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2145,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2226,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2305,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2424,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3103,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2572,7 +3118,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">қате</translation>
@@ -2800,18 +3346,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3373,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Саны</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3703,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3743,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3783,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3793,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3816,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3868,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4030,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4065,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4157,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4195,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4305,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4356,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4371,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4409,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4471,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4586,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3803,7 +4727,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4890,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4905,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4963,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5054,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5542,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5663,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5777,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5800,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5812,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5936,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +5996,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6036,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5229,7 +6144,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5367,42 +6282,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6328,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6379,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6387,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6435,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Күні</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6513,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6530,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6552,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6586,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">Саны</translation>
     </message>
@@ -5734,11 +6649,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">Күні</translation>
     </message>
@@ -5758,7 +6678,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Саны</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6706,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6936,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +6999,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7054,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6129,7 +7089,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7100,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">Растық</translation>
     </message>
@@ -6185,7 +7145,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6221,19 +7181,12 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Шығу</translation>
+        <translation type="obsolete">Шығу</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Quit application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">Файл</translation>
+        <translation type="obsolete">Файл</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7200,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7226,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,23 +7312,15 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
         <location filename="../bitcoinstrings.cpp" line="+12"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6401,17 +7346,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6435,21 +7400,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6490,11 +7441,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6514,7 +7460,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6554,7 +7500,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6595,11 +7541,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6645,11 +7586,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6736,7 +7672,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6748,11 +7684,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6823,16 +7754,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7012,11 +7933,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7043,16 +7959,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7182,16 +8088,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7237,11 +8133,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Magnitude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7282,21 +8173,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7313,6 +8242,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7542,82 +8476,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7668,16 +8527,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7758,6 +8607,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7863,6 +8717,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>poll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ko_KR.ts
+++ b/src/qt/locale/bitcoin_ko_KR.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">예</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">아니요</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>삭제(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>라벨 복사(&amp;L)</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>편집 (&amp;E)</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>라벨</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(라벨 없음)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>지갑에 새로운 비밀문구를 입력하세요.&lt;br/&gt;비밀문구를 &lt;b&gt;열 개 이상의 무작위 글자&lt;/b&gt; 혹은 &lt;b&gt;여덟개 이상의 단어로&lt;b&gt; 정하세요.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>지갑 암호화 승인</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>지갑 암호화 완료</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>중요: 본인 지갑 파일에서 만든 예전 백업들은 새로 생성한 암호화된 지갑 파일로 교체됩니다. 보안상 이유로 이전에 암호화하지 않은 지갑 파일 백업은 사용할 수 없게 되니 이른 시일 내로 새로 암호화된 지갑을 사용하시기 바랍니다.</translation>
+        <translation type="vanished">중요: 본인 지갑 파일에서 만든 예전 백업들은 새로 생성한 암호화된 지갑 파일로 교체됩니다. 보안상 이유로 이전에 암호화하지 않은 지갑 파일 백업은 사용할 수 없게 되니 이른 시일 내로 새로 암호화된 지갑을 사용하시기 바랍니다.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>지갑 암호화 실패</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>지갑 암호화는 내부 에러로 인해 실패했습니다.  당신의 지갑은 암호화 되지 않았습니다.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>지정한 암호가 일치하지 않습니다.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>지갑 잠금해제 실패</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>지갑 해독을 위한 암호가 틀렸습니다.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>지갑 비밀번호가 성공적으로 변경되었습니다.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>지갑</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>개요(&amp;O)</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>나가기(&amp;X)</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>메시지 확인(&amp;V)...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>디버깅 및 진단 콘솔을 엽니다</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>파일(&amp;F)</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>설정(&amp;S)</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -796,17 +961,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>거래 보내기</translation>
     </message>
@@ -824,17 +989,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -854,7 +1009,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -872,7 +1027,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1054,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -904,12 +1069,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>지갑이 암호화 되었고 현재 잠겨져 있습니다</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -920,18 +1085,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -941,7 +1105,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1028,7 +1197,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1077,7 +1246,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,12 +1254,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1318,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1373,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>거래액</translation>
+        <translation type="vanished">거래액</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">라벨</translation>
+        <translation type="obsolete">라벨</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">주소</translation>
+        <translation type="obsolete">주소</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>날짜</translation>
+        <translation type="vanished">날짜</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>확인</translation>
+        <translation type="vanished">확인</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>확인됨</translation>
+        <translation type="vanished">확인됨</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>주소 복사</translation>
     </message>
@@ -1245,17 +1408,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>거래액 복사</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>거래 아이디 복사</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>수량 복사</translation>
     </message>
@@ -1285,17 +1448,17 @@ Expires: %3
         <translation>잔돈 복사</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>예</translation>
     </message>
@@ -1335,20 +1498,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(라벨 없음)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>%1로부터 변경 (%2)</translation>
+        <translation type="vanished">%1로부터 변경 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(잔돈)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(라벨 없음)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">%1로부터 변경 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(잔돈)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">거래액</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(잔돈)</translation>
+        <source>Label</source>
+        <translation type="unfinished">라벨</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">주소</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">날짜</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">확인</translation>
     </message>
 </context>
 <context>
@@ -1374,7 +1582,7 @@ Expires: %3
         <translation type="unfinished">주소</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,7 +1644,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1471,37 +1679,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">거래액</translation>
+        <translation type="obsolete">거래액</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">라벨</translation>
+        <translation type="obsolete">라벨</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">주소</translation>
+        <translation type="obsolete">주소</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">날짜</translation>
+        <translation type="obsolete">날짜</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">확인</translation>
+        <translation type="obsolete">확인</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">확인됨</translation>
+        <translation type="obsolete">확인됨</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1536,7 +1738,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,25 +1748,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(라벨 없음)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">%1로부터 변경 (%2)</translation>
+        <translation type="obsolete">%1로부터 변경 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(잔돈)</translation>
+        <translation type="obsolete">(잔돈)</translation>
     </message>
 </context>
 <context>
@@ -1714,7 +1913,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,7 +1943,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1915,7 +2119,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,6 +2134,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1938,7 +2147,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1966,7 +2175,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2035,22 +2253,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,7 +2332,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2233,6 +2451,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">모두 지우기(&amp;A)</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">예</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">아니요</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2548,7 +3127,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>기본값</translation>
     </message>
@@ -2563,7 +3142,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">오류</translation>
@@ -2791,18 +3370,23 @@ Expires: %3
         <translation>당신의 현재 총액</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">거래액 복사</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2813,9 +3397,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">거래액</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2929,7 +3723,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2969,6 +3763,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3004,7 +3803,7 @@ Expires: %3
         <translation type="unfinished">유형</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,7 +3813,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3027,7 +3836,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3080,6 +3889,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">예</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">아니요</translation>
     </message>
 </context>
 <context>
@@ -3164,12 +4050,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3194,12 +4085,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3286,7 +4177,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3324,7 +4215,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">없음</translation>
     </message>
@@ -3428,14 +4319,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,7 +4370,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,12 +4385,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4423,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,6 +4485,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3632,7 +4585,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>없음</translation>
     </message>
@@ -3773,7 +4726,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3951,7 +4904,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4919,7 @@ Expires: %3
         <translation>사용할 수 있는 명령을 둘러보려면 &lt;b&gt;help&lt;/b&gt;를 입력하십시오.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation>%1 바이트</translation>
     </message>
@@ -4024,12 +4977,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4121,40 +5068,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,7 +5556,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4733,7 +5677,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4847,7 +5791,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4870,7 +5814,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4882,7 +5826,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,7 +5950,7 @@ Expires: %3
         <translation>보내기(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>수량 복사</translation>
     </message>
@@ -5066,7 +6010,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5106,8 +6050,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(라벨 없음)</translation>
     </message>
@@ -5214,7 +6158,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">주소</translation>
     </message>
@@ -5352,42 +6296,42 @@ Expires: %3
         <translation>모든 검증 메시지 필드 재설정</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5398,7 +6342,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5449,39 +6393,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5503,74 +6447,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>날짜</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5581,13 +6525,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5598,16 +6542,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5619,31 +6563,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5653,38 +6597,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">거래액</translation>
     </message>
@@ -5716,11 +6660,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
@@ -5740,7 +6689,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">거래액</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5767,12 +6716,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5997,7 +6946,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6025,7 +7009,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6080,7 +7064,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>주소 복사</translation>
     </message>
@@ -6110,7 +7099,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>거래 세부 내역 보기</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6121,7 +7110,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>확인됨</translation>
     </message>
@@ -6166,7 +7155,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>범위:</translation>
     </message>
@@ -6202,19 +7191,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">나가기(&amp;X)</translation>
+        <translation type="obsolete">나가기(&amp;X)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">어플리케이션 종료</translation>
+        <translation type="obsolete">어플리케이션 종료</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">파일(&amp;F)</translation>
+        <translation type="obsolete">파일(&amp;F)</translation>
     </message>
 </context>
 <context>
@@ -6228,7 +7214,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6254,18 +7240,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6340,38 +7326,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>어떤 포트도 반응하지 않습니다. 사용자 반응=0 만약 원한다면</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>잘못된 -proxy 주소입니다: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>주소를 불러오는 중...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6415,18 +7388,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">없음</translation>
+        <translation type="obsolete">없음</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6447,6 +7414,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6661,42 +7633,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6750,7 +7687,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6780,18 +7717,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>-onlynet에 지정한 네트워크를 알 수 없습니다: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>자금 부족</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6817,17 +7754,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6851,21 +7808,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6906,11 +7849,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6927,6 +7865,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6971,6 +7919,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7011,11 +7964,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7061,11 +8009,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7153,6 +8096,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7164,11 +8112,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7239,16 +8182,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7412,11 +8345,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7439,16 +8367,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7568,16 +8486,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7612,7 +8520,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>지갑을 불러오는 중...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7622,57 +8530,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+20"/>
         <source>Unknown poll response type.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7719,6 +8577,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7828,6 +8691,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7862,17 +8735,45 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>기본 계좌에 기록할 수 없습니다</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+383"/>
         <source>Rescanning...</source>
         <translation>재검색 중...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>로딩 완료</translation>
     </message>

--- a/src/qt/locale/bitcoin_ky.ts
+++ b/src/qt/locale/bitcoin_ky.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ө&amp;чүрүү</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Address</source>
         <translation>Дарек</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(аты жок)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Капчык</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Билдирүүнү &amp;текшерүү...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,15 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Дарек</translation>
+        <translation type="obsolete">Дарек</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>Дата</translation>
+        <translation type="vanished">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1251,17 +1394,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1434,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,19 +1484,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(аты жок)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(аты жок)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Дарек</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Дата</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1380,7 +1560,7 @@ Expires: %3
         <translation type="unfinished">Дарек</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1622,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1657,15 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Дарек</translation>
+        <translation type="obsolete">Дарек</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Дата</translation>
+        <translation type="obsolete">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1700,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1710,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(аты жок)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1867,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1897,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2073,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2088,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2101,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2129,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2210,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2289,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2408,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;Бардыгын тазалоо</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3087,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>жарыяланбаган</translation>
     </message>
@@ -2572,7 +3102,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Ката</translation>
@@ -2800,18 +3330,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3357,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3687,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3727,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3767,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3777,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3800,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3852,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4014,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4049,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4141,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4179,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4289,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4340,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4355,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4393,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4455,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4570,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3803,7 +4711,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4874,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4889,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4947,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5038,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5526,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5647,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5761,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5784,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5796,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5920,7 @@ Expires: %3
         <translation>&amp;Жөнөтүү</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +5980,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6020,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(аты жок)</translation>
     </message>
@@ -5229,7 +6128,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Дарек</translation>
     </message>
@@ -5367,42 +6266,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6312,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6363,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6371,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/тармакта эмес</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6419,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6497,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6514,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6536,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Билдирүү</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6570,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5734,11 +6633,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
@@ -5758,7 +6662,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6690,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6920,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +6983,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7038,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6129,7 +7073,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7084,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6185,7 +7129,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6221,19 +7165,8 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Quit application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Файл</translation>
+        <translation type="obsolete">&amp;Файл</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7180,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7206,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,23 +7292,15 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
         <location filename="../bitcoinstrings.cpp" line="+12"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6401,17 +7326,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6435,21 +7380,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6490,11 +7421,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6514,7 +7440,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6554,7 +7480,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6595,11 +7521,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6645,11 +7566,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6736,7 +7652,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6748,11 +7664,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6823,16 +7734,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7012,11 +7913,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7043,16 +7939,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7182,16 +8068,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7237,11 +8113,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Magnitude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7282,21 +8153,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7313,6 +8222,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7542,82 +8456,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7668,16 +8507,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7758,6 +8587,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7863,6 +8697,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>poll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_la.ts
+++ b/src/qt/locale/bitcoin_la.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Dele</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copia &amp;Titulum</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Muta</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Titulus</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(nullus titulus)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Insero veterem novamque tesseram cassidili.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirma cifrationem cassidilis</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Cassidile cifratum</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>GRAVE: Oportet ulla prioria conservata quae fecisti de plica tui cassidilis reponi a nove generata cifrata plica cassidilis.  Propter securitatem, prioria conservata de plica non cifrata cassidilis inutilia fiet simul atque incipis uti novo cifrato cassidili.</translation>
+        <translation type="vanished">GRAVE: Oportet ulla prioria conservata quae fecisti de plica tui cassidilis reponi a nove generata cifrata plica cassidilis.  Propter securitatem, prioria conservata de plica non cifrata cassidilis inutilia fiet simul atque incipis uti novo cifrato cassidili.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Cassidile cifrare abortum est</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Cassidile cifrare abortum est propter internum errorem.  Tuum cassidile cifratum non est.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Tesserae datae non eaedem sunt.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Cassidile reserare abortum est.</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Tessera inserta pro cassidilis decifrando prava erat.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Tessera cassidilis successa est in mutando.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Cassidile</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Summarium</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>E&amp;xi</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifica nuntium...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Aperi terminalem debug et diagnosticalem</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Plica</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuratio</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transactio missa</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Cassidile &lt;b&gt;cifratum&lt;/b&gt; est et iam nunc &lt;b&gt;seratum&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Monitio Retis</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Quantitas</translation>
+        <translation type="vanished">Quantitas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Titulus</translation>
+        <translation type="obsolete">Titulus</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Dies</translation>
+        <translation type="vanished">Dies</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmatum</translation>
+        <translation type="vanished">Confirmatum</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Inscriptio</translation>
+        <translation type="vanished">Inscriptio</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copia inscriptionem</translation>
     </message>
@@ -1251,17 +1410,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copia quantitatem</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copia transactionis ID</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1450,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,19 +1500,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(nullus titulus)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(nullus titulus)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Quantitas</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Titulus</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Inscriptio</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Dies</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1380,7 +1576,7 @@ Expires: %3
         <translation type="unfinished">Inscriptio</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1638,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1673,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Quantitas</translation>
+        <translation type="obsolete">Quantitas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Titulus</translation>
+        <translation type="obsolete">Titulus</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Inscriptio</translation>
+        <translation type="obsolete">Inscriptio</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Dies</translation>
+        <translation type="obsolete">Dies</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmatum</translation>
+        <translation type="obsolete">Confirmatum</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1728,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1738,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(nullus titulus)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1895,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1925,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2101,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2116,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2129,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2157,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2238,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2317,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2436,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Vacuefac &amp;Omnia</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Cassidilis reserare cancellatum est.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3115,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>praedefinitum</translation>
     </message>
@@ -2572,7 +3130,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2800,18 +3358,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copia quantitatem</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3385,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Quantitas</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3715,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3755,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3795,7 @@ Expires: %3
         <translation type="unfinished">Schema</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3805,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3828,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3880,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4042,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4077,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4169,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4207,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4317,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4368,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4383,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4421,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4483,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3687,7 +4623,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3788,7 +4724,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4902,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4917,7 @@ Expires: %3
         <translation>Scribe &lt;b&gt;help&lt;/b&gt; pro summario possibilium mandatorum.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4975,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5066,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5554,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5675,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5789,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5812,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5824,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5948,7 @@ Expires: %3
         <translation>&amp;Mitte</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +6008,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Inscriptio accipientis non est valida, sodes reproba.</translation>
     </message>
@@ -5121,8 +6048,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(nullus titulus)</translation>
     </message>
@@ -5229,7 +6156,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Inscriptio</translation>
     </message>
@@ -5367,42 +6294,42 @@ Expires: %3
         <translation>Clicca &quot;Signa Nuntium&quot; ut signatio generetur</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Inscriptio inserta non valida est.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Sodes inscriptionem proba et rursus conare.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Inserta inscriptio clavem non refert.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Cassidilis reserare cancellatum est.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Clavis privata absens est pro inserta inscriptione.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Nuntium signare abortum est.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Nuntius signatus.</translation>
     </message>
@@ -5413,7 +6340,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Sodes signationem proba et rursus conare.</translation>
     </message>
@@ -5464,7 +6391,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6399,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Apertum donec %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/non conecto</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/non confirmata</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmationes</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6447,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Dies</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Fons</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Ab</translation>
     </message>
@@ -5598,13 +6525,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>inscriptio propria</translation>
@@ -5615,16 +6542,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>titulus</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Creditum</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6564,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>non acceptum</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debitum</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Transactionis merces</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Cuncta quantitas</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Nuntius</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Annotatio</translation>
     </message>
@@ -5671,38 +6598,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Quantitas</translation>
     </message>
@@ -5734,11 +6661,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Dies</translation>
     </message>
@@ -5758,7 +6690,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Quantitas</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6718,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmatum (%1 confirmationes)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6948,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status transactionis.  Supervola cum mure ut monstretur numerus confirmationum.</translation>
     </message>
@@ -6044,7 +7011,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7066,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Quantitas minima</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copia inscriptionem</translation>
     </message>
@@ -6129,7 +7101,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Monstra particularia transactionis</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7112,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmatum</translation>
     </message>
@@ -6185,7 +7157,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Intervallum:</translation>
     </message>
@@ -6221,19 +7193,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">E&amp;xi</translation>
+        <translation type="obsolete">E&amp;xi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Exi applicatione</translation>
+        <translation type="obsolete">Exi applicatione</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Plica</translation>
+        <translation type="obsolete">&amp;Plica</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7216,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7242,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,17 +7328,9 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Error erat dum initians portam RPC %u pro auscultando in IPv6, labens retrorsum ad IPv4: %s</translation>
     </message>
@@ -6379,27 +7340,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Error erat dum initians portam RPC %u pro auscultando in IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Usus:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Enumera mandata</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Accipe auxilium pro mandato</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Monitio: -paytxfee constitutum valde magnum!  Hoc est merces transactionis solves si mittis transactionem.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Monitio: wallet.data corrupta, data salvata!  Originalis wallet.dat salvata ut wallet.{timestamp}.bak in %s; si pendendum tuum vel transactiones pravae sunt, oportet ab conservato restituere.</translation>
     </message>
@@ -6409,32 +7370,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Monitio: error legendo wallet.dat!  Omnes claves recte lectae, sed data transactionum vel libri inscriptionum fortasse desint vel prava sint.</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-191"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+149"/>
         <source>The wallet will now shutdown. Please start your wallet to begin sync from zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+168"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6490,11 +7436,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Non potuisse auscultare in ulla porta.  Utere -listen=0 si hoc vis.</translation>
     </message>
@@ -6521,16 +7462,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6634,16 +7565,6 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -6666,11 +7587,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6715,17 +7631,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6749,7 +7655,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>No wallet available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6970,82 +7876,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7100,16 +7931,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7119,7 +7940,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ut utaris optione %s</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7128,12 +7949,85 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Si plica non existat, crea eam cum permissionibus ut solus eius dominus eam legere sinatur.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="-224"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+79"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantitas non valida pro -paytxfee=&lt;quantitas&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+28"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7185,6 +8079,11 @@ Si plica non existat, crea eam cum permissionibus ut solus eius dominus eam lege
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7294,6 +8193,16 @@ Si plica non existat, crea eam cum permissionibus ut solus eius dominus eam lege
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7328,18 +8237,18 @@ Si plica non existat, crea eam cum permissionibus ut solus eius dominus eam lege
         <translation>wallet.dat corrupta, salvare abortum est</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Inscriptio -proxy non valida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7364,12 +8273,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+19"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7384,21 +8293,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7439,11 +8334,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7463,7 +8353,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7503,7 +8393,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7539,11 +8429,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7584,11 +8469,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7658,7 +8538,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7673,7 +8553,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Authorized</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7743,7 +8623,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Non posse resolvere -bind inscriptonem: &apos;%s&apos;</translation>
     </message>
@@ -7853,32 +8733,32 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Error legendi wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Legens inscriptiones...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Non posse conglutinare ad %s in hoc computatro (conglutinare redidit errorem %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Quantitas non valida</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+87"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Ignotum rete specificatum in -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Inopia nummorum</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Legens indicem frustorum...</translation>
     </message>
@@ -7888,17 +8768,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Legens cassidile...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Non posse scribere praedefinitam inscriptionem</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Iterum perlegens...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Completo lengendi</translation>
     </message>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">taip</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Trinti</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopijuoti ž&amp;ymę</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Keisti</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Žymė</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(nėra žymės)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Įveskite seną ir naują piniginės slaptafrazes.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Patvirtinkite piniginės užšifravimą</translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Piniginė užšifruota</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Nepavyko užšifruoti piniginės</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Dėl vidinės klaidos nepavyko užšifruoti piniginės.Piniginė neužšifruota.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Įvestos slaptafrazės nesutampa.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Nepavyko atrakinti piniginės</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Neteisingai įvestas slaptažodis piniginės iššifravimui.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Piniginės slaptažodis sėkmingai pakeistas.</translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Piniginė</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Apžvalga</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Išeiti</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Tikrinti žinutę...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Atverti derinimo ir diagnostikos konsolę</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Failas</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Nustatymai</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[testavimotinklas]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,17 +969,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Sandoris nusiųstas</translation>
     </message>
@@ -836,17 +997,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -866,7 +1017,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -884,7 +1035,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -901,7 +1062,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +1077,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Piniginė &lt;b&gt;užšifruota&lt;/b&gt; ir šiuo metu &lt;b&gt;užrakinta&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -932,18 +1093,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +1113,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1040,7 +1205,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1089,7 +1254,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,12 +1262,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Tinklo įspėjimas</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1156,7 +1321,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1211,42 +1376,36 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Suma</translation>
+        <translation type="vanished">Suma</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Patvirtinimai</translation>
+        <translation type="vanished">Patvirtinimai</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Patvirtintas</translation>
+        <translation type="vanished">Patvirtintas</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Žymė</translation>
+        <translation type="vanished">Žymė</translation>
     </message>
     <message>
-        <location line="-424"/>
+        <location line="-376"/>
         <source>Coin Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+429"/>
         <source>Address</source>
-        <translation>Adresas</translation>
+        <translation type="vanished">Adresas</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopijuoti adresą</translation>
     </message>
@@ -1257,17 +1416,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopijuoti sumą</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1297,17 +1456,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>taip</translation>
     </message>
@@ -1347,20 +1506,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(nėra žymės)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(nėra žymės)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Suma</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Žymė</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresas</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Patvirtinimai</translation>
     </message>
 </context>
 <context>
@@ -1386,7 +1582,7 @@ Expires: %3
         <translation type="unfinished">Adresas</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1448,7 +1644,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,37 +1679,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Suma</translation>
+        <translation type="obsolete">Suma</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Žymė</translation>
+        <translation type="obsolete">Žymė</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adresas</translation>
+        <translation type="obsolete">Adresas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Patvirtinimai</translation>
+        <translation type="obsolete">Patvirtinimai</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Patvirtintas</translation>
+        <translation type="obsolete">Patvirtintas</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1548,7 +1738,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,25 +1748,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(nėra žymės)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1726,7 +1905,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1751,7 +1935,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1927,7 +2111,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,6 +2126,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1950,7 +2139,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versija</translation>
     </message>
@@ -1978,7 +2167,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2053,22 +2251,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2132,7 +2330,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2251,6 +2449,373 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Išvalyti &amp;viską</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">taip</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Piniginės atrakinimas atšauktas.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2566,7 +3131,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>numatyta</translation>
     </message>
@@ -2581,7 +3146,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Klaida</translation>
@@ -2809,18 +3374,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopijuoti sumą</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2831,9 +3401,227 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Būsena</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Suma</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2947,7 +3735,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2987,6 +3775,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3022,7 +3815,7 @@ Expires: %3
         <translation type="unfinished">Forma</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3032,7 +3825,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,7 +3848,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3098,6 +3901,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">taip</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
     </message>
 </context>
 <context>
@@ -3182,12 +4062,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3212,12 +4097,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3304,7 +4189,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3342,7 +4227,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">nėra</translation>
     </message>
@@ -3458,14 +4343,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4394,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,12 +4409,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,7 +4447,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3567,6 +4509,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4609,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>nėra</translation>
     </message>
@@ -3798,7 +4745,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4928,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3996,7 +4943,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4054,12 +5001,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4151,40 +5092,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4642,7 +5580,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4763,7 +5701,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4877,7 +5815,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4900,7 +5838,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4912,7 +5850,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5036,7 +5974,7 @@ Expires: %3
         <translation>&amp;Siųsti</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5096,7 +6034,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Negaliojantis gavėjo adresas. Patikrinkite.</translation>
     </message>
@@ -5136,8 +6074,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(nėra žymės)</translation>
     </message>
@@ -5244,7 +6182,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresas</translation>
     </message>
@@ -5382,42 +6320,42 @@ Expires: %3
         <translation>Spragtelėkite &quot;Registruotis žinutę&quot; tam, kad gauti parašą</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Įvestas adresas negalioja.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Prašom patikrinti adresą ir bandyti iš naujo.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Piniginės atrakinimas atšauktas.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Žinutės pasirašymas nepavyko.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Žinutė pasirašyta.</translation>
     </message>
@@ -5428,7 +6366,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Prašom patikrinti parašą ir bandyti iš naujo.</translation>
     </message>
@@ -5479,7 +6417,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5488,32 +6426,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Atidaryta iki %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/neprisijungęs</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepatvirtintas</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 patvirtinimų</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Būsena</translation>
     </message>
@@ -5537,74 +6475,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Šaltinis</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Nuo</translation>
     </message>
@@ -5615,13 +6553,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Kam</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>savo adresas</translation>
@@ -5632,16 +6570,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>žymė</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Kreditas</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5655,31 +6593,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>nepriimta</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debitas</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Sandorio mokestis</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Neto suma</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Žinutė</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Komentaras</translation>
     </message>
@@ -5689,38 +6627,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
@@ -5752,11 +6690,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5776,7 +6719,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Suma</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5805,12 +6748,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Patvirtinta (%1 patvirtinimai)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6035,7 +6978,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Sandorio būklė. Užvedus pelės žymeklį ant šios srities matysite patvirtinimų skaičių.</translation>
     </message>
@@ -6063,7 +7041,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,7 +7096,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minimali suma</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopijuoti adresą</translation>
     </message>
@@ -6148,7 +7131,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Rodyti sandorio detales</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6159,7 +7142,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Patvirtintas</translation>
     </message>
@@ -6204,7 +7187,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6240,19 +7223,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Išeiti</translation>
+        <translation type="obsolete">&amp;Išeiti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Išjungti programą</translation>
+        <translation type="obsolete">Išjungti programą</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Failas</translation>
+        <translation type="obsolete">&amp;Failas</translation>
     </message>
 </context>
 <context>
@@ -6266,7 +7246,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6292,18 +7272,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6378,37 +7358,29 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+488"/>
+        <location filename="../bitcoinstrings.cpp" line="+499"/>
         <source>Usage:</source>
         <translation>Naudojimas:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Komand? s?rašas</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Suteikti pagalba komandai</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>?sp?jimas: -paytxfee yra nustatytas per didelis. Tai sandorio mokestis, kur? tur?site mok?ti, jei si?site sandor?.</translation>
     </message>
     <message>
-        <location line="+187"/>
+        <location line="+179"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Neteisinga suma -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
@@ -6418,7 +7390,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Neteisingas proxy adresas: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-38"/>
+        <location line="-35"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation> wallet.dat pakrovimo klaida,  wallet.dat sugadintas</translation>
     </message>
@@ -6428,18 +7400,41 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation> wallet.dat pakrovimo klaida</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="-304"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+322"/>
         <source>Loading addresses...</source>
         <translation>Užkraunami adresai...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6483,18 +7478,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">nėra</translation>
+        <translation type="obsolete">nėra</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6515,6 +7504,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6729,42 +7723,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6818,7 +7777,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6833,18 +7792,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Nepavyko susieti šiame kompiuteryje prievado %s (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Neteisinga suma</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+344"/>
+        <location line="-394"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6870,17 +7829,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6904,21 +7883,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6959,11 +7924,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6980,6 +7940,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7024,6 +7994,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7064,11 +8039,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7109,11 +8079,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7201,6 +8166,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7212,11 +8182,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7287,16 +8252,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7451,11 +8406,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7482,16 +8432,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7600,16 +8540,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7640,7 +8570,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Užkraunama piniginė...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7650,57 +8580,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
+        <location line="+17"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7757,6 +8637,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7866,6 +8751,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7900,17 +8795,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>Negalima parašyti įprasto adreso</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Peržiūra</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Įkėlimas baigtas</translation>
     </message>

--- a/src/qt/locale/bitcoin_lv_LV.ts
+++ b/src/qt/locale/bitcoin_lv_LV.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Dzēst</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kop?t &amp;Nosaukumu</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Redi??t</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Nosaukums</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(bez nosaukuma)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ierakstiet maci?a veco un jauno paroli.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Apstiprin?t maci?a šifr?šanu</translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Maci?š nošifr?ts</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Maci?a šifr?šana neizdev?s</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Maci?a šifr?šana neizdev?s programmas k??das d??. J?su maci?š netika šifr?ts.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Ievad?t?s paroles nav vien?das.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Maci?u atšifr?t neizdev?s</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Maci?a atšifr?šanai ievad?t? parole nav pareiza.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Maciņš</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Pārskats</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Iziet</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Pārbaudīt ziņojumu...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Atvērt atkļūdošanas un diagnostikas konsoli</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fails</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Uzstādījumi</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,17 +969,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transakcija nosūtīta</translation>
     </message>
@@ -836,17 +997,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -866,7 +1017,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -884,7 +1035,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -901,7 +1062,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +1077,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Maciņš ir &lt;b&gt;šifrēts&lt;/b&gt; un pašlaik &lt;b&gt;slēgts&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -932,18 +1093,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +1113,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1040,7 +1205,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1089,7 +1254,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,12 +1262,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>T?kla br?din?jums</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,7 +1326,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1216,37 +1381,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Daudzums</translation>
+        <translation type="vanished">Daudzums</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Nosaukums</translation>
+        <translation type="obsolete">Nosaukums</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Datums</translation>
+        <translation type="vanished">Datums</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Apstiprinājumi</translation>
+        <translation type="vanished">Apstiprinājumi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Apstiprināts</translation>
+        <translation type="vanished">Apstiprināts</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Adrese</translation>
+        <translation type="vanished">Adrese</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kop?t adresi</translation>
     </message>
@@ -1257,17 +1416,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kop?t daudzumu</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1297,17 +1456,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1347,20 +1506,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(bez nosaukuma)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(bez nosaukuma)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Daudzums</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Nosaukums</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adrese</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Datums</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Apstiprinājumi</translation>
     </message>
 </context>
 <context>
@@ -1386,7 +1582,7 @@ Expires: %3
         <translation type="unfinished">Adrese</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1448,7 +1644,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,37 +1679,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Daudzums</translation>
+        <translation type="obsolete">Daudzums</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Nosaukums</translation>
+        <translation type="obsolete">Nosaukums</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adrese</translation>
+        <translation type="obsolete">Adrese</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Datums</translation>
+        <translation type="obsolete">Datums</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Apstiprinājumi</translation>
+        <translation type="obsolete">Apstiprinājumi</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1548,7 +1734,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,25 +1744,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(bez nosaukuma)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1726,7 +1901,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1751,7 +1931,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1927,7 +2107,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,6 +2122,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1950,7 +2135,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1978,7 +2163,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2053,22 +2247,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2132,7 +2326,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2251,6 +2445,373 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;Notīrīt visu</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2566,7 +3127,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>pēc noklusēšanas</translation>
     </message>
@@ -2581,7 +3142,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Kļūda</translation>
@@ -2809,18 +3370,23 @@ Expires: %3
         <translation>Jūsu kopējā tekošā bilance</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kop?t daudzumu</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2831,9 +3397,227 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Daudzums</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2947,7 +3731,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2987,6 +3771,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3022,7 +3811,7 @@ Expires: %3
         <translation type="unfinished">Forma</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3032,7 +3821,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,7 +3844,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3097,6 +3896,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3182,12 +4058,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3212,12 +4093,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3304,7 +4185,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3342,7 +4223,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3458,14 +4339,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4390,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,12 +4405,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,7 +4443,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3567,6 +4505,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3702,7 +4645,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3783,7 +4726,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4924,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3996,7 +4939,7 @@ Expires: %3
         <translation>Ierakstiet &lt;b&gt;help&lt;/b&gt; lai iegūtu pieejamo komandu sarakstu.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4054,12 +4997,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4151,40 +5088,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4642,7 +5576,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4763,7 +5697,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4877,7 +5811,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4900,7 +5834,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4912,7 +5846,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5036,7 +5970,7 @@ Expires: %3
         <translation>&amp;Sūtīt</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5096,7 +6030,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5136,8 +6070,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(bez nosaukuma)</translation>
     </message>
@@ -5244,7 +6178,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adrese</translation>
     </message>
@@ -5382,42 +6316,42 @@ Expires: %3
         <translation>Atiestatīt visus laukus</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5428,7 +6362,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5479,7 +6413,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5488,32 +6422,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Atv?rts l?dz %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/neapstiprin?tas</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 apstiprin?jumu</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5537,74 +6471,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Datums</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5615,13 +6549,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5632,16 +6566,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5655,31 +6589,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5689,38 +6623,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Daudzums</translation>
     </message>
@@ -5752,11 +6686,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Datums</translation>
     </message>
@@ -5776,7 +6715,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Daudzums</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5805,12 +6744,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Apstiprin?ts (%1 apstiprin?jumu)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6035,7 +6974,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transakcijas statuss. Turiet peli virs š? lauka, lai redz?tu apstiprin?jumu skaitu.</translation>
     </message>
@@ -6063,7 +7037,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,7 +7092,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minim?lais daudzums</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kop?t adresi</translation>
     </message>
@@ -6148,7 +7127,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>R?d?t transakcijas deta?as</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6159,7 +7138,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Apstiprin?ts</translation>
     </message>
@@ -6204,7 +7183,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Diapazons:</translation>
     </message>
@@ -6240,19 +7219,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Iziet</translation>
+        <translation type="obsolete">&amp;Iziet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Aizvērt programmu</translation>
+        <translation type="obsolete">Aizvērt programmu</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fails</translation>
+        <translation type="obsolete">&amp;Fails</translation>
     </message>
 </context>
 <context>
@@ -6266,7 +7242,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6292,18 +7268,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6378,52 +7354,29 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+488"/>
+        <location filename="../bitcoinstrings.cpp" line="+499"/>
         <source>Usage:</source>
         <translation>Lietojums:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Komandu saraksts</translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-360"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+149"/>
         <source>The wallet will now shutdown. Please start your wallet to begin sync from zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+168"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6474,11 +7427,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6505,16 +7453,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6623,16 +7561,6 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -6655,11 +7583,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6704,17 +7627,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6735,6 +7648,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6959,82 +7877,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7085,16 +7928,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7150,6 +7983,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7259,6 +8097,16 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7293,7 +8141,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-305"/>
+        <location line="-282"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7302,7 +8150,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Ja fails neeksist?, izveidojiet to ar at?auju las?šanai tikai ?pašniekam.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="+151"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Neder?gs daudzums priekš -paytxfree=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
@@ -7312,13 +8160,13 @@ Ja fails neeksist?, izveidojiet to ar at?auju las?šanai tikai ?pašniekam.</tra
         <translation>Nederīga -proxy adrese: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7344,17 +8192,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7373,21 +8241,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7428,11 +8282,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7449,6 +8298,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7493,6 +8352,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7528,11 +8392,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7578,11 +8437,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7663,6 +8517,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7677,7 +8536,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Authorized</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7747,7 +8606,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Nevar uzmekl?t -bind adresi: &apos;%s&apos;</translation>
     </message>
@@ -7857,22 +8716,50 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>K??da iel?d?jot wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Ielādē adreses...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Nevar pievienoties pie %s šaj? dator? (pievienošan?s atgrieza k??du %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Neder?gs daudzums</translation>
     </message>
     <message>
-        <location line="+106"/>
+        <location line="-346"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+402"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7887,12 +8774,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>-onlynet komandā norādīts nepazīstams tīkls: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Nepietiek bitkoinu</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Ielādē bloku indeksu...</translation>
     </message>
@@ -7902,17 +8789,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Ielādē maciņu...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Nevar ierakstīt adresi pēc noklusēšanas</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Skanēju no jauna...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Ielāde pabeigta</translation>
     </message>

--- a/src/qt/locale/bitcoin_ms_MY.ts
+++ b/src/qt/locale/bitcoin_ms_MY.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Padam</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -796,17 +957,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -824,17 +985,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -854,7 +1005,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -872,7 +1023,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1050,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -904,12 +1065,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -920,18 +1081,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -941,7 +1101,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1028,7 +1193,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1077,7 +1242,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,12 +1250,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1314,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1369,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Alamat</translation>
+        <translation type="vanished">Alamat</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1245,17 +1384,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1285,17 +1424,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1335,19 +1474,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Alamat</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1374,7 +1550,7 @@ Expires: %3
         <translation type="unfinished">Alamat</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,7 +1612,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1471,37 +1647,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Alamat</translation>
+        <translation type="obsolete">Alamat</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1536,7 +1686,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,24 +1696,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1714,7 +1853,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,7 +1883,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1915,7 +2059,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,6 +2074,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1938,7 +2087,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1966,7 +2115,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2035,22 +2193,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,7 +2272,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2233,6 +2391,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2548,7 +3067,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2563,7 +3082,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
@@ -2791,18 +3310,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2813,9 +3337,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2929,7 +3663,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2969,6 +3703,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3004,7 +3743,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,7 +3753,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3027,7 +3776,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3079,6 +3828,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3164,12 +3990,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3194,12 +4025,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3286,7 +4117,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3324,7 +4155,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3428,14 +4259,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,7 +4310,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,12 +4325,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4363,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,6 +4425,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3647,7 +4540,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3788,7 +4681,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3951,7 +4844,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4859,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4024,12 +4917,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4121,40 +5008,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,7 +5496,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4733,7 +5617,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4847,7 +5731,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4870,7 +5754,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4882,7 +5766,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,7 +5890,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5066,7 +5950,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5106,8 +5990,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,7 +6098,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Alamat</translation>
     </message>
@@ -5352,42 +6236,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5398,7 +6282,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5449,39 +6333,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5503,74 +6387,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5581,13 +6465,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5598,16 +6482,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5619,31 +6503,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5653,38 +6537,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5716,11 +6600,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
@@ -5740,7 +6629,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5767,12 +6656,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5997,7 +6886,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6025,7 +6949,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6080,7 +7004,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6110,7 +7039,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6121,7 +7050,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6166,7 +7095,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6200,24 +7129,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>UpgradeQt</name>
-    <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Quit application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>VoteWizard</name>
     <message>
         <location filename="../forms/voting/votewizard.ui" line="+20"/>
@@ -6228,7 +7139,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6254,18 +7165,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6340,23 +7251,15 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
         <location filename="../bitcoinstrings.cpp" line="+12"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6382,17 +7285,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6416,21 +7339,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6471,11 +7380,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6495,7 +7399,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6535,7 +7439,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6576,11 +7480,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6626,11 +7525,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6717,7 +7611,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6729,11 +7623,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6804,16 +7693,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6993,11 +7872,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7024,16 +7898,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7163,16 +8027,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7218,11 +8072,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Magnitude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7263,21 +8112,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7294,6 +8181,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7523,82 +8415,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7649,16 +8466,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7739,6 +8546,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7844,6 +8656,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>poll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -14,7 +14,7 @@
         <translation>&lt;b&gt;Gridcoin&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nei</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Slett</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopier &amp;Merkelapp</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Rediger</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Eksporter Adressebok</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Merkelapp</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ingen merkelapp)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Angi en adgangsfrase for lommeboken.&lt;br/&gt; Venligst velg en frase med ti eller mer tilfeldige karakterer&lt;b&gt;, eller&lt;b&gt; åtte eller flere ord.&lt;/b&gt;</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Skriv inn gammel og ny adgangsfrase for lommeboken.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Bekreft kryptering av lommebok</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Er du sikker på at du vil kryptere lommeboken?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Lommebok kryptert</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin vil nå lukke applikasjonen for å fullføre krypteringsprosessen. Husk at en fullt kryptert lommebok ikke kan hindre myntene dine fra å bli stjålet hvis datamaskinen din blir infisert av skadevare.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>VIKTIG: Tidligere sikkerhetskopier av din lommebok-fil, bør erstattes med den nylig genererte, krypterte filen, da de blir ugyldiggjort av sikkerhetshensyn så snart du begynner å bruke den nye krypterte lommeboken.</translation>
+        <translation type="vanished">VIKTIG: Tidligere sikkerhetskopier av din lommebok-fil, bør erstattes med den nylig genererte, krypterte filen, da de blir ugyldiggjort av sikkerhetshensyn så snart du begynner å bruke den nye krypterte lommeboken.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Kryptering av lommebok feilet</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Kryptering av lommebok feilet på grunn av en intern feil. Din lommebok ble ikke kryptert.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>De angitte adgangsfrasene er ulike.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Opplåsing av lommebok feilet</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Adgangsfrasen angitt for dekryptering av lommeboken var feil.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Adgangsfrase for lommebok endret.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Lommebok</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Oversikt</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Avslutt</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifiser melding...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Eksporter...</translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Åpne konsoll for feilsøk og diagnostikk</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fil</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Innstillinger</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[testnett]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Sendt transaksjon</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation>Lommeboken er &lt;b&gt;kryptert&lt;/b&gt; og for tiden %1</translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation>&lt;b&gt;Helt låst opp&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Lommeboken er &lt;b&gt;kryptert&lt;/b&gt; og for tiden &lt;b&gt;låst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Backup Mislyktes</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1208,7 @@ Prosjekt(er) ekskludert: %2.</translation>
         <translation>Skraper: Kunne ikke oppå konvergens. Prøver igjen om noen minutter.</translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1088,7 +1257,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1096,12 +1265,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Nettverksvarsel</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,42 +1379,36 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Beløp</translation>
+        <translation type="vanished">Beløp</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Dato</translation>
+        <translation type="vanished">Dato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Bekreftelser</translation>
+        <translation type="vanished">Bekreftelser</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Bekreftet</translation>
+        <translation type="vanished">Bekreftet</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Merkelapp</translation>
+        <translation type="vanished">Merkelapp</translation>
     </message>
     <message>
-        <location line="-424"/>
+        <location line="-376"/>
         <source>Coin Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+429"/>
         <source>Address</source>
-        <translation>Adresse</translation>
+        <translation type="vanished">Adresse</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopier adresse</translation>
     </message>
@@ -1256,17 +1419,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopiér beløp</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopier transaksjons-ID</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopier mengde</translation>
     </message>
@@ -1296,17 +1459,17 @@ Expires: %3
         <translation>Kopier veksel</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>ja</translation>
     </message>
@@ -1348,20 +1511,65 @@ Expires: %3
 Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(ingen merkelapp)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>endring fra %1 (%2)</translation>
+        <translation type="vanished">endring fra %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(endring)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(ingen merkelapp)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">endring fra %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(endring)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Beløp</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(endring)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Merkelapp</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresse</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Dato</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Bekreftelser</translation>
     </message>
 </context>
 <context>
@@ -1387,7 +1595,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished">Adresse</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1449,7 +1657,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1484,37 +1692,31 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Beløp</translation>
+        <translation type="obsolete">Beløp</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Merkelapp</translation>
+        <translation type="obsolete">Merkelapp</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adresse</translation>
+        <translation type="obsolete">Adresse</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Dato</translation>
+        <translation type="obsolete">Dato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Bekreftelser</translation>
+        <translation type="obsolete">Bekreftelser</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Bekreftet</translation>
+        <translation type="obsolete">Bekreftet</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1549,7 +1751,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1559,25 +1761,22 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(ingen merkelapp)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">endring fra %1 (%2)</translation>
+        <translation type="obsolete">endring fra %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(endring)</translation>
+        <translation type="obsolete">(endring)</translation>
     </message>
 </context>
 <context>
@@ -1727,7 +1926,12 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1752,7 +1956,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1928,7 +2132,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1943,6 +2147,11 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1951,7 +2160,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versjon</translation>
     </message>
@@ -1979,7 +2188,16 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2051,22 +2269,22 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2130,7 +2348,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2249,6 +2467,370 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Fjern &amp;Alt</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">nei</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Opplåsing av lommebok ble avbrutt.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2564,7 +3146,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation>&amp;Avbryt</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>standardverdi</translation>
     </message>
@@ -2579,7 +3161,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Feil</translation>
@@ -2807,18 +3389,23 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation>Din nåværende saldo</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopiér beløp</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2829,9 +3416,223 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Beløp</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2945,7 +3746,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2985,6 +3786,11 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3020,7 +3826,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished">Skjema</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3030,7 +3836,17 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3043,7 +3859,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3096,6 +3912,83 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished">Ingen</translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nei</translation>
     </message>
 </context>
 <context>
@@ -3180,12 +4073,17 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3210,12 +4108,12 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3302,7 +4200,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3340,7 +4238,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">-</translation>
     </message>
@@ -3450,14 +4348,48 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3467,7 +4399,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3482,12 +4414,35 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3497,7 +4452,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3559,6 +4514,11 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3654,7 +4614,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>-</translation>
     </message>
@@ -3770,7 +4730,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3973,7 +4933,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3988,7 +4948,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation>Skriv &lt;b&gt;help&lt;/b&gt; for en oversikt over kommandoer.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4046,12 +5006,6 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4143,40 +5097,37 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4634,7 +5585,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4755,7 +5706,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4869,7 +5820,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4892,7 +5843,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4904,7 +5855,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5028,7 +5979,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopier mengde</translation>
     </message>
@@ -5088,7 +6039,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation>og</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresse for mottaker er ugyldig.</translation>
     </message>
@@ -5128,8 +6079,8 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(ingen merkelapp)</translation>
     </message>
@@ -5236,7 +6187,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresse</translation>
     </message>
@@ -5374,42 +6325,42 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
         <translation>Klikk &quot;Signer Melding&quot; for å generere signatur</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Angitt adresse er ugyldig.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Vennligst sjekk adressen og prøv igjen.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Angitt adresse refererer ikke til en nøkkel.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Opplåsing av lommebok ble avbrutt.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Privat nøkkel for den angitte adressen er ikke tilgjengelig.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Signering av melding feilet.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Melding signert.</translation>
     </message>
@@ -5420,7 +6371,7 @@ Dette betyr at det trengs en avgift på minimum %2.</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Vennligst sjekk signaturen og prøv igjen.</translation>
     </message>
@@ -5471,7 +6422,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5479,32 +6430,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Åpen til %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/frakoblet</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/ubekreftet</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 bekreftelser</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5527,74 +6478,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Fra</translation>
     </message>
@@ -5605,13 +6556,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Til</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>egen adresse</translation>
@@ -5622,16 +6573,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>merkelapp</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Kredit</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5644,31 +6595,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>ikke akseptert</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debet</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Transaksjonsgebyr</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Nettobeløp</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Melding</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
@@ -5678,38 +6629,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Beløp</translation>
     </message>
@@ -5741,11 +6692,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
@@ -5765,7 +6721,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5793,12 +6749,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bekreftet (%1 bekreftelser)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6023,7 +6979,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transaksjonsstatus. Hold muspekeren over dette feltet for å se antall bekreftelser.</translation>
     </message>
@@ -6051,7 +7042,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6106,7 +7097,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minimumsbeløp</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopier adresse</translation>
     </message>
@@ -6136,7 +7132,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Vis transaksjonsdetaljer</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6147,7 +7143,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Bekreftet</translation>
     </message>
@@ -6192,7 +7188,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Feil under eksportering</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Intervall:</translation>
     </message>
@@ -6228,19 +7224,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Avslutt</translation>
+        <translation type="obsolete">&amp;Avslutt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Avslutt applikasjonen</translation>
+        <translation type="obsolete">Avslutt applikasjonen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fil</translation>
+        <translation type="obsolete">&amp;Fil</translation>
     </message>
 </context>
 <context>
@@ -6254,7 +7247,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6280,18 +7273,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6368,15 +7361,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Sender...</translation>
+        <translation type="vanished">Sender...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>En feil oppstod under oppsettet av RPC port %u for IPv6, tilbakestilles til IPv4: %s</translation>
     </message>
@@ -6386,27 +7378,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>En feil oppstod ved opprettelse av RPC port %u for lytting: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Bruk:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>List opp kommandoer</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Vis hjelpetekst for en kommando</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Advarsel: -paytxfee er satt veldig høyt! Dette er transaksjonsgebyret du betaler når du sender transaksjoner.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Advarsel: wallet.dat korrupt, data reddet! Original wallet.dat lagret som wallet.{timestamp}.bak i %s; hvis din saldo eller dine transaksjoner ikke er korrekte bør du gjenopprette fra en backup.</translation>
     </message>
@@ -6416,13 +7408,13 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Advarsel: Feil ved lesing av wallet.dat! Alle taster lest riktig, men transaksjon dataene eller adresse innlegg er kanskje manglende eller feil.</translation>
     </message>
     <message>
-        <location line="-191"/>
-        <location line="+344"/>
+        <location line="-228"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6447,12 +7439,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6472,21 +7464,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6527,11 +7505,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6551,7 +7524,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6591,7 +7564,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6632,11 +7605,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6677,11 +7645,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6751,7 +7714,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6763,11 +7726,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6838,16 +7796,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6992,11 +7940,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Kunne ikke lytte på noen port. Bruk -listen=0 hvis det er dette du vil.</translation>
     </message>
@@ -7023,16 +7966,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7136,16 +8069,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7168,11 +8091,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7216,18 +8134,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">-</translation>
+        <translation type="obsolete">-</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7248,6 +8160,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7471,78 +8388,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7597,16 +8444,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7616,7 +8453,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>For å bruke %s opsjonen</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7625,12 +8462,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Hvis filen ikke finnes, opprett den med leserettighet kun for eier av filen.</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="+151"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ugyldig beløp for -paytxfee=&lt;beløp&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+88"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7685,7 +8522,80 @@ Hvis filen ikke finnes, opprett den med leserettighet kun for eier av filen.</tr
         <translation>Verifiserer databasens integritet...</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
         <source>Wrong Payload version specified for current block height.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7751,6 +8661,16 @@ Hvis filen ikke finnes, opprett den med leserettighet kun for eier av filen.</tr
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7785,12 +8705,12 @@ Hvis filen ikke finnes, opprett den med leserettighet kun for eier av filen.</tr
         <translation>wallet.dat korrupt, bergning feilet</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ugyldig -proxy adresse: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-58"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kunne ikke slå opp -bind adresse: &apos;%s&apos;</translation>
     </message>
@@ -7810,27 +8730,26 @@ Hvis filen ikke finnes, opprett den med leserettighet kun for eier av filen.</tr
         <translation>Feil ved lasting av wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Laster adresser...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Kan ikke binde til %s på denne datamaskinen (bind returnerte feil %d, %s)</translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Sending...</source>
-        <translation>Sender...</translation>
+        <translation type="vanished">Sender...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Ugyldig beløp</translation>
     </message>
     <message>
-        <location line="+119"/>
+        <location line="+99"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7870,17 +8789,17 @@ Hvis filen ikke finnes, opprett den med leserettighet kun for eier av filen.</tr
         <translation>Advarsel: Lite lagringsplass!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Ukjent nettverk angitt i -onlynet &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Utilstrekkelige midler</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Laster blokkindeks...</translation>
     </message>
@@ -7890,17 +8809,17 @@ Hvis filen ikke finnes, opprett den med leserettighet kun for eier av filen.</tr
         <translation>Laster lommebok...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Kan ikke skrive standardadresse</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Leser gjennom...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Ferdig med lasting</translation>
     </message>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nee</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verwijder</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopieer &amp;Label</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Bewerk</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exporteer Adresboek Data</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(geen label)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Alleen voor staking</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Voer een nieuw wachtwoord in voor uw portemonnee.&lt;br/&gt;Gebruik een wachtwoord van &lt;b&gt;tien of meer willekeurige karakters&lt;/b&gt;, of &lt;b&gt;acht of meer woorden&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Vul uw oude en nieuwe portemonneewachtwoord in.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Bevestig versleuteling van de portemonnee</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Weet u zeker dat u uw portemonnee wilt versleutelen?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Portemonnee versleuteld</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin zal nu sluiten om het versleutel proces te voltooien. Onthou dat het versleutelen van je portemonnee je niet volledig beschermt tegen diefstal van munten door malware op je computer.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>BELANGRIJK: Elke eerder gemaakte backup van uw portemonneebestand dient u te vervangen door het nieuw gegenereerde, versleutelde portemonneebestand. Om veiligheidsredenen zullen eerdere backups van het niet-versleutelde portemonneebestand onbruikbaar worden zodra u uw nieuwe, versleutelde, portemonnee begint te gebruiken.</translation>
+        <translation type="vanished">BELANGRIJK: Elke eerder gemaakte backup van uw portemonneebestand dient u te vervangen door het nieuw gegenereerde, versleutelde portemonneebestand. Om veiligheidsredenen zullen eerdere backups van het niet-versleutelde portemonneebestand onbruikbaar worden zodra u uw nieuwe, versleutelde, portemonnee begint te gebruiken.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Portemonneeversleuteling mislukt</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Portemonneeversleuteling mislukt door een interne fout. Uw portemonnee is niet versleuteld.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>De opgegeven wachtwoorden komen niet overeen</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Portemonnee openen mislukt</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Het opgegeven wachtwoord voor de portemonnee-ontsleuteling is niet correct.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Portemonneewachtwoord is met succes gewijzigd.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Een fatale fout . Gridcoin kan niet langer veilig doorgaan en sluit af.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Portemonnee</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Overzicht</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>A&amp;fsluiten</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifiëer bericht...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Exporteren...</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Open debugging en diagnostische console</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Bestand</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Instellingen</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[testnetwerk]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +972,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Laatst ontvangen blok is gegenereerd op %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>De grootte van deze transactie overschrijdt de limiet. U kan deze transactie laten uitvoeren voor een meerkost van %1, dewelke doorgestuurd wordt naar de nodes die uw transactie verwerken, alsook ter ondersteuning van het netwerk. Wil u deze meerkost betalen?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Bevestig transactie kosten</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Verstuurde transactie</translation>
     </message>
@@ -835,17 +1000,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -865,7 +1020,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -883,7 +1038,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>URI-behandeling</translation>
@@ -900,7 +1065,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -915,12 +1080,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Portemonnee is &lt;b&gt;versleuteld&lt;/b&gt; en momenteel &lt;b&gt;gesloten&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Backup Portemonnee</translation>
     </message>
@@ -931,18 +1096,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Backup mislukt</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Er was een fout opgetreden bij het opslaan van de wallet data naar de nieuwe locatie.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,7 +1116,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1039,7 +1208,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Netwerkwaarschuwing</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Bedrag</translation>
+        <translation type="vanished">Bedrag</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Datum</translation>
+        <translation type="vanished">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Bevestigingen</translation>
+        <translation type="vanished">Bevestigingen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Bevestigd</translation>
+        <translation type="vanished">Bevestigd</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Adres</translation>
+        <translation type="vanished">Adres</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopieer adres</translation>
     </message>
@@ -1251,17 +1410,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopieer transactie-ID</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopieer aantal</translation>
     </message>
@@ -1291,17 +1450,17 @@ Expires: %3
         <translation>Kopieer wijziging</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>STOF</translation>
     </message>
@@ -1351,20 +1510,65 @@ Bedragen onder 0.546 keer het minimum vergoeding worden weergegeven als DUST.</t
 Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(geen label)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>wijzig van %1 (%2)</translation>
+        <translation type="vanished">wijzig van %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(wijzig)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(geen label)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">wijzig van %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(wijzig)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Bedrag</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(wijzig)</translation>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adres</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Bevestigingen</translation>
     </message>
 </context>
 <context>
@@ -1390,7 +1594,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished">Adres</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1452,7 +1656,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,37 +1691,27 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Bedrag</translation>
+        <translation type="obsolete">Bedrag</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adres</translation>
+        <translation type="obsolete">Adres</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Datum</translation>
+        <translation type="obsolete">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Bevestigingen</translation>
+        <translation type="obsolete">Bevestigingen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Bevestigd</translation>
+        <translation type="obsolete">Bevestigd</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,7 +1746,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1562,25 +1756,22 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(geen label)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">wijzig van %1 (%2)</translation>
+        <translation type="obsolete">wijzig van %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(wijzig)</translation>
+        <translation type="obsolete">(wijzig)</translation>
     </message>
 </context>
 <context>
@@ -1730,7 +1921,12 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1755,7 +1951,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1931,7 +2127,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1946,6 +2142,11 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1954,7 +2155,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versie</translation>
     </message>
@@ -1982,7 +2183,16 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2054,22 +2264,22 @@ Dit betekend dat een fee van %2 is vereist.</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2133,7 +2343,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2252,6 +2462,370 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Verwijder &amp;Alles</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">nee</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Portemonnee-ontsleuteling is geannuleerd.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2567,7 +3141,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation>&amp;Annuleren</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>standaard</translation>
     </message>
@@ -2582,7 +3156,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Fout</translation>
@@ -2810,18 +3384,23 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation>Uw totale saldo</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2832,9 +3411,223 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Bedrag</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2948,7 +3741,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2988,6 +3781,11 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3023,7 +3821,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished">Vorm</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3033,7 +3831,17 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3046,7 +3854,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3099,6 +3907,83 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nee</translation>
     </message>
 </context>
 <context>
@@ -3183,12 +4068,17 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3213,12 +4103,12 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3305,7 +4195,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3343,7 +4233,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">N.v.t.</translation>
     </message>
@@ -3453,14 +4343,48 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3470,7 +4394,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3485,12 +4409,35 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,7 +4447,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3562,6 +4509,11 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3657,7 +4609,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>N.v.t.</translation>
     </message>
@@ -3788,7 +4740,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3976,7 +4928,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3991,7 +4943,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation>Typ &lt;b&gt;help&lt;/b&gt; voor een overzicht van de beschikbare opdrachten.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4049,12 +5001,6 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4146,40 +5092,37 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4637,7 +5580,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4758,7 +5701,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4872,7 +5815,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4895,7 +5838,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4907,7 +5850,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5031,7 +5974,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation>V&amp;erstuur</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopieer aantal</translation>
     </message>
@@ -5091,7 +6034,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation>en</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Het ontvangstadres is niet geldig, controleer uw invoer.</translation>
     </message>
@@ -5131,8 +6074,8 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation>Fout: De transactie was geweigerd, Dit kan gebeuren als sommige munten in je portemonnee al gebruikt zijn, door het gebruik van een kopie van wallet.dat en de munten in de kopie zijn niet gemarkeerd als gebruikt.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(geen label)</translation>
     </message>
@@ -5239,7 +6182,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adres</translation>
     </message>
@@ -5377,42 +6320,42 @@ Dit betekend dat een fee van %2 is vereist.</translation>
         <translation>Voer Gridcoin handtekening in</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Het opgegeven adres is ongeldig.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Controleer het adres en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Het opgegeven adres verwijst niet naar een sleutel.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Portemonnee-ontsleuteling is geannuleerd.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Geheime sleutel voor het ingevoerde adres is niet beschikbaar.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Ondertekenen van het bericht is mislukt.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Bericht ondertekend.</translation>
     </message>
@@ -5423,7 +6366,7 @@ Dit betekend dat een fee van %2 is vereist.</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Controleer de handtekening en probeer het opnieuw.</translation>
     </message>
@@ -5474,7 +6417,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5482,32 +6425,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Open tot %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/onbevestigd</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 bevestigingen</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5530,74 +6473,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Bron</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Van</translation>
     </message>
@@ -5608,13 +6551,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Aan</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>eigen adres</translation>
@@ -5625,16 +6568,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5647,31 +6590,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>niet geaccepteerd</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debet</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Transactiekosten</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Netto bedrag</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Bericht</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Opmerking</translation>
     </message>
@@ -5681,38 +6624,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
@@ -5744,11 +6687,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -5768,7 +6716,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5796,12 +6744,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bevestigd (%1 bevestigingen)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Conflicterend</translation>
     </message>
@@ -6026,7 +6974,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transactiestatus. Houd de cursor boven dit veld om het aantal bevestigingen te laten zien.</translation>
     </message>
@@ -6054,7 +7037,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6109,7 +7092,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Min. bedrag</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopieer adres</translation>
     </message>
@@ -6139,7 +7127,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Toon transactiedetails</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exporteer Transactie Data</translation>
     </message>
@@ -6150,7 +7138,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Bevestigd</translation>
     </message>
@@ -6195,7 +7183,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kan niet schrijven naar bestand %1</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Bereik:</translation>
     </message>
@@ -6231,19 +7219,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">A&amp;fsluiten</translation>
+        <translation type="obsolete">A&amp;fsluiten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Programma afsluiten</translation>
+        <translation type="obsolete">Programma afsluiten</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Bestand</translation>
+        <translation type="obsolete">&amp;Bestand</translation>
     </message>
 </context>
 <context>
@@ -6257,7 +7242,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6283,18 +7268,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6371,15 +7356,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Versturen...</translation>
+        <translation type="vanished">Versturen...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Er is een fout opgetreden tijdens het instellen van de inkomende RPC-poort %u op IPv6, terugval naar IPv4: %s</translation>
     </message>
@@ -6389,27 +7373,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Er is een fout opgetreden tijdens het instellen van de inkomende RPC-poort %u op IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Gebruik:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lijst van commando&apos;s</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Toon hulp voor een commando</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Waarschuwing: -paytxfee is zeer hoog ingesteld.  Dit zijn de transactiekosten die u betaalt bij het versturen van een transactie.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Waarschuwing: wallet.dat is corrupt, data is veiliggesteld! Originele wallet.dat is opgeslagen als wallet.{tijdstip}.bak in %s; als uw balans of transacties incorrect zijn dient u een backup terug te zetten.</translation>
     </message>
@@ -6419,7 +7403,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Waarschuwing: Fout bij het lezen van wallet.dat! Alle sleutels zijn in goede orde uitgelezen, maar transactiedata of adresboeklemma&apos;s zouden kunnen ontbreken of fouten bevatten.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Fout: Creëren van transactie mislukt.</translation>
     </message>
@@ -6429,17 +7413,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Fout: De transactie was geweigerd, Dit kan gebeuren als sommige munten in je portemonnee al gebruikt zijn, door het gebruik van een kopie van wallet.dat en de munten in de kopie zijn niet gemarkeerd als gebruikt.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Mislukt om op welke poort dan ook te luisteren. Gebruik -listen=0 as u dit wilt.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Om de %s optie te gebruiken</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -6448,7 +7432,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Als het bestand niet bestaat, maak het dan aan, met een alleen-lezen permissie.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Gridcoin versie</translation>
     </message>
@@ -6463,7 +7447,7 @@ Als het bestand niet bestaat, maak het dan aan, met een alleen-lezen permissie.<
         <translation>Ongeldig bedrag voor -mininput = &lt;bedrag&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+101"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Portemonnee %s bevindt zich buiten de datamap %s.</translation>
     </message>
@@ -6473,12 +7457,85 @@ Als het bestand niet bestaat, maak het dan aan, met een alleen-lezen permissie.<
         <translation>Database integriteit wordt geverifieërd</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Fout bij het ??initialiseren van de database omgeving %s! Om te herstellen, BACKUP die directory, verwijder dan alles van behalve het wallet.dat.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6569,6 +7626,16 @@ Als het bestand niet bestaat, maak het dan aan, met een alleen-lezen permissie.<
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6603,7 +7670,7 @@ Als het bestand niet bestaat, maak het dan aan, met een alleen-lezen permissie.<
         <translation>wallet.dat corrupt, veiligstellen mislukt</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ongeldig -proxy adres: &apos;%s&apos;</translation>
     </message>
@@ -6613,7 +7680,7 @@ Als het bestand niet bestaat, maak het dan aan, met een alleen-lezen permissie.<
         <translation>Ongeldig-tor adres: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kan -bind adres niet herleiden: &apos;%s&apos;</translation>
     </message>
@@ -6623,23 +7690,23 @@ Als het bestand niet bestaat, maak het dan aan, met een alleen-lezen permissie.<
         <translation>Kan -externlip adres niet herleiden: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Ongeldig bedrag voor -reservebalance = &lt;bedrag&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Fout bij laden van blkindex.dat</translation>
     </message>
     <message>
-        <location line="-316"/>
-        <location line="+344"/>
+        <location line="-351"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6664,12 +7731,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6689,21 +7756,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6729,11 +7782,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6753,7 +7801,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6793,7 +7841,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6829,11 +7877,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6873,12 +7916,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6943,7 +7981,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6955,11 +7993,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7030,16 +8063,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7163,11 +8186,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7190,16 +8208,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7278,16 +8286,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7310,11 +8308,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7358,18 +8351,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">N.v.t.</translation>
+        <translation type="obsolete">N.v.t.</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7390,6 +8377,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7613,78 +8605,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7739,16 +8661,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7798,7 +8710,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7808,37 +8720,37 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Portemonnee moet herschreven worden: herstart Gridcoin om te voltooien</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Fout bij laden wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Importeren van blokketen data bestand.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Adressen aan het laden...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Fout: kan geen verbinding maken met node</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Niet mogelijk om %s op deze computer. Gridcoin is waarschijnlijk al geopened.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Niet in staat om aan %s te binden op deze computer (bind gaf error %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Fout: Portemonnee is op slot, niet mogelijk een transactie te creëren.</translation>
     </message>
@@ -7853,37 +8765,36 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Fout: Deze transactie vereist een transactie vergoeding van ten minste %s vanwege de hoeveelheid, complexiteit, of het gebruik van recent ontvangen gelden</translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Versturen...</translation>
+        <translation type="vanished">Versturen...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Ongeldig bedrag</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Waarschuwing: Controleer of de datum en tijd van de computer juist zijn! Als uw klok verkeerd is Gridcoin zal niet goed werken.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Waarschuwing: Hardeschijf raakt vol!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Onbekend netwerk gespecificeerd in -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Ontoereikend saldo</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Blokindex aan het laden...</translation>
     </message>
@@ -7893,17 +8804,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Portemonnee aan het laden...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Kan standaardadres niet schrijven</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Blokketen aan het herscannen...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Klaar met laden</translation>
     </message>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -14,7 +14,7 @@
         <translation>Gridcoin </translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -34,7 +34,7 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,11 +43,51 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,6 +100,41 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">tak</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nie</translation>
     </message>
 </context>
 <context>
@@ -145,7 +220,17 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation>&amp;Usuń</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopiuj Etykietę (&amp;L)</translation>
     </message>
@@ -155,7 +240,7 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation>&amp;Edytuj</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Eksportuj Książkę Adresową</translation>
     </message>
@@ -179,7 +264,7 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etykieta</translation>
     </message>
@@ -190,8 +275,19 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(brak etykiety)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -227,7 +323,7 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation>Tylko do gromadzenia (staking)</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Wprowadź nowe hasło do portfela.&lt;br/&gt;Proszę używać hasła złożonego z &lt;b&gt;10 lub więcej losowych znaków&lt;/b&gt; albo &lt;b&gt;8 lub więcej słów&lt;/b&gt;.</translation>
     </message>
@@ -257,7 +353,7 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation>Podaj stare i nowe hasło do portfela.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Potwierdź szyfrowanie portfela</translation>
     </message>
@@ -272,58 +368,82 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation>Jesteś pewien, że chcesz zaszyfrować swój portfel?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Portfel zaszyfrowany</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Portfel teraz się zamknie w celu dokończenia procesu szyfrowania. Uwaga! Zaszyfrowanie portfela nie gwarantuje, że twoje pieniądze nie zostaną skradzione jeśli twój komputer jest zainfekowany malware.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>WAŻNE: Wszystkie wykonane wcześniej kopie pliku portfela powinny być zamienione na nowe, szyfrowane pliki. Z powodów bezpieczeństwa, poprzednie kopie nieszyfrowanych plików portfela staną się bezużyteczne jak tylko zaczniesz korzystać z nowego, szyfrowanego portfela.</translation>
+        <translation type="vanished">WAŻNE: Wszystkie wykonane wcześniej kopie pliku portfela powinny być zamienione na nowe, szyfrowane pliki. Z powodów bezpieczeństwa, poprzednie kopie nieszyfrowanych plików portfela staną się bezużyteczne jak tylko zaczniesz korzystać z nowego, szyfrowanego portfela.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Szyfrowanie portfela nie powiodło się</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Szyfrowanie portfela nie powiodło się z powodu wewnętrznego błędu. Twój portfel nie został zaszyfrowany.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Podane hasła nie są takie same.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Odblokowanie portfela nie powiodło się</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Wprowadzone hasło do odszyfrowania portfela jest niepoprawne.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Hasło do portfela zostało pomyślnie zmienione.</translation>
     </message>
@@ -348,7 +468,7 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -361,12 +481,12 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Błąd krytyczny. Portfel gridcoin nie może kontynuować i się zamknie.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Portfel</translation>
     </message>
@@ -376,7 +496,12 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>P&amp;odsumowanie</translation>
     </message>
@@ -512,7 +637,7 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Zakończ</translation>
     </message>
@@ -637,6 +762,11 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation>&amp;Zweryfikuj wiadomość...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Eksportuj...</translation>
@@ -657,17 +787,17 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation>Otwórz konsolę debugowania i diagnostyki</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -687,12 +817,32 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Plik</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>P&amp;referencje</translation>
     </message>
@@ -727,19 +877,34 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Klient Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -818,17 +983,17 @@ Ten produkt zawiera oprogramowanie stworzone przez OpenSSL Project do użytku pr
         <translation>Ostatni odebrany blok został wygenerowany %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Ta transakcja jest poza limitem. Wciąż możesz ją wysłać za opłatą %1, która zostanie przekazana do gałęzi, które przetwarzają twoją transakcję i wesprze sieć. Czy chcesz uiścić opłatę?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Potwierdź opłatę tranzakcyjną</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transakcja wysłana</translation>
     </message>
@@ -846,17 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -876,7 +1031,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -894,7 +1049,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Obsługa URI</translation>
@@ -911,7 +1076,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,12 +1091,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Portfel jest &lt;b&gt;zaszyfrowany&lt;/b&gt; i obecnie &lt;b&gt;zablokowany&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Kopia zapasowa portfela</translation>
     </message>
@@ -942,18 +1107,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Nie udało się wykonać kopii zapasowej</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Wystąpił problem przy zapisie danych portfela w nowym miejscu.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -963,7 +1127,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1050,7 +1219,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1102,12 +1271,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Ostrzeżenie sieci</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1166,7 +1335,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1216,42 +1385,36 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Kwota</translation>
+        <translation type="vanished">Kwota</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Potwierdzenia</translation>
+        <translation type="vanished">Potwierdzenia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Potwierdzony</translation>
+        <translation type="vanished">Potwierdzony</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Etykieta</translation>
+        <translation type="vanished">Etykieta</translation>
     </message>
     <message>
-        <location line="-128"/>
+        <location line="-80"/>
         <source>&amp;List mode</source>
         <translation>Wi&amp;dok listy</translation>
     </message>
     <message>
-        <location line="+133"/>
         <source>Address</source>
-        <translation>Adres</translation>
+        <translation type="vanished">Adres</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopiuj adres</translation>
     </message>
@@ -1262,17 +1425,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopiuj kwotę</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Skopiuj ID transakcji</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Skopiuj ilość</translation>
     </message>
@@ -1302,17 +1465,17 @@ Expires: %3
         <translation>Skopiuj resztę</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>tak</translation>
     </message>
@@ -1362,20 +1525,65 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
  Oznacza to opłatę w wysokości conajmniej %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(brak etykiety)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>reszta z %1 (%2)</translation>
+        <translation type="vanished">reszta z %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(reszta)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(brak etykiety)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">reszta z %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(reszta)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Kwota</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(reszta)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etykieta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adres</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Potwierdzenia</translation>
     </message>
 </context>
 <context>
@@ -1401,7 +1609,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished">Adres</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1463,7 +1671,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1498,37 +1706,31 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Kwota</translation>
+        <translation type="obsolete">Kwota</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etykieta</translation>
+        <translation type="obsolete">Etykieta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adres</translation>
+        <translation type="obsolete">Adres</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Potwierdzenia</translation>
+        <translation type="obsolete">Potwierdzenia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Potwierdzony</translation>
+        <translation type="obsolete">Potwierdzony</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1563,7 +1765,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1573,25 +1775,22 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(brak etykiety)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">reszta z %1 (%2)</translation>
+        <translation type="obsolete">reszta z %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(reszta)</translation>
+        <translation type="obsolete">(reszta)</translation>
     </message>
 </context>
 <context>
@@ -1741,7 +1940,12 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1766,7 +1970,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,7 +2146,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1957,6 +2161,11 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1965,7 +2174,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>wersja</translation>
     </message>
@@ -1993,7 +2202,16 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2068,22 +2286,22 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2147,7 +2365,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2266,6 +2484,373 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Wyczyść &amp;wszystko</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">tak</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">nie</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Odblokowanie portfela zostało anulowane.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2581,7 +3166,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation>&amp;Anuluj</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>domyślny</translation>
     </message>
@@ -2596,7 +3181,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation>Jasny</translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
@@ -2824,18 +3409,23 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopiuj kwotę</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2846,9 +3436,227 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Kwota</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2962,7 +3770,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3002,6 +3810,11 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3037,7 +3850,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished">Formularz</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3047,7 +3860,17 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3060,7 +3883,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3113,6 +3936,83 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">tak</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nie</translation>
     </message>
 </context>
 <context>
@@ -3197,12 +4097,17 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3227,12 +4132,12 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3319,7 +4224,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3357,7 +4262,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">NIEDOSTĘPNE</translation>
     </message>
@@ -3473,14 +4378,48 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4429,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,12 +4444,35 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3520,7 +4482,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3582,6 +4544,11 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3677,7 +4644,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>NIEDOSTĘPNE</translation>
     </message>
@@ -3748,7 +4715,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3996,7 +4963,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation>Witaj w konsoli RPC! </translation>
     </message>
@@ -4011,7 +4978,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation>Wpisz &lt;b&gt;help&lt;/b&gt; aby uzyskać listę dostępnych komend.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4069,12 +5036,6 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4166,40 +5127,37 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4657,7 +5615,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4778,7 +5736,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4892,7 +5850,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4915,7 +5873,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4927,7 +5885,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5051,7 +6009,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation>Wprowadź adres Gridcoin (n.p. S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopiuj ilość</translation>
     </message>
@@ -5111,7 +6069,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation> i </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adres odbiorcy jest nieprawidłowy, proszę poprawić.</translation>
     </message>
@@ -5151,8 +6109,8 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation>Błąd: Transakcja odrzucona. Przyczyną może być, że część twoich monet w portfelu zostały już wydane. Kiedy n.p. użyłeś kopii wallet.dat i monety zostały w nim wydane oraz oznaczaone, ale nie oznaczone tutaj.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(brak etykiety)</translation>
     </message>
@@ -5259,7 +6217,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adres</translation>
     </message>
@@ -5397,42 +6355,42 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
         <translation>Wprowadź podpis Gridcoin</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Podany adres jest nieprawid?owy.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Proszę sprawdziś adres i spróbować ponownie.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Wprowadzony adres nie odnosi się do klucza.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Odblokowanie portfela zostało anulowane.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Klucz prywatny dla podanego adresu nie jest dostępny.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Podpisanie wiadomości nie powiodło się.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Wiadomość podpisana.</translation>
     </message>
@@ -5443,7 +6401,7 @@ Wartości poniżej 0.546*minimalna wartość przekazu. są traktowane jako &quot
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Sprawdź podpis i spróbuj ponownie.</translation>
     </message>
@@ -5494,7 +6452,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5503,32 +6461,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Otwórz do %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>konflikt</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/niezatwierdzone</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potwierdzeń</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5552,74 +6510,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Źródło</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
@@ -5630,13 +6588,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Do</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>własny adres</translation>
@@ -5647,16 +6605,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etykieta</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Przypisy</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5670,31 +6628,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>niezaakceptowane</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Debet</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Prowizja transakcji</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Kwota netto</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Wiadomość</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Komentarz</translation>
     </message>
@@ -5704,38 +6662,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Wygenerowane money musza &quot;dojrzeć&quot; przez 110 bloków zanim mogą zostać użyte. Kiedy wygenerowałeś ten blok, ogłoszenie zostało rozesłane do sieci aby go dodać do sieci bloków. Jeśli się nie powiedzie, jego status zostanie zmieniony na  &quot;brak akceptacji&quot; i nie będzie można go użyć. Może się to czasem zdarzyć jeśli inna gałąź wygeneruje blok w przeciągu kilku sekund od twojego.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Kwota</translation>
     </message>
@@ -5767,11 +6725,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation>Z&amp;amknij</translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5791,7 +6754,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kwota</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5820,12 +6783,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Potwierdzanie (%1 z %2 zalecanych potwierdzeń)&lt;br&gt;</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Zatwierdzony (%1 potwierdzeń)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Kolidujące</translation>
     </message>
@@ -6050,7 +7013,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status transakcji. Najedź na pole, aby zobaczyć liczbę potwierdzeń.</translation>
     </message>
@@ -6078,7 +7076,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6133,7 +7131,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Min suma</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopiuj adres</translation>
     </message>
@@ -6163,7 +7166,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Pokaż szczegóły transakcji</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Eksportuj dane transakcji</translation>
     </message>
@@ -6174,7 +7177,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Potwierdzony</translation>
     </message>
@@ -6219,7 +7222,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Nie można zapisać do pliku %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Zakres:</translation>
     </message>
@@ -6255,19 +7258,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Zakończ</translation>
+        <translation type="obsolete">&amp;Zakończ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Zamknij program</translation>
+        <translation type="obsolete">Zamknij program</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Plik</translation>
+        <translation type="obsolete">&amp;Plik</translation>
     </message>
 </context>
 <context>
@@ -6281,7 +7281,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6307,18 +7307,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6395,15 +7395,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Wysyłanie...</translation>
+        <translation type="vanished">Wysyłanie...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Wystąpił błąd podczas ustawiania portu RPC %u w tryb nasłuchu dla IPv6, korzystam z IPv4: %s</translation>
     </message>
@@ -6413,27 +7412,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Wystąpił błąd podczas ustawiania portu RPC %u w tryb nasłuchu: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Użycie:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lista poleceń</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Uzyskaj pomoc do polecenia</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Ostrzeżenie: -paytxfee jest bardzo duży. To jest prowizja za transakcje, którą płacisz, gdy wysyłasz monety.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Ostrzeżenie: Odtworzono dane z uszkodzonego pliku wallet.dat! Oryginalny wallet.dat został zapisany jako wallet.{timestamp}.bak w %s; jeżli twoje saldo lub transakcje są niepoprawne powinieneś odtworzyć kopię zapasową.</translation>
     </message>
@@ -6443,7 +7442,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ostrzeżenie: błąd odczytu wallet.dat! Wszystkie klucze zostały odczytane, ale może brakować pewnych danych transakcji lub wpisów w książce adresowej lub mogą one być nieprawidłowe.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Bład: Utworzenie transakcji nie powiodło się  </translation>
     </message>
@@ -6453,17 +7452,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Błąd: Transakcja odrzucona.  Może się tak zdarzyć jeśli niektóre z monet w twoich portfelu zostały już wydane, czyli jeśli użyłeś kopii zapasowej wallet.dat i monety zostały wydany w kopii ale nie zostały oznaczone jako wydane tutaj.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Próba nasłuchiwania na jakimkolwiek porcie nie powiodła się. Użyj -listen=0 jeśli tego chcesz.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Aby użyć opcji %s</translation>
     </message>
     <message>
-        <location line="-463"/>
+        <location line="-474"/>
         <source>%s, you must set a rpcpassword in the configuration file:
  %s
 It is recommended you use the following random password:
@@ -6489,12 +7488,12 @@ na przykład: alertnotify=echo %%s | mail -s &quot;Alarm Gridcoin&quot; admin@fo
     </message>
     <message>
         <location line="-3"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6504,12 +7503,12 @@ na przykład: alertnotify=echo %%s | mail -s &quot;Alarm Gridcoin&quot; admin@fo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+19"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6529,21 +7528,7 @@ na przykład: alertnotify=echo %%s | mail -s &quot;Alarm Gridcoin&quot; admin@fo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6569,11 +7554,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6593,7 +7573,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6633,7 +7613,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6669,11 +7649,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6713,12 +7688,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6792,7 +7762,7 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6804,11 +7774,6 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6879,16 +7844,6 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7002,11 +7957,6 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7029,16 +7979,6 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7117,7 +8057,7 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation>Inicjalizacja poprawności działa nie udała się. Aplikacja gridcoin wyłączy się.</translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Portfel %s znajduje się poza folderem z danymi %s.</translation>
     </message>
@@ -7127,12 +8067,85 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation>Sprawdzanie integralności bazy danych...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Bład inicjalizacji bazy danych %s! Aby odzyskać, ZRÓB KOPIĘ ZAPASOWĄ FOLDERU, dopiero usuń z niego wszystko POMIJAJĄC wallet.dat.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7223,6 +8236,16 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7257,7 +8280,7 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation>wallet.dat uszkodzony, odtworzenie się nie powiodło</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Nieprawidłowy adres -proxy: &apos;%s&apos;</translation>
     </message>
@@ -7267,7 +8290,7 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation>Nieprawidłowy adres -tor: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Nie można uzyskać adresu -bind: &apos;%s&apos;</translation>
     </message>
@@ -7277,12 +8300,12 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation>Nie można uzyskać adresu -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Nieprawidłowa kwota dla -reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Bład ładowania blkindex.dat</translation>
     </message>
@@ -7297,7 +8320,7 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation>Błąd ładowania wallet.dat: Portfel wymaga nowej wersji aplikacji Gridcoin</translation>
     </message>
     <message>
-        <location line="+41"/>
+        <location line="+38"/>
         <source>Invalid amount for -peertimeout=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7309,16 +8332,6 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
     <message>
         <location line="+1"/>
         <source>Is Superblock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7344,11 +8357,6 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7392,18 +8400,12 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">NIEDOSTĘPNE</translation>
+        <translation type="obsolete">NIEDOSTĘPNE</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7424,6 +8426,11 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7647,78 +8654,8 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7773,16 +8710,6 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7832,7 +8759,7 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7842,37 +8769,37 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation>Portfel potrzebuje być zapisany: uruchom ponownie aplikację Gridcoin aby zakończyć</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Błąd ładowania wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Importowanie pliku startera z łańcuchem bloków.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Wczytywanie adresów...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Błąd: nie udało się wystartować gałęzi</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Nie można przywiązać %s na tym komputerze. Aplikacja Gridcoin jest już prawdopodobnie uruchomiona.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Nie można przywiązać %s na tym komputerze (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Błąd: Portfel zablokowany, nie mozna utworzyć transakcji  </translation>
     </message>
@@ -7887,37 +8814,36 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation>Bład: Ta transakcja wymaga opłaty transakcyjnej wysokości conajmniej %s z powodu jej rozmiaru, kompleksowości lub użycia dopiero otrzymanych środków  </translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Wysyłanie...</translation>
+        <translation type="vanished">Wysyłanie...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Nieprawidłowa kwota</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Ostrzeżenie: Proszę sprawdzić czy data i czas twojego komputera są prawidłowe! Jeśli twój zegar jest źle ustawiony, aplikacja Gridcoin nie będzie prawidłowo pracować.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Ostrzeżenie: Mało miejsca na dysku!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Nieznana sieć w -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Niewystarczające środki</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Ładowanie indeksu bloku...</translation>
     </message>
@@ -7927,17 +8853,17 @@ Jeżeli plik nie istnieje, utwórz go z uprawnieniami właćciciela-tylko-do-odc
         <translation>Wczytywanie portfela...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Nie można zapisać domyślnego adresu</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Ponowne skanowanie...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Wczytywanie zakończone</translation>
     </message>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sim</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">não</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>E&amp;xcluir</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar rótu&amp;lo</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exportar Dados do Livro de Endereços</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Rótulo</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sem rótulo)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Apenas para participação</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Insira a nova senha para a carteira.&lt;br/&gt;Favor usar uma senha com &lt;b&gt;dez ou mais caracteres aleatórios&lt;/b&gt;, ou &lt;b&gt;oito ou mais palavras&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Digite a frase de segurança antiga e nova para a carteira.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar criptografia da carteira</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Tem certeza que deseja criptografar a carteira?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Carteira criptografada</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: Qualquer backup prévio que você tenha feito da sua carteira deve ser substituído pelo novo e encriptado arquivo gerado. Por razões de segurança, qualquer backup do arquivo não criptografado se tornará inútil assim que você começar a usar uma nova carteira criptografada.</translation>
+        <translation type="vanished">IMPORTANTE: Qualquer backup prévio que você tenha feito da sua carteira deve ser substituído pelo novo e encriptado arquivo gerado. Por razões de segurança, qualquer backup do arquivo não criptografado se tornará inútil assim que você começar a usar uma nova carteira criptografada.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Falha ao criptografar carteira</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Falha na criptografia devido a um erro inerno. Sua carteira não foi criptografada.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>As senhas não conferem.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Falha ao desbloquear carteira</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>A senha inserida para descriptografar a carteira está incorreta.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>A senha da carteira foi alterada com êxito.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Carteira</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Visão geral</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>S&amp;air</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verificar mensagem...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Exportar...</translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Abrir console de depuração e diagnóstico</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Arquivo</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Definições</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +967,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transação enviada</translation>
     </message>
@@ -830,17 +995,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1015,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1033,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1060,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1075,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Carteira está &lt;b&gt;criptografada&lt;/b&gt; e atualmente &lt;b&gt;bloqueada&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1091,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1111,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1203,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1252,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1260,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alerta da Rede</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1379,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Quantidade</translation>
+        <translation type="vanished">Quantidade</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Rótulo</translation>
+        <translation type="obsolete">Rótulo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmações</translation>
+        <translation type="vanished">Confirmações</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmado</translation>
+        <translation type="vanished">Confirmado</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Endereço</translation>
+        <translation type="vanished">Endereço</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copiar endereço</translation>
     </message>
@@ -1251,17 +1414,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID da transação</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copiar quantia</translation>
     </message>
@@ -1291,17 +1454,17 @@ Expires: %3
         <translation>Copiar troco</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>sim</translation>
     </message>
@@ -1341,20 +1504,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(sem rótulo)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>troco de %1 (%2)</translation>
+        <translation type="vanished">troco de %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(troco)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(sem rótulo)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">troco de %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(troco)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(troco)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Rótulo</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Endereço</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmações</translation>
     </message>
 </context>
 <context>
@@ -1380,7 +1588,7 @@ Expires: %3
         <translation type="unfinished">Endereço</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1650,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1685,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Rótulo</translation>
+        <translation type="obsolete">Rótulo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Endereço</translation>
+        <translation type="obsolete">Endereço</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Confirmações</translation>
+        <translation type="obsolete">Confirmações</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmado</translation>
+        <translation type="obsolete">Confirmado</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1740,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1750,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(sem rótulo)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">troco de %1 (%2)</translation>
+        <translation type="obsolete">troco de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(troco)</translation>
+        <translation type="obsolete">(troco)</translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1915,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1945,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2121,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2136,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2149,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2177,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2258,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2337,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2456,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Limpar Tudo</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">sim</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">não</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">O desbloqueio da carteira foi cancelado</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3135,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>padrão</translation>
     </message>
@@ -2572,7 +3150,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
@@ -2800,18 +3378,23 @@ Expires: %3
         <translation>Seu saldo total atual</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copiar quantia</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3405,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3735,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3775,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3815,7 @@ Expires: %3
         <translation type="unfinished">Formulário</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3825,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3848,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,6 +3901,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sim</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">não</translation>
     </message>
 </context>
 <context>
@@ -3173,12 +4062,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4097,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4189,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4227,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4337,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4388,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4403,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4441,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4503,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3687,7 +4643,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3793,7 +4749,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4922,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4937,7 @@ Expires: %3
         <translation>Digite &lt;b&gt;help&lt;/b&gt; para uma visão geral dos comandos disponíveis.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4995,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5086,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5574,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5695,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5809,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5832,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5844,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5968,7 @@ Expires: %3
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copiar quantia</translation>
     </message>
@@ -5081,7 +6028,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>O endereço do destinatário não é válido, favor verificar.</translation>
     </message>
@@ -5121,8 +6068,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(sem rótulo)</translation>
     </message>
@@ -5229,7 +6176,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Endereço</translation>
     </message>
@@ -5367,42 +6314,42 @@ Expires: %3
         <translation>Clique em &quot;Assinar mensagem&quot; para gerar a assinatura</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>O endereço digitado é inválido</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Favor checar o endereço e tente novamente</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>O endereço fornecido não se refere a uma chave.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>O desbloqueio da carteira foi cancelado</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>A chave privada do endereço inserido não está disponível</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Falha ao assinar mensagem</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Mensagem assinada</translation>
     </message>
@@ -5413,7 +6360,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Favor checar a assinatura e tente novamente</translation>
     </message>
@@ -5464,7 +6411,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6419,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Aberto até %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>em conflito</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/não confirmado</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmações</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6467,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Fonte</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -5598,13 +6545,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>próprio endereço</translation>
@@ -5615,16 +6562,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>rótulo</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Crédito</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6584,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>não aceito</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Débito</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Taxa da transação</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Valor líquido</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Mensagem</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Comentário</translation>
     </message>
@@ -5671,38 +6618,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Quantia</translation>
     </message>
@@ -5734,11 +6681,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5758,7 +6710,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Quantidade</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6738,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmações)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Conflitado</translation>
     </message>
@@ -6016,7 +6968,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status da transação. Passe o mouse sobre este campo para mostrar o número de confirmações.</translation>
     </message>
@@ -6044,7 +7031,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7086,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Quantia mínima</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copiar endereço</translation>
     </message>
@@ -6129,7 +7121,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mostrar detalhes da transação</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7132,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
@@ -6185,7 +7177,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Não foi possível escrever no arquivo %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Intervalo: </translation>
     </message>
@@ -6221,19 +7213,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">S&amp;air</translation>
+        <translation type="obsolete">S&amp;air</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Sair da aplicação</translation>
+        <translation type="obsolete">Sair da aplicação</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Arquivo</translation>
+        <translation type="obsolete">&amp;Arquivo</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7236,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7262,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,17 +7348,9 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Um erro ocorreu ao configurar a porta RPC %u para escuta em IPv6, voltando ao IPv4: %s</translation>
     </message>
@@ -6379,27 +7360,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Um erro ocorreu ao configurar a porta RPC %u para escuta em IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lista de comandos</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Obtenha ajuda sobre um comando</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Cuidado: valor de -paytxfee escolhido é muito alto! Este é o valor da taxa de transação que você irá pagar se enviar a transação.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Aviso: wallet.dat corrompido, dados recuperados! Arquivo wallet.dat original salvo como wallet.{timestamp}.bak em %s; se seu saldo ou transações estiverem incorretos, você deve restauras o backup.</translation>
     </message>
@@ -6409,32 +7390,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cuidado: erro ao ler arquivo wallet.dat! Todas as chaves foram lidas corretamente, mas dados transações e do catálogo de endereços podem estar faltando ou estar incorretas.</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-191"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+149"/>
         <source>The wallet will now shutdown. Please start your wallet to begin sync from zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+168"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6485,11 +7451,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Falha ao escutar em qualquer porta. Use -listen=0 se você quiser isso.</translation>
     </message>
@@ -6516,16 +7477,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6629,16 +7580,6 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -6661,11 +7602,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6710,17 +7646,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6744,7 +7670,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>No wallet available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6965,82 +7891,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7095,16 +7946,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7114,7 +7955,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Para usar a opção %s</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7123,12 +7964,85 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Se o arquivo não existir, crie um com permissão de leitura apenas pelo dono</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="-224"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+79"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantidade inválida para -paytxfee=&lt;quantidade&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+109"/>
+        <location line="+28"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7180,6 +8094,11 @@ Se o arquivo não existir, crie um com permissão de leitura apenas pelo dono</t
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7289,6 +8208,16 @@ Se o arquivo não existir, crie um com permissão de leitura apenas pelo dono</t
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7323,18 +8252,18 @@ Se o arquivo não existir, crie um com permissão de leitura apenas pelo dono</t
         <translation>wallet.dat corrompido, recuperação falhou</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Endereço -proxy inválido: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7359,12 +8288,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+19"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7379,21 +8308,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7434,11 +8349,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7458,7 +8368,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7498,7 +8408,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7534,11 +8444,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7579,11 +8484,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7653,7 +8553,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7668,7 +8568,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Authorized</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7738,7 +8638,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Impossível encontrar o endereço -bind: &apos;%s&apos;</translation>
     </message>
@@ -7848,32 +8748,32 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Erro ao carregar wallet.dat</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+47"/>
         <source>Loading addresses...</source>
         <translation>Carregando endereços...</translation>
     </message>
     <message>
-        <location line="+98"/>
+        <location line="+79"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Impossível vincular a %s neste computador (bind retornou erro %d, %s)</translation>
     </message>
     <message>
-        <location line="-105"/>
+        <location line="-84"/>
         <source>Invalid amount</source>
         <translation>Quantidade inválida</translation>
     </message>
     <message>
-        <location line="+108"/>
+        <location line="+87"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Rede desconhecida especificada em -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Saldo insuficiente</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Carregando índice de blocos...</translation>
     </message>
@@ -7883,17 +8783,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Carregando carteira...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Não foi possível escrever no endereço padrão</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Re-escaneando...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Carregamento terminado!</translation>
     </message>

--- a/src/qt/locale/bitcoin_pt_PT.ts
+++ b/src/qt/locale/bitcoin_pt_PT.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -34,7 +34,7 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,11 +43,51 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -60,6 +100,41 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <location line="+1"/>
         <source>Required</source>
         <translation>Requerido</translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sim</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">não</translation>
     </message>
 </context>
 <context>
@@ -145,7 +220,17 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>&amp;Eliminar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar &amp;Etiqueta</translation>
     </message>
@@ -155,7 +240,7 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exportar Dados do Livro de Endereços</translation>
     </message>
@@ -179,7 +264,7 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
@@ -190,8 +275,19 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sem etiqueta)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -227,7 +323,7 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>Apenas para realizar stake</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Insira a nova frase de segurança para a carteira. &lt;br/&gt; Por favor, utilize uma frase de segurança de &lt;b&gt;10 ou mais carateres aleatórios,&lt;/b&gt; ou &lt;b&gt;oito ou mais palavras&lt;/b&gt;.</translation>
     </message>
@@ -257,7 +353,7 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>Escreva a frase de segurança da carteira antiga, seguida da nova.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar encriptação da carteira</translation>
     </message>
@@ -272,58 +368,82 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>Tem a certeza que deseja encriptar a sua carteira?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Carteira encriptada</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>O Gridcoin irá agora terminar o processo de encriptação. Lembre-se que encriptar a sua carteira não garante que as suas moedas não possam ser roubadas por um malware que infete o seu computador.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: Qualquer cópia de segurança feita ao ficheiro da carteira, deverá ser substituído pelo novo ficheiro, atualmente encriptado na carteira. Por razões de segurança, cópias de segurança não encriptadas efetuadas anteriormente do ficheiro da carteira tornar-se-ão inúteis assim que começar a usar a nova carteira encriptada.</translation>
+        <translation type="vanished">IMPORTANTE: Qualquer cópia de segurança feita ao ficheiro da carteira, deverá ser substituído pelo novo ficheiro, atualmente encriptado na carteira. Por razões de segurança, cópias de segurança não encriptadas efetuadas anteriormente do ficheiro da carteira tornar-se-ão inúteis assim que começar a usar a nova carteira encriptada.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Encriptação da carteira falhou</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>A encriptação da carteira falhou devido a um erro interno. A sua carteira não foi encriptada.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>As frases de segurança fornecidas não coincidem.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Desbloqueio da carteira falhou</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>A frase de segurança introduzida para a desencriptação da carteira estava incorreta.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>A frase de segurança da carteira foi alterada com sucesso.</translation>
     </message>
@@ -348,7 +468,7 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>Banned Until</source>
         <translation>Banido Até</translation>
     </message>
@@ -361,12 +481,12 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Ocorreu um erro fatal. O Gridcoin não consegue continuar em segurança e irá fechar.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Carteira</translation>
     </message>
@@ -376,7 +496,12 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Resumo</translation>
     </message>
@@ -512,7 +637,7 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>S&amp;air</translation>
     </message>
@@ -637,6 +762,11 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>&amp;Verificar mensagem...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Exportar...</translation>
@@ -657,17 +787,25 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>Abrir consola de diagnóstico e depuração</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Snapshot Download</source>
-        <translation>Transferência do &amp;Snapshot</translation>
+        <translation type="vanished">Transferência do &amp;Snapshot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Download and apply latest snapshot</source>
-        <translation>Transferir e aplicar o último snapshot</translation>
+        <translation type="vanished">Transferir e aplicar o último snapshot</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation>&amp;Repor dados da cadeia de blocos</translation>
     </message>
@@ -687,12 +825,32 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>Mascarar os valores no ecrã de Visão Geral</translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Ficheiro</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configurações</translation>
     </message>
@@ -727,19 +885,34 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>Não realizando stake: Desabilitado por configuração.</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[rede de testes]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Cliente Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation>Sem ligações ativas à rede do Gridcoin. Se isto persistir por mais dum que uns minutos, por favor verifique a sua configuração e a conetividade à rede.</translation>
     </message>
@@ -812,17 +985,17 @@ Este produto inclui desenvolvimento de software pelo Projeto OpenSSL para uso em
         <translation>O último bloco recebido foi gerado há %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Esta transação excede o limite de tamanho. Pode continuar a enviar com uma taxa de %1, que vais para os nós que processam a sua transação e ajudam a suportar a rede. Tem a certeza que quer pagar a taxa?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Confirmar taxa de transação</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transação enviada</translation>
     </message>
@@ -843,17 +1016,15 @@ Tipo: %3
 Endereço: %4</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation>Quer transferir e aplicar o último snapshot? Se sim, a carteira irá encerrar e executar a tarefa.</translation>
+        <translation type="vanished">Quer transferir e aplicar o último snapshot? Se sim, a carteira irá encerrar e executar a tarefa.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation>Aviso: Cancelar depois do 2º passo irá resultar em sincronizar tudo do &quot;0&quot;, ou ficheiros corrompidos na cadeia de blocos.</translation>
+        <translation type="vanished">Aviso: Cancelar depois do 2º passo irá resultar em sincronizar tudo do &quot;0&quot;, ou ficheiros corrompidos na cadeia de blocos.</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation>Tem a certeza que quer eliminar os dados da cadeia de blocos e começar a sincronização do zero?</translation>
     </message>
@@ -873,7 +1044,7 @@ Endereço: %4</translation>
         <translation>Fechar a carteira Gridcoin?</translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -891,7 +1062,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Tratamento do URI</translation>
@@ -908,7 +1089,7 @@ Are you sure you want to proceed?</source>
         <translation>A Carteira está &lt;b&gt;não encriptada&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation>A Carteira está &lt;b&gt;encriptada&lt;/b&gt; e atualmente %1</translation>
     </message>
@@ -923,12 +1104,12 @@ Are you sure you want to proceed?</source>
         <translation>&lt;b&gt;completamente desbloqueada&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>A carteira está &lt;b&gt;encriptada&lt;/b&gt; e atualmente &lt;b&gt;bloqueada&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Cópia de Segurança da Carteira</translation>
     </message>
@@ -939,18 +1120,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Cópia de Segurança Falhou</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Houve um erro ao tentar guardar os dados da carteira para uma nova localização.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation>Configuração da Cópia de Segurança</translation>
     </message>
@@ -960,7 +1140,12 @@ Are you sure you want to proceed?</source>
         <translation>Configuração da Carteira (*.conf)</translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation>indisponível</translation>
     </message>
@@ -1052,7 +1237,7 @@ Projeto(s) excluído(s): %2.</translation>
         <translation>Scraper: Convergência não alcançada. Irá tentar novamente em alguns minutos.</translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1110,12 +1295,12 @@ Expira: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alerta de Rede</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation>Dificuldade baixa!;</translation>
     </message>
@@ -1174,7 +1359,7 @@ Expira: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation>Selecionar Todos</translation>
     </message>
@@ -1224,42 +1409,36 @@ Expira: %3
         <translation>Pronto para consolidar</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Quantia</translation>
+        <translation type="vanished">Quantia</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmações</translation>
+        <translation type="vanished">Confirmações</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmada</translation>
+        <translation type="vanished">Confirmada</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="vanished">Etiqueta</translation>
     </message>
     <message>
-        <location line="-128"/>
+        <location line="-80"/>
         <source>&amp;List mode</source>
         <translation>&amp;Lista de modo</translation>
     </message>
     <message>
-        <location line="+133"/>
         <source>Address</source>
-        <translation>Endereço</translation>
+        <translation type="vanished">Endereço</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copiar endereço</translation>
     </message>
@@ -1270,17 +1449,17 @@ Expira: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID da transação</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copiar quantidade</translation>
     </message>
@@ -1310,17 +1489,17 @@ Expira: %3
         <translation>Copiar modificação</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation>Alterna o modo de filtro entre a seleção de entradas menores ou iguais ao valor fornecido (&lt;=) e maiores ou iguais ao valor fornecido (&gt;=). O filtro também limita automaticamente o número de entradas a %1, em ordem crescente para &lt;= e decrescente para &gt;=.</translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation>Não Selecionar Nenhum</translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>INSIGNIFICANTE</translation>
     </message>
@@ -1370,20 +1549,65 @@ Quantias 0.546 vezes menores que o mínimo, são mostradas como INSIGNIFICANTES.
 Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(sem etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>alterar de %1 (%2)</translation>
+        <translation type="vanished">alterar de %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(modificar)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(sem etiqueta)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">alterar de %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(modificar)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(modificar)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Endereço</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmações</translation>
     </message>
 </context>
 <context>
@@ -1409,7 +1633,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation>Nota: O número de entradas selecionado para consolidação foi limitado a %1, para prevenir uma falha de transação devido a demasiadas entradas.</translation>
     </message>
@@ -1471,7 +1695,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation>Selecionar Todos</translation>
     </message>
@@ -1506,37 +1730,31 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Filtro</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Quantia</translation>
+        <translation type="vanished">Quantia</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="vanished">Etiqueta</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Endereço</translation>
+        <translation type="vanished">Endereço</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmações</translation>
+        <translation type="vanished">Confirmações</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmada</translation>
+        <translation type="vanished">Confirmada</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation>Quantidade</translation>
     </message>
@@ -1571,7 +1789,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>estáConcluído</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation>Nota: O número de entradas selecionadas para consolidação foi limitado a %1, para prevenir falhas de transação devido a demasiadas entradas.</translation>
     </message>
@@ -1581,25 +1799,22 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Nota: O número de entradas selecionadas para consolidação é atualmente maior que o limite de %1. Por favor utilize o filtro ou seleção manual para reduzir o número de entradas para %1 ou menos, para prevenir uma falha de transação devido a demasiadas entradas.</translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation>Não Selecionar Nenhum</translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation>(sem etiqueta)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>alterar de %1 (%2)</translation>
+        <translation type="vanished">alterar de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation>(modificar)</translation>
+        <translation type="vanished">(modificar)</translation>
     </message>
 </context>
 <context>
@@ -1749,7 +1964,12 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Testar</translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation>Testando...</translation>
     </message>
@@ -1774,7 +1994,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Falhou</translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation>Um ou mais testes geraram um estado de alerta. Operações com a carteira podem estar corrompidas. Por favor, consulte as dicas individuais de teste para detalhes e ações recomendadas.</translation>
     </message>
@@ -1950,7 +2170,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation>Uma nova diretoria de dados irá ser criada.</translation>
     </message>
@@ -1965,6 +2185,11 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Caminho já existente, e não é uma diretoria.</translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Não é possível criar diretoria aqui.</translation>
@@ -1973,7 +2198,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versão</translation>
     </message>
@@ -2036,7 +2261,16 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation>Erro: Diretoria de dados especificada &quot;%1&quot; não pode ser criada.</translation>
     </message>
@@ -2073,22 +2307,22 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation>Tem que ter um balanço com maturidade de pelo menos 1 GRC para poder submeter um pedido de MRC.</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation>A taxa total (taxa mínima + taxa de boost) é maior que os ganhos da recompensa.</translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation>O seu MRC foi submetido com sucesso mais cedo, mas agora tornou-se obsoleto sem estar ligado ao bloco recém recebido por um staker. Isto pode acontecerr porque o seu MRC foi submetida pouco antes do bloco ter sido staked e o MRC não chegou a tempo ao staker, ou o seu MRC desceu na fila para além do limite de pagamentos. Por favor, aguarde pelo próximo bloco para limpar a fila de espera e tente novamente.</translation>
     </message>
@@ -2152,7 +2386,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2272,6 +2506,370 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation>Tem que ter um balanço com maturidade de pelo menos 1 GRC para poder submeter um pedido de MRC.</translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Limpar &amp;Tudo</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">sim</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">não</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">O desbloqueio da carteira foi cancelado.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2586,7 +3184,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>por defeito</translation>
     </message>
@@ -2601,7 +3199,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Claro</translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
@@ -2829,18 +3427,23 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Sondagens Atuais</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation>Fora de Sincronia</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copiar quantia</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2851,9 +3454,223 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n segundo(s)</numerusform>
+            <numerusform>%n segundo(s)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n minuto(s)</numerusform>
+            <numerusform>%n minuto(s)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n hora(s)</numerusform>
+            <numerusform>%n hora(s)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n dia(s)</numerusform>
+            <numerusform>%n dia(s)</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Estado</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation>ID do Nódulo</translation>
     </message>
@@ -2967,7 +3784,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation>Votação terminada.</translation>
     </message>
@@ -3007,6 +3824,11 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <source>Top Answer:</source>
         <translation>Resposta Mais Votada:</translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3042,7 +3864,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Formulário</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation>Clique em &quot;Recarregar &quot; para atualizar a lista.</translation>
     </message>
@@ -3052,7 +3874,17 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Isto pode demorar alguns minutos.</translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation>Mostrar Resultados</translation>
     </message>
@@ -3065,7 +3897,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation>Título</translation>
     </message>
@@ -3118,6 +3950,83 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished">nenhum</translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">sim</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">não</translation>
     </message>
 </context>
 <context>
@@ -3202,12 +4111,17 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation>Criar Sondagem</translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation>Balanço</translation>
     </message>
@@ -3232,12 +4146,12 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Escolha Múltipla</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation>Esta sondagem irá custar %1 para além duma taxa adicional. Continuar?</translation>
     </message>
@@ -3324,7 +4238,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -3362,7 +4276,35 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
@@ -3370,7 +4312,13 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
 </translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation>Erro: Não é possível ler o ficheiro de configuração. Verifique o caminho e o formato do ficheiro.</translation>
     </message>
@@ -3380,7 +4328,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Erro: A diretoria %1 especificada não existe.</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation>Erro: Não foi possível cadear a diretoria de dados especificada. Uma instância já está provavelmente a utilizar essa diretoria</translation>
     </message>
@@ -3395,12 +4343,35 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Erro ao inicializar as definições: %1</translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation>%1 ainda não saiu de modo seguro...</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation>N/D</translation>
     </message>
@@ -3515,7 +4486,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>%1 restante.</translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3525,7 +4496,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3582,6 +4553,11 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     <message>
         <location line="+1"/>
         <source>MRCs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3677,7 +4653,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>N/D</translation>
     </message>
@@ -3748,7 +4724,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation>Selecione um peer para visualizar a informação detalhada</translation>
     </message>
@@ -3996,7 +4972,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Não</translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation>Bem-vindo à consola RPC Gridcoin! </translation>
     </message>
@@ -4011,7 +4987,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Escreva &lt;b&gt;help&lt;/b&gt; para visualizar os comandos disponíveis.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4072,10 +5048,8 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Saída</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+6"/>
         <source>Unknown</source>
-        <translation>Desconhecido</translation>
+        <translation type="vanished">Desconhecido</translation>
     </message>
 </context>
 <context>
@@ -4166,40 +5140,37 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation>Aguardando pela sincronização...</translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation>Não listado na lista aprovada</translation>
     </message>
     <message>
-        <location line="+32"/>
+        <location line="+3"/>
         <source>Not attached</source>
         <translation>Não anexado</translation>
     </message>
     <message>
-        <location line="-2"/>
+        <location line="+3"/>
         <source>Uses external adapter</source>
         <translation>Utiliza adaptador externo</translation>
     </message>
@@ -4669,7 +5640,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Carregue em &quot;Seguinte&quot; quando estiver pronto.</translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation>Etiqueta do Endereço</translation>
     </message>
@@ -4790,7 +5761,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation>Tudo parece bem.</translation>
     </message>
@@ -4904,7 +5875,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4927,7 +5898,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation>Disponível (%1)</translation>
@@ -4939,7 +5910,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation>Inativo</translation>
     </message>
@@ -5063,7 +6034,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Insira um endereço Gridcoin (ex: S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copiar quantidade</translation>
     </message>
@@ -5123,7 +6094,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation> e </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>O endereço de destino não é válido, por favor verifique.</translation>
     </message>
@@ -5163,8 +6134,8 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Erro: A transação foi rejeitada. Isso pode acontecer se algumas das suas moedas na carteira já tiverem sido gastas, se tiver utilizado uma cópia da wallet.dat e as moedas não tiverem sido marcadas como gastas aqui.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(sem etiqueta)</translation>
     </message>
@@ -5271,7 +6242,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Endereço</translation>
     </message>
@@ -5409,42 +6380,42 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
         <translation>Insira assinatura do Gridcoin</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>O endereço introduzido é inválido. </translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Por favor verifique o endereço e tente de novo.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>O endereço introduzido não se refere a uma  chave.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>O desbloqueio da carteira foi cancelado.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>A chave privada para o endereço introduzido não está disponível.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Assinatura de mensagem falhou.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Mensagem assinada.</translation>
     </message>
@@ -5455,7 +6426,7 @@ Isto significa que uma taxa de pelo menos %2 é necessária.</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Por favor, verifique a assinatura e tente novamente.</translation>
     </message>
@@ -5506,7 +6477,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation>
             <numerusform>Aberto para mais %n bloco(s)</numerusform>
@@ -5514,32 +6485,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Aberto até %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>conflito</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/não confirmada</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmações</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
@@ -5562,74 +6533,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Origem</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation>Gerada na CoinBase</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation>Minada - PoS</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation>Minada - PoS+RR</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation>Minada - Orfã</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation>PoS Side Stake Recebido</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation>PoS+RR Side Stake Recebido</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation>PoS Side Stake Enviado</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation>PoS+RR Side Stake Enviado</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation>Pagamento MRC Recebido</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation>Pagamento MRC Enviado</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation>Minada -  Super Bloco</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation>Minada - Desconhecido</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -5640,13 +6611,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>endereço próprio</translation>
@@ -5657,16 +6628,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Crédito</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation>
             <numerusform>matura em %n bloco(s)</numerusform>
@@ -5679,31 +6650,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>não aceite</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Débito</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Taxa de transação</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Valor líquido</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Mensagem</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Comentário</translation>
     </message>
@@ -5713,38 +6684,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>ID da TX</translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation>Hash do Bloco</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation>Dados de Stake da Transação</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>As moedas gerados pelo Gridcoin devem maturar durante 110 blocos antes de poderem ser gastas. Quando gerou este bloco, ele foi transmitido à rede para ser adicionado à blockchain. Se falhar a entrada na cadeia, o seu estado será alterado para &quot;não aceite&quot; e não será  possível gastá-la. Isto pode acontecer ocasionalmente se outro nó gerar um bloco com segundos de diferença do seu.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation>Débitos/Créditos da Transação</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation>Dados da Transação</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation>Entradas de Transação</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Valor</translation>
     </message>
@@ -5776,11 +6747,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation>F&amp;echar</translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5800,7 +6776,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Quantia</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation>
             <numerusform>Aberto por mais %n bloco(s)</numerusform>
@@ -5828,12 +6804,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Confirmando (%1 de %2 confirmações recomendadas)&lt;br&gt;</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmada (%1 confirmações)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Em Conflito</translation>
     </message>
@@ -6058,7 +7034,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estado da transação. Coloque ponteiro por cima deste campo para mostrar o número de confirmações.</translation>
     </message>
@@ -6086,7 +7097,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation>Histórico de Transações</translation>
     </message>
@@ -6141,7 +7152,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Quantia mínima</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copiar endereço</translation>
     </message>
@@ -6171,7 +7187,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mostrar detalhes da transação</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exportar Dados da Transação</translation>
     </message>
@@ -6182,7 +7198,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ficheiro separado por vírgulas</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
@@ -6227,7 +7243,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Não foi possível escrever para o ficheiro %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Alcance:</translation>
     </message>
@@ -6263,19 +7279,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation>S&amp;air</translation>
+        <translation type="vanished">S&amp;air</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation>Sair da aplicação</translation>
+        <translation type="vanished">Sair da aplicação</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation>&amp;Ficheiro</translation>
+        <translation type="vanished">&amp;Ficheiro</translation>
     </message>
 </context>
 <context>
@@ -6289,7 +7302,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation>Submeter Voto</translation>
     </message>
@@ -6315,18 +7328,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation>Por favor desbloqueie a carteira.</translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation>Sondagem não encontrada.</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation>Falhou o carregamento das sondagens do disco</translation>
     </message>
@@ -6403,15 +7416,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Enviando...</translation>
+        <translation type="vanished">Enviando...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ocorreu um erro ao definir a porta %u do serviço RPC ao escutar em IPv6, a reverter para IPv4: %s</translation>
     </message>
@@ -6421,33 +7433,33 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ocorreu um erro ao definir a porta %u do serviço RPC ao escutar em IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Utilização:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Listar comandos</translation>
     </message>
     <message>
-        <location line="-367"/>
-        <location line="+344"/>
+        <location line="-397"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-342"/>
+        <location line="-374"/>
         <source>The Gridcoin developers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+19"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation>Uma sondagem com uma resposta do tipo sim/não/abster-se, não pode incluir quaisquer escolhas adicionais.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6462,21 +7474,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Verifique que o BOINC está instalado e que tem o caminho correto no ficheiro de configuração, caso o tenha instalado numa localização não definida por padrão.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+46"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation>Erro: O sincronização do relógio é de 5 minutos ou mais. Verifique as definições do seu relógio.</translation>
     </message>
@@ -6496,7 +7494,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Erro: Esta transação devido à sua quantia, complexidade ou utilização de fundos recebidos recentemente, necessita de uma taxa de transação de pelo menos %s </translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+6"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6511,7 +7509,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Para sondagens sobre representação comunitária, relações públicas e comunicações.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation>Por favor, verifique a sua rede e também o ficheiro de configuração e certifique-se de que as suas entradas addnode estão atualizadas. Se iniciou recentemente a carteira, poderá querer aguardar mais alguns minutos para que as ligações sejam estabelecidas e testar novamente. Consulte https://gridcoin.us/wiki/config-file.html e https://addnodes.cycy.me/.</translation>
     </message>
@@ -6551,7 +7549,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation>A rede sofreu um erro de baixo nível, o que provavelmente significa que o seu endereço IP ou outros parâmetros de ligação à rede não estão corretamente configurados. Verifique a configuração da rede no seu computador.</translation>
     </message>
@@ -6586,7 +7584,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Existe uma nova versão obrigatória disponível e deve atualizá-la o mais rapidamente possível para garantir que a sua carteira se mantém em consenso com a rede.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+5"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation>Verifique (1) se o BOINC está instalado corretamente, (2) se adicionou pelo menos um projeto da whitelist, (3) se anunciou seu beacon com o mesmo e-mail que usa para o(s) seu(s) projeto(s) BOINC e (4) se o CPID no ecrã de visão geral corresponde ao CPID quando inicia sessão no(s) seu(s) projeto(s) BOINC on-line.</translation>
     </message>
@@ -6626,12 +7624,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Aviso: O ETTS é infinito. Não há moedas para realizar stake - aumente o saldo ou use o MRC</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation>Aviso: Acabar este processo antes da Fase 2 irá resultar numa sincronização do &quot;0&quot;, ou numa cadeia de blocos incompleta/corrupta.</translation>
+        <translation type="vanished">Aviso: Acabar este processo antes da Fase 2 irá resultar numa sincronização do &quot;0&quot;, ou numa cadeia de blocos incompleta/corrupta.</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation>Não tens saldo e não será possível recuperar as tuas recompensas de investigação quando estiveres a fazer crunch a solo por staking. Podes usar MRC para recuperar as tuas recompensas, ou deverás adquirir GRC para fazer stake e poderes recuperar as tuas recompensas de investigação. Consulte https://gridcoin.us/guides/boinc-install.htm.</translation>
     </message>
@@ -6696,7 +7693,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>A sua carteira ainda está na sincronização inicial. Se se tratar de uma sincronização desde o início (génese), o processo de sincronização pode demorar de 2 a 4 horas, ou mais num computador lento. Se já sincronizou a sua carteira antes, mas acabou de a iniciar, aguarde mais alguns minutos e tente executar novamente o diagnóstico.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation>A escolha duma sondagem não pode estar vazia.</translation>
     </message>
@@ -6709,11 +7706,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <location line="+1"/>
         <source>Active</source>
         <translation type="unfinished">Ativo</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6743,16 +7735,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6826,11 +7808,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation>Falhou a alteração de nome por motivos de backups no ficheiro bootstrap para .old.</translation>
@@ -6854,16 +7831,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
         <translation>Para opiniões ou sondagens casuais sem requisitos especiais.</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6906,12 +7873,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Fundos insuficientes.</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+16"/>
         <source>Loading history for contract type </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6924,11 +7886,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <location line="+2"/>
         <source>Local version: </source>
         <translation>Versão local:</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6966,9 +7923,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Escolha Múltipla</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation>N/D</translation>
+        <translation type="vanished">N/D</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6976,9 +7932,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Sem UTXOs disponíveis devido ao balanço de reserva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>No address contains %s GRC in %s UTXOs or fewer.</source>
-        <translation>Sem endereços contendo %s GRC em %s UTXOs ou menos.</translation>
+        <translation type="vanished">Sem endereços contendo %s GRC em %s UTXOs ou menos.</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6994,6 +7949,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <location line="+1"/>
         <source>No mature coins</source>
         <translation>Sem moedas maduras</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -7201,46 +8161,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Enviar comando para -server ou gridcoinresearchd</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+4"/>
         <source>Staking Only - Non-cruncher Mode</source>
         <translation type="unfinished"></translation>
@@ -7266,16 +8186,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+4"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation>Não foi possível criar o ficheiro PID &quot;%s&apos;: %s</translation>
@@ -7286,7 +8196,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Tipo de sondagem desconhecida. Isto nunca deverá acontecer.</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+9"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7377,6 +8292,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7401,22 +8326,90 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>desconhecido</translation>
     </message>
     <message>
-        <location line="-224"/>
+        <location line="-201"/>
         <source>Balance</source>
         <translation>Balanço</translation>
     </message>
     <message>
-        <location line="-281"/>
+        <location line="-318"/>
         <source>The %s developers</source>
         <translation>Os %s desenvolvedores</translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+15"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+31"/>
         <source>Error: Unsupported argument -socks found. Setting SOCKS version isn&apos;t possible anymore, only SOCKS5 proxies are supported.</source>
         <translation>Erro: Argumento não suportado -socks encontrado. Definir a versão SOCKS não é mais possível, são apenas suportadas proxies SOCKS5.</translation>
     </message>
     <message>
-        <location line="+210"/>
+        <location line="+15"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Block Version</source>
         <translation>Versão do Bloco</translation>
     </message>
@@ -7451,7 +8444,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Recompensa do BOINC</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+9"/>
         <source>Client Version</source>
         <translation>Versão do Cliente</translation>
     </message>
@@ -7491,7 +8484,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Erro: Carteira bloqueada, não foi possível criar transação</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+13"/>
         <source>GitHub version: </source>
         <translation>Versão GitHub:</translation>
     </message>
@@ -7526,9 +8519,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>É um Super Bloco</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Latest Version GitHub data response:</source>
-        <translation>Versão mais recente da resposta de dados do GitHub:</translation>
+        <translation type="vanished">Versão mais recente da resposta de dados do GitHub:</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -7541,12 +8533,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>A carregar lista de proibidos...</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+9"/>
         <source>Malformed CPID</source>
         <translation>CPID Mal Formado</translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+14"/>
         <source>Organization</source>
         <translation>Empresa</translation>
     </message>
@@ -7556,12 +8548,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Email de projeto incompatível</translation>
     </message>
     <message>
-        <location line="-251"/>
+        <location line="-239"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Atenção: -paytxfee está definida com um valor muito elevado! Esta é a taxa que irá pagar se enviar uma transação.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Atenção: wallet.dat corrupto, dados recuperados! Wallet.dat original guardada como wallet.{timestamp}.bak em %s; se o seu saldo ou transações estiverem incorretos, deverá restaurar duma cópia de segurança.</translation>
     </message>
@@ -7571,7 +8563,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Atenção: erro ao ler wallet.dat! Todas as chaves foram lidas correctamente, mas os dados de transação ou  entradas do livro de endereços podem estar em falta ou incorretos.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Erro: Criação de transação falhou</translation>
     </message>
@@ -7581,32 +8573,30 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Erro: A transação foi rejeitada. Isto pode acontecer se algumas das moedas na sua carteira já tiverem sido gastas, por exemplo se as usou na cópia da sua wallet.dat, mas não foram marcadas como gastas aqui.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Falhou a escutar em qualquer porta. Use -listen=0 se quiser isto.</translation>
     </message>
     <message>
-        <location line="+107"/>
+        <location line="+100"/>
         <source>Single Choice</source>
         <translation>Escolha Única</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Snapshot Process Complete!</source>
-        <translation>Processo de Snapshot Completo!</translation>
+        <translation type="vanished">Processo de Snapshot Completo!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Snapshot Process Has Begun.</source>
-        <translation>Processo de Snapshot Iniciou.</translation>
+        <translation type="vanished">Processo de Snapshot Iniciou.</translation>
     </message>
     <message>
-        <location line="+26"/>
+        <location line="+12"/>
         <source>To use the %s option</source>
         <translation>Para utilizar as opções %s</translation>
     </message>
     <message>
-        <location line="-463"/>
+        <location line="-474"/>
         <source>%s, you must set a rpcpassword in the configuration file:
  %s
 It is recommended you use the following random password:
@@ -7631,27 +8621,25 @@ por exemplo: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
 </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+42"/>
         <source>Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet.</source>
         <translation>Devido à falha na eliminação dos dados da cadeia de blocos, ser-lhe-á solicitado que elimine manualmente os dados antes de iniciar a sua carteira.</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation>Falhou a transferência do snapshot porque existe uma atualização obrigatória da aplicação.</translation>
+        <translation type="vanished">Falhou a transferência do snapshot porque existe uma atualização obrigatória da aplicação.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+69"/>
         <source>Failure to do so will result in undefined behaviour or failure to start wallet.</source>
         <translation>Se não o fizer, o resultado será um comportamento indefinido ou uma falha no arranque da carteira.</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation>Não foi possível transferir o snapshot, porque a carteira detetou que uma versão obrigatória mais recente, está disponível para instalar. A atualização obrigatória deve ser instalada antes que o snapshot possa ser transferido e aplicado.</translation>
+        <translation type="vanished">Não foi possível transferir o snapshot, porque a carteira detetou que uma versão obrigatória mais recente, está disponível para instalar. A atualização obrigatória deve ser instalada antes que o snapshot possa ser transferido e aplicado.</translation>
     </message>
     <message>
-        <location line="+50"/>
+        <location line="+126"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7660,37 +8648,33 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Versão do Gridcoin</translation>
     </message>
     <message>
-        <location line="+92"/>
+        <location line="+88"/>
         <source>Resetting block chain index to prepare for reindexing...</source>
         <translation>Repondo o índice da block chain para preparar a reindexação...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation>Etapa (1/4): Transferindo o snapshot.zip:</translation>
+        <translation type="vanished">Etapa (1/4): Transferindo o snapshot.zip:</translation>
+    </message>
+    <message>
+        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
+        <translation type="vanished">Etapa (2/4): Verificando SHA256SUM do snapshot.zip:</translation>
+    </message>
+    <message>
+        <source>Stage (3/4): Cleanup blockchain data:          </source>
+        <translation type="vanished">Etapa (3/4): Limpar dados da cadeia de blocos:</translation>
+    </message>
+    <message>
+        <source>Stage (4/4): Extracting snapshot.zip:          </source>
+        <translation type="vanished">Etapa (4/4): Extraindo o snapshot.zip:</translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation>Etapa (2/4): Verificando SHA256SUM do snapshot.zip:</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation>Etapa (3/4): Limpar dados da cadeia de blocos:</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
-        <translation>Etapa (4/4): Extraindo o snapshot.zip:</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Staking Only - No Eligible Research Projects</source>
         <translation>Para Realizar Stake Apenas - Sem Projetos de Pesquisa Elegíveis</translation>
     </message>
@@ -7700,7 +8684,7 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Versão de rede de testes apenas</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Unknown error</source>
         <translation>Erro desconhecido</translation>
     </message>
@@ -7710,7 +8694,7 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Desconhecido</translation>
     </message>
     <message>
-        <location line="-21"/>
+        <location line="-19"/>
         <source>Staking Only - No active beacon</source>
         <translation>A Realizar Stake Apenas - Beacon Inativo</translation>
     </message>
@@ -7725,7 +8709,7 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Super Bloco de Tamanho Binário</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+6"/>
         <source>This update is </source>
         <translation>A atualização está</translation>
     </message>
@@ -7745,12 +8729,12 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Tipo de peso da sondagem desconhecido.</translation>
     </message>
     <message>
-        <location line="-85"/>
+        <location line="-69"/>
         <source>No current polls</source>
         <translation>Sem sondagens</translation>
     </message>
     <message>
-        <location line="-30"/>
+        <location line="-25"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantia inválida para -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
@@ -7765,7 +8749,7 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Inicialização de verificação de sanidade falhou. O Gridcoin está a encerrar.</translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>A carteira %s reside fora da diretoria de dados %s.</translation>
     </message>
@@ -7775,12 +8759,12 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Verificando integridade da base de dados...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-404"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Erro ao iniciar o ambiente da base de dados %s! Para recuperar, FAÇA UMA CÓPIA DE SEGURANÇA DESSA DIRETORIA, depois remova tudo, exceto o wallet.dat.</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+436"/>
         <source>vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7790,7 +8774,7 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>wallet.dat corrupto, recuperação falhou</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Endereço -proxy inválido: &apos;%s&apos;</translation>
     </message>
@@ -7800,7 +8784,7 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Endereço -tor inválido: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Não foi possível resolver o endereço -bind: &apos;%s&apos;</translation>
     </message>
@@ -7810,12 +8794,12 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Não foi possível resolver o endereço -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Quantia inválida para - reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Erro ao carregar blkindex.dat</translation>
     </message>
@@ -7830,12 +8814,12 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Erro ao carregar wallet.dat: A carteira necessita de uma versão mais recente do Gridcoin</translation>
     </message>
     <message>
-        <location line="+158"/>
+        <location line="+134"/>
         <source>Verifying checkpoints...</source>
         <translation>Verificando checkpoints...</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Wallet locked</source>
         <translation>Carteira trancada</translation>
     </message>
@@ -7845,37 +8829,37 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>A carteira precisa de ser reescrita: reinicie o Gridcoin para concluir</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Erro ao carregar wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Importação do ficheiro de dados da cadeia de blocos bootstrap.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>A carregar os endereços...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Erro: Não foi possível iniciar o nó</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Não foi possível ligar ao %s neste computador. O Gridcoin já está possivelmente a ser executado.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Não foi possível vincular a %s neste computador (ligação retornou erro %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Erro: Carteira bloqueada, não foi possível criar transação</translation>
     </message>
@@ -7890,42 +8874,41 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>Erro: Esta transação devido à sua quantia, complexidade ou utilização de fundos recebidos recentemente, necessita de uma taxa de transação de pelo menos %s </translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Enviando...</translation>
+        <translation type="vanished">Enviando...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Quantia inválida</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Aviso: Por favor verifique que a data e hora do seu computador estão corretos! Se o seu relógio estiver incorreto, o Gridcoin não funcionará bem.</translation>
     </message>
     <message>
-        <location line="+291"/>
+        <location line="+265"/>
         <source>Vote signature failed. See debug.log.</source>
         <translation>Assinatura da votação falhou. Ver debug.log.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Warning: Disk space is low!</source>
         <translation>Aviso: Pouco disco em espaço!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Rede desconhecida especificada em -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Fundos insuficientes</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>A carregar o índice de blocos...</translation>
     </message>
@@ -7935,17 +8918,17 @@ Se o ficheiro não existir, crie-o com permissões de leitura.</translation>
         <translation>A carregar a carteira...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Impossível escrever endereço por defeito</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Reexaminando...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Carregamento concluído</translation>
     </message>

--- a/src/qt/locale/bitcoin_ro_RO.ts
+++ b/src/qt/locale/bitcoin_ro_RO.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">da</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nu</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Şterge</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Copiaz? &amp;eticheta</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Editeaz?</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Export? datele din Agend?</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etichet?</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(f?r? etichet?)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Doar pentru staking</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Introdu vechea ?i noua parol? pentru portofel.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirm? criptarea portofelului</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Sunte?i sigur c? dori?i s? cripta?i portofelul electronic?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Portofel criptat</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin se va inchide pentru a termina procesul de encriptie. Aminti?i-v?, criptarea portofelul dumneavoastr? nu poate proteja pe deplin monedele dvs. de a fi furate de  infectarea cu malware a computerului.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANT: Orice copie de siguranta facuta in prealabil portofelului dumneavoastra ar trebui inlocuita cu cea generata cel mai recent fisier criptat al portofelului. Pentru siguranta, copiile de siguranta vechi ale portofelului ne-criptat vor deveni inutile de indata ce veti incepe folosirea noului fisier criptat al portofelului.</translation>
+        <translation type="vanished">IMPORTANT: Orice copie de siguranta facuta in prealabil portofelului dumneavoastra ar trebui inlocuita cu cea generata cel mai recent fisier criptat al portofelului. Pentru siguranta, copiile de siguranta vechi ale portofelului ne-criptat vor deveni inutile de indata ce veti incepe folosirea noului fisier criptat al portofelului.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Criptarea portofelului a e?uat</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Criptarea portofelului a e?uat din cauza unei erori interne. Portofelul t?u nu a fost criptat.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Frazele de acces introduse nu se potrivesc.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Deblocarea portofelului a e?uat</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Fraza de acces introdus? pentru decriptarea portofelului a fost incorect?.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Parola portofelului electronic a fost schimbat?.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>A ap?rut o eroare fatal?. Gridcoin nu mai poate continua în condi?ii de siguran?? ?i va iesi.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Portofel</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Imagine de ansamblu</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Ieşire</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifică mesaj...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Export?</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Deschide consola de depanare şi diagnosticare</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Fişier</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Setări</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Clientul Gridcoin</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -813,17 +978,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ultimul bloc primit a fost generat %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Aceast? tranzactie este peste limita admisa. Pute?i sa trimite?i pentru o taxa de %1, care este pentru nodurile care proceseaza tranzactia si ajuta la sprijinirea retelei. Vrei s? pl?te?ti taxa?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Confirm? comisinoul tranzac?iei</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Tranzacţie expediată</translation>
     </message>
@@ -841,17 +1006,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -871,7 +1026,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1044,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Manipulare URI</translation>
@@ -906,7 +1071,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -921,12 +1086,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Portofelul este &lt;b&gt;criptat&lt;/b&gt; iar în momentul de faţă este &lt;b&gt;blocat&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>F? o copie de siguran?? a portofelului</translation>
     </message>
@@ -937,18 +1102,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Copia de rezerva a esuat</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Eroare la încercarea de a salva datele portofelului în noua loca?ie.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -958,7 +1122,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1045,7 +1214,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1097,12 +1266,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Alert? re?ea</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,7 +1330,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1216,37 +1385,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Sumă</translation>
+        <translation type="vanished">Sumă</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Confirmări</translation>
+        <translation type="vanished">Confirmări</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Confirmat</translation>
+        <translation type="vanished">Confirmat</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Etichet?</translation>
+        <translation type="vanished">Etichet?</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Adres?</translation>
+        <translation type="vanished">Adres?</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Copiaz? adresa</translation>
     </message>
@@ -1257,17 +1420,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Copiaz? suma</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Copiaz? ID tranzac?ie</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Copia?i quantitea</translation>
     </message>
@@ -1297,17 +1460,17 @@ Expires: %3
         <translation>Copia?i schimb</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>da</translation>
     </message>
@@ -1357,20 +1520,65 @@ Sume mai mici decat 0.546 ori minimul comisionului de relay sunt afisate ca DUST
 Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(f?r? etichet?)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>schimb? la %1(%2)</translation>
+        <translation type="vanished">schimb? la %1(%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(schimb)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(f?r? etichet?)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">schimb? la %1(%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(schimb)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(schimb)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etichet?</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Confirmări</translation>
     </message>
 </context>
 <context>
@@ -1396,7 +1604,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1458,7 +1666,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1493,37 +1701,23 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etichet?</translation>
+        <translation type="obsolete">Etichet?</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Confirmări</translation>
+        <translation type="obsolete">Confirmări</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Confirmat</translation>
+        <translation type="obsolete">Confirmat</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,7 +1752,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1568,25 +1762,22 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(f?r? etichet?)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">schimb? la %1(%2)</translation>
+        <translation type="obsolete">schimb? la %1(%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(schimb)</translation>
+        <translation type="obsolete">(schimb)</translation>
     </message>
 </context>
 <context>
@@ -1736,7 +1927,12 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1761,7 +1957,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1937,7 +2133,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1952,6 +2148,11 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1960,7 +2161,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versiune</translation>
     </message>
@@ -1988,7 +2189,16 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2063,22 +2273,22 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2142,7 +2352,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2261,6 +2471,373 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Curăţă to&amp;ate</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">da</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">nu</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Blocarea portofelului a fost intrerupta</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2576,7 +3153,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation>Renunţă</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>iniţial</translation>
     </message>
@@ -2591,7 +3168,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
@@ -2819,18 +3396,23 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Copiaz? suma</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2841,9 +3423,227 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Stare</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2957,7 +3757,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,6 +3797,11 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3032,7 +3837,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished">Formular</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3042,7 +3847,17 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3055,7 +3870,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3108,6 +3923,83 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">da</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nu</translation>
     </message>
 </context>
 <context>
@@ -3192,12 +4084,17 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3222,12 +4119,12 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3314,7 +4211,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3352,7 +4249,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">indisponibil</translation>
     </message>
@@ -3468,14 +4365,48 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3485,7 +4416,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,12 +4431,35 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3515,7 +4469,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3577,6 +4531,11 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3672,7 +4631,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>indisponibil</translation>
     </message>
@@ -3773,7 +4732,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3991,7 +4950,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -4006,7 +4965,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation>Scrieţi &lt;b&gt;help&lt;/b&gt; pentru a vedea comenzile disponibile.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4064,12 +5023,6 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4161,40 +5114,37 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4652,7 +5602,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4773,7 +5723,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4887,7 +5837,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4910,7 +5860,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4922,7 +5872,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5046,7 +5996,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation>Trimit&amp;e</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Copia?i quantitea</translation>
     </message>
@@ -5106,7 +6056,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation>?i</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresa destinatarului nu este valid?, v? rug?m s? o verifica?i.</translation>
     </message>
@@ -5146,8 +6096,8 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation>Eroare: tranzac?ia a fost respins?. Acest lucru s-ar putea întâmpla în cazul în care unele dintre monedele din portofel au fost deja cheltuite, cum si cum a?i utilizat o copie a wallet.dat ?i monedele au fost cheltuite în copie dar nu au fost marcate ca ?i cheltuite aici.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(f?r? etichet?)</translation>
     </message>
@@ -5254,7 +6204,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5392,42 +6342,42 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
         <translation>Introduceti semnatura Gridcoin</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Adresa introdusa nu este valida</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Te rugam verifica adresa si introduce-o din nou</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Adresa introdusa nu se refera la o cheie.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Blocarea portofelului a fost intrerupta</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Cheia privata pentru adresa introdusa nu este valida.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Semnarea mesajului a esuat</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Mesaj Semnat!</translation>
     </message>
@@ -5438,7 +6388,7 @@ Acest lucru înseamn? c? o tax? de cel pu?in %2 este necesar?</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Verifica semnatura si incearca din nou</translation>
     </message>
@@ -5489,7 +6439,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5498,32 +6448,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Deschis pân? la %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>conflictual</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/deconectat</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/neconfirmat</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirm?ri</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Stare</translation>
     </message>
@@ -5547,74 +6497,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Sursa</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>De la</translation>
     </message>
@@ -5625,13 +6575,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>C?tre</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>Adresa posedata</translation>
@@ -5642,16 +6592,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etichet?</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5665,31 +6615,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>nu este acceptat</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Comisionul tranzac?iei</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Suma net?</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Comentarii</translation>
     </message>
@@ -5699,38 +6649,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Cantitate</translation>
     </message>
@@ -5762,11 +6712,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5786,7 +6741,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantitate</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5815,12 +6770,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmat (%1 confirm?ri)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Conflictual</translation>
     </message>
@@ -6045,7 +7000,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Starea tranzac?iei. Treci cu mausul peste acest câmp pentru afi?area num?rului de confirm?ri.</translation>
     </message>
@@ -6073,7 +7063,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6128,7 +7118,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cantitatea minim?</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Copiaz? adresa</translation>
     </message>
@@ -6158,7 +7153,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Arat? detaliile tranzac?iei</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exporta datele trazactiei</translation>
     </message>
@@ -6169,7 +7164,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Confirmat</translation>
     </message>
@@ -6214,7 +7209,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Nu s-a putut scrie în fi?ier %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Interval:</translation>
     </message>
@@ -6250,19 +7245,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Ieşire</translation>
+        <translation type="obsolete">Ieşire</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Închide aplicaţia</translation>
+        <translation type="obsolete">Închide aplicaţia</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Fişier</translation>
+        <translation type="obsolete">&amp;Fişier</translation>
     </message>
 </context>
 <context>
@@ -6276,7 +7268,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6302,18 +7294,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6390,15 +7382,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Se trimite...</translation>
+        <translation type="vanished">Se trimite...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>A intervenit o eroare in timp ce se seta portul RPC %u pentru ascultare pe IPv6, reintoarcere la IPv4: %s</translation>
     </message>
@@ -6408,27 +7399,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>A intervenit o eroare in timp ce se seta portul RPC %u pentru ascultare pe IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Uz:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>List? de comenzi</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Ajutor pentru o comand?</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Atentie: setarea -paytxfee este foarte ridicata! Aceasta este taxa tranzactiei pe care o vei plati daca trimiti o tranzactie.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Atentie: fisierul wallet.dat este corupt, date salvate! Fisierul original wallet.dat a fost salvat ca wallet.{timestamp}.bak in %s; daca balansul sau tranzactiile sunt incorecte ar trebui sa restaurati dintr-o copie de siguranta. </translation>
     </message>
@@ -6438,7 +7429,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Atentie: eroare la citirea fisierului wallet.dat! Toate cheile sunt citite corect, dar datele tranzactiei sau anumite intrari din agenda sunt incorecte sau lipsesc.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Eroare: crearea tranzac?iei a e?uat.</translation>
     </message>
@@ -6448,17 +7439,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Eroare: tranzac?ia a fost respins?. Acest lucru s-ar putea întâmpla în cazul în care unele dintre monedele din portofel au fost deja cheltuite, cum si cum a?i utilizat o copie a wallet.dat ?i monedele au fost cheltuite în copie dar nu au fost marcate ca ?i cheltuite aici.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Nu s-a reuşit ascultarea pe orice port. Folosiţi -listen=0 dacă vreţi asta.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Pentru a folosi op?iunea %s</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -6467,7 +7458,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Dac? fi?ierul nu exist?, creeaz?-l cu permisiuni de citire doar de c?tre proprietar.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Versiune Gridcoin</translation>
     </message>
@@ -6482,7 +7473,7 @@ Dac? fi?ierul nu exist?, creeaz?-l cu permisiuni de citire doar de c?tre proprie
         <translation>Suma invalida pentru -mininput=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+101"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Portofelul %s este in afara directorului %s</translation>
     </message>
@@ -6492,12 +7483,85 @@ Dac? fi?ierul nu exist?, creeaz?-l cu permisiuni de citire doar de c?tre proprie
         <translation>Se verifica integritatea bazei de date...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Eroare la ini?ializarea mediu de baze de date %s! Pentru a recupera, SALVATI ACEL DIRECTORr, apoi scoate?i totul din el, cu excep?ia wallet.dat.</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6588,6 +7652,16 @@ Dac? fi?ierul nu exist?, creeaz?-l cu permisiuni de citire doar de c?tre proprie
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6622,7 +7696,7 @@ Dac? fi?ierul nu exist?, creeaz?-l cu permisiuni de citire doar de c?tre proprie
         <translation>wallet.dat corupt, recuperare e?uat?</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Adresa -proxy nevalidă: &apos;%s&apos;</translation>
     </message>
@@ -6632,7 +7706,7 @@ Dac? fi?ierul nu exist?, creeaz?-l cu permisiuni de citire doar de c?tre proprie
         <translation>Adresa -tor invalida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Nu se poate rezolva adresa -bind: &apos;%s&apos;</translation>
     </message>
@@ -6642,23 +7716,23 @@ Dac? fi?ierul nu exist?, creeaz?-l cu permisiuni de citire doar de c?tre proprie
         <translation>Nu se poate rezolva adresa -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Suma invalida pentru -reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Eroare la înc?rcarea blkindex.dat</translation>
     </message>
     <message>
-        <location line="-316"/>
-        <location line="+344"/>
+        <location line="-351"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6683,12 +7757,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,21 +7782,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6748,11 +7808,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6772,7 +7827,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6812,7 +7867,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6848,11 +7903,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6892,12 +7942,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6962,7 +8007,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6974,11 +8019,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7049,16 +8089,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7182,11 +8212,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7209,16 +8234,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7297,16 +8312,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7329,11 +8334,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7377,18 +8377,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">indisponibil</translation>
+        <translation type="obsolete">indisponibil</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7409,6 +8403,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7632,78 +8631,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7758,16 +8687,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7817,7 +8736,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7827,37 +8746,37 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>A fost nevoie de rescrierea portofelului: restarta?i Gridcoin pentru a finaliza</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Eroare la înc?rcarea wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Se importa fisierul bootstrap blockchain</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Încărcare adrese...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Eroare: nodul nu a putut fi pornit</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Imposibil de conectat %s pe acest computer. Cel mai probabil Gridcoin ruleaza</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Nu se poate folosi %s pe acest calculator (eroarea returnat? este %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Eroare: portofel blocat, tranzactia nu s-a creat</translation>
     </message>
@@ -7872,37 +8791,36 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Eroare: Aceast? tranzac?ie necesit? un comision de tranzac?ie de cel pu?in %s din cauza valorii sale, complexitate, sau utilizarea de fonduri recent primite</translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Se trimite...</translation>
+        <translation type="vanished">Se trimite...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Sum? nevalid?</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Atentie: Va rugam verificati ca timpul si data calculatorului sunt corete. Daca timpul este gresit Gridcoin nu va functiona corect.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Avertisment: spa?iul pe disc este sc?zut!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Reţeaua specificată în -onlynet este necunoscută: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Fonduri insuficiente</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Încărcare index bloc...</translation>
     </message>
@@ -7912,17 +8830,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Încărcare portofel...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Nu se poate scrie adresa implicită</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Rescanare...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Încărcare terminată</translation>
     </message>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -34,7 +34,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,11 +43,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
@@ -60,6 +100,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation>Необходимый</translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">да</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">нет</translation>
     </message>
 </context>
 <context>
@@ -145,7 +220,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Удалить</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Копировать &amp;Метку</translation>
     </message>
@@ -155,7 +240,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Редактировать</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Экспортировать Данные Адресной Книги</translation>
     </message>
@@ -179,7 +264,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Метка</translation>
     </message>
@@ -190,8 +275,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(без метки)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -227,7 +323,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Только для стейкинга</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Введите новый пароль кошелька.&lt;br/&gt;Используйте пароль, состоящий из &lt;b&gt;десяти или более случайных символов&lt;/b&gt;, или &lt;b&gt;восьми или более слов&lt;/b&gt;.</translation>
     </message>
@@ -257,7 +353,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Введите старый и придумайте новый пароль для кошелька.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Подтвердите шифрование кошелька</translation>
     </message>
@@ -272,58 +368,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Вы уверены, что хотите зашифровать ваш кошелёк?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Кошелёк зашифрован</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Сейчас программа закроется для завершения процесса шифрования. Помните, что шифрование вашего кошелька не может полностью защитить ваши средства от кражи с помощью инфицирования вашего компьютера вредоносным ПО.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>ВАЖНО: все предыдущие резервные копии вашего кошелька должны быть заменены новым зашифрованным файлом. В целях безопасности предыдущие резервные копии незашифрованного кошелька станут бесполезны, как только вы начнёте использовать новый зашифрованный кошелёк.</translation>
+        <translation type="vanished">ВАЖНО: все предыдущие резервные копии вашего кошелька должны быть заменены новым зашифрованным файлом. В целях безопасности предыдущие резервные копии незашифрованного кошелька станут бесполезны, как только вы начнёте использовать новый зашифрованный кошелёк.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Не удалось зашифровать кошелёк</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Шифрование кошелька не удалось из-за внутренней ошибки. Ваш кошелёк не был зашифрован.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Введённые пароли не совпадают.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Разблокировка кошелька не удалась</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Неверный пароль для расшифровки кошелька.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Пароль кошелька успешно изменён.</translation>
     </message>
@@ -348,7 +468,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation>IP/Маска подсети</translation>
     </message>
@@ -361,12 +481,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Произошла неисправимая ошибка. Gridcoin не может безопасно продолжать работу и будет закрыт.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Кошелёк</translation>
     </message>
@@ -376,7 +496,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Обзор</translation>
     </message>
@@ -512,7 +637,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>В&amp;ыход</translation>
     </message>
@@ -637,6 +762,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Проверить сообщение...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Экспорт...</translation>
@@ -657,17 +787,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Открыть консоль отладки и диагностики</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation>&amp;Сбросить данные блокчейна</translation>
     </message>
@@ -687,12 +817,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Маскирует значения на Обзорном экране.</translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Настройки</translation>
     </message>
@@ -727,19 +877,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Без стекинга: отключено настройкой.</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[тестовая сеть]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin клиент</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation>Нет активных подключений к сети Gridcoin. Если это продолжается более пары минут, проверьте свои настройки и подключение к сети.</translation>
     </message>
@@ -818,17 +983,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Последний полученный блок был сгенерирован %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Транзакция превышает разрешенный лимит. Вы можете отправить её за комиссию в размере %1, которая отправляется узлам, обрабатывающим вашу транзакцию, и помогает поддерживать сеть. Вы хотите заплатить комиссию?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Подтвердите комиссию за транзакцию</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Исходящая транзакция</translation>
     </message>
@@ -849,17 +1014,15 @@ Address: %4</source>
 Адрес: %4</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation>Вы хотите загрузить и применить последний снимок состояния? Если да, кошелек отключится и выполнит задачу.</translation>
+        <translation type="vanished">Вы хотите загрузить и применить последний снимок состояния? Если да, кошелек отключится и выполнит задачу.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation>Внимание: отмена после этапа 2 приведет к синхронизации с 0 или поврежденными файлами цепочки блоков.</translation>
+        <translation type="vanished">Внимание: отмена после этапа 2 приведет к синхронизации с 0 или поврежденными файлами цепочки блоков.</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation>Вы хотите удалить данные блокчейна и выполнить синхронизацию с нуля?</translation>
     </message>
@@ -879,7 +1042,7 @@ Address: %4</source>
         <translation>Выйти из Gridcoin кошелька?</translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -897,7 +1060,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Обработка URI</translation>
@@ -914,7 +1087,7 @@ Are you sure you want to proceed?</source>
         <translation>Кошелёк &lt;b&gt;не зашифрован&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation>Кошелёк &lt;b&gt;зашифрован&lt;/b&gt; и сейчас %1 </translation>
     </message>
@@ -929,12 +1102,12 @@ Are you sure you want to proceed?</source>
         <translation>&lt;b&gt;полностью разблокирован&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Кошелёк &lt;b&gt;зашифрован&lt;/b&gt; и в настоящее время &lt;b&gt;заблокирован&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Бэкап Кошелька</translation>
     </message>
@@ -945,18 +1118,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Резервное копирование не удалось</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Произошла ошибка при попытке сохранить данные кошелька в новом месте.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation>Бэкап Конфигурации</translation>
     </message>
@@ -966,7 +1138,12 @@ Are you sure you want to proceed?</source>
         <translation>Конфигурация Кошелька (*.conf)</translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation>недоступно</translation>
     </message>
@@ -1058,7 +1235,7 @@ Scraper(ов) не публикуются: %5.</translation>
         <translation>Scraper: Невозможно достичь схождения. Повторная попытка через несколько минут.</translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1116,12 +1293,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Сетевая Тревога</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation>Низкая сложность!;</translation>
     </message>
@@ -1180,7 +1357,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation>Выбрать Всё</translation>
     </message>
@@ -1230,42 +1407,36 @@ Expires: %3
         <translation>Готово к объединению</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Сумма</translation>
+        <translation type="vanished">Сумма</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Дата</translation>
+        <translation type="vanished">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Подтверждения</translation>
+        <translation type="vanished">Подтверждения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Подтверждено</translation>
+        <translation type="vanished">Подтверждено</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Метка</translation>
+        <translation type="vanished">Метка</translation>
     </message>
     <message>
-        <location line="-128"/>
+        <location line="-80"/>
         <source>&amp;List mode</source>
         <translation>&amp;Режим списка</translation>
     </message>
     <message>
-        <location line="+133"/>
         <source>Address</source>
-        <translation>Адрес</translation>
+        <translation type="vanished">Адрес</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Копировать адрес</translation>
     </message>
@@ -1276,17 +1447,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Копировать сумму</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Копировать ID транзакции</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Копировать количество</translation>
     </message>
@@ -1316,17 +1487,17 @@ Expires: %3
         <translation>Копировать сдачу</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation>Переворачивает режим фильтрации между выбором поступлений, меньших или равных указанному значению (&lt;=) и больше или равных предоставленному значению (&gt;=). Фильтр также автоматически ограничивает количество входов до %1 в порядке возрастания для &lt;= и порядке убывания для &gt;=.</translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation>Очистить Выбор</translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>ПЫЛЬ</translation>
     </message>
@@ -1376,20 +1547,65 @@ Expires: %3
  Это означает, что требуется комиссия не менее %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(нет метки)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>сдача с %1 (%2)</translation>
+        <translation type="vanished">сдача с %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(сдача)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">сдача с %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(сдача)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Сумма</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(сдача)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Метка</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Адрес</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Дата</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Подтверждения</translation>
     </message>
 </context>
 <context>
@@ -1415,7 +1631,7 @@ Expires: %3
         <translation>Адрес</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation>Примечание: Количество поступлений, выбранных для объединения, ограничено %1 во избежание сбоя транзакции из-за слишком большого количества поступлений.</translation>
     </message>
@@ -1477,7 +1693,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation>Выбрать Всё</translation>
     </message>
@@ -1512,37 +1728,31 @@ Expires: %3
         <translation>Фильтровать</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Сумма</translation>
+        <translation type="vanished">Сумма</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation>Метка</translation>
+        <translation type="vanished">Метка</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Адрес</translation>
+        <translation type="vanished">Адрес</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>Дата</translation>
+        <translation type="vanished">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Подтверждения</translation>
+        <translation type="vanished">Подтверждения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Подтверждено</translation>
+        <translation type="vanished">Подтверждено</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation>Количество</translation>
     </message>
@@ -1577,7 +1787,7 @@ Expires: %3
         <translation>Завершено</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation>Примечание: Количество поступлений, выбранных для объединения, ограничено %1 во избежание сбоя транзакции из-за слишком большого количества поступлений.</translation>
     </message>
@@ -1587,25 +1797,22 @@ Expires: %3
         <translation>Примечание: Количество поступлений, выбранных для объединения, в настоящее время превышает ограничение %1. Пожалуйста, используйте фильтр или ручной выбор, чтобы уменьшить количество входных данных до %1 или меньше, чтобы предотвратить сбой транзакции из-за слишком большого количества поступлений.</translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation>Очистить Выбор</translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation>(нет метки)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>сдача с %1 (%2)</translation>
+        <translation type="vanished">сдача с %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation>(сдача)</translation>
+        <translation type="vanished">(сдача)</translation>
     </message>
 </context>
 <context>
@@ -1755,7 +1962,12 @@ Expires: %3
         <translation>Проверить</translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation>Проверка...</translation>
     </message>
@@ -1780,7 +1992,7 @@ Expires: %3
         <translation>Неудачно</translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation>Один или несколько тестов выдали статус &quot;Внимание&quot;. Работа кошелька может ухудшиться. Подробные сведения и рекомендуемые действия смотрите в подсказках для отдельных(ого) тестов.</translation>
     </message>
@@ -1956,7 +2168,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation>Будет создан новый каталог данных.</translation>
     </message>
@@ -1971,6 +2183,11 @@ Expires: %3
         <translation>Путь уже существует и не является каталогом.</translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Невозможно здесь создать каталог данных.</translation>
@@ -1979,7 +2196,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>версия</translation>
     </message>
@@ -2042,7 +2259,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation>Ошибка: Невозможно создать указанный каталог &quot;%1&quot;.</translation>
     </message>
@@ -2082,22 +2308,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation>Чтобы отправить MRC, у вас должен быть зрелый баланс не менее 1 GRC.</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation>Общая сумма комиссии (минимальная комиссия + повышение комиссии) превышает причитающиеся вознаграждения.</translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation>Ваш MRC был успешно отправлен ранее, но теперь устарел без привязки к только что полученному блоку стейкером. Это может быть связано с тем, что ваш MRC был отправлен непосредственно перед тем, как блок был поставлен, и MRC не дошел до стейкера вовремя, или ваш MRC был перемещен в очередь после превышения лимита выплат. Подождите, пока следующий блок очистит очередь, и повторите попытку.</translation>
     </message>
@@ -2161,7 +2387,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2281,6 +2507,373 @@ Expires: %3
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation>Чтобы отправить MRC, у вас должен быть зрелый баланс не менее 1 GRC.</translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Очистить &amp;Всё</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">да</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">нет</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Разблокировка кошелька была отменена.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2595,7 +3188,7 @@ Expires: %3
         <translation>&amp;Отмена</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>по умолчанию</translation>
     </message>
@@ -2610,7 +3203,7 @@ Expires: %3
         <translation>Лайт</translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Ошибка</translation>
@@ -2838,18 +3431,23 @@ Expires: %3
         <translation>Текущие Опросы</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation>Не синхронизировано</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Копировать сумму</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation>Пул</translation>
     </message>
@@ -2860,9 +3458,227 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n секунд(у)</numerusform>
+            <numerusform>%n секунд(у)</numerusform>
+            <numerusform>%n секунд(у)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n минут(у)</numerusform>
+            <numerusform>%n минут(у)</numerusform>
+            <numerusform>%n минут(у)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n час(ов)</numerusform>
+            <numerusform>%n час(ов)</numerusform>
+            <numerusform>%n час(ов)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n день</numerusform>
+            <numerusform>%n дней</numerusform>
+            <numerusform>%n дней</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Статус</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Сумма</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation>ID Узла</translation>
     </message>
@@ -2976,7 +3792,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation>Голосование завершено.</translation>
     </message>
@@ -3016,6 +3832,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation>Популярный ответ:</translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3051,7 +3872,7 @@ Expires: %3
         <translation>Форма</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation>Нажмите &quot;Обновить&quot; для обновления списка.</translation>
     </message>
@@ -3061,7 +3882,17 @@ Expires: %3
         <translation>Это может занять пару минут.</translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation>Показать результаты</translation>
     </message>
@@ -3074,7 +3905,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation>Заголовок</translation>
     </message>
@@ -3127,6 +3958,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">да</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">нет</translation>
     </message>
 </context>
 <context>
@@ -3211,12 +4119,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation>Создать Опрос</translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation>Баланс</translation>
     </message>
@@ -3241,12 +4154,12 @@ Expires: %3
         <translation>Множественный Выбор</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation>Этот опрос будет стоить %1 плюс комиссия за транзакцию. Продолжить?</translation>
     </message>
@@ -3333,7 +4246,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
@@ -3371,7 +4284,35 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
@@ -3380,7 +4321,13 @@ Expires: %3
 </translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation>Ошибка: Не удается прочитать файл конфигурации. Пожалуйста, проверьте путь и формат файла.</translation>
     </message>
@@ -3390,7 +4337,7 @@ Expires: %3
         <translation>Ошибка: Указанная директория &quot;%1&quot; не существует.</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation>Ошибка: Не удается заблокировать указанный каталог данных. Вероятно этот каталог уже занят.</translation>
     </message>
@@ -3405,12 +4352,35 @@ Expires: %3
         <translation>Ошибка инициализации настроек: %1</translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation>%1 еще не был благополучно завершен...</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation>Нет данных</translation>
     </message>
@@ -3531,7 +4501,7 @@ Expires: %3
         <translation>Осталось %1.</translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3541,7 +4511,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3598,6 +4568,11 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>MRCs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3693,7 +4668,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>Н/Д</translation>
     </message>
@@ -3774,7 +4749,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation>Выберите пир для просмотра подробной информации.</translation>
     </message>
@@ -4012,7 +4987,7 @@ Expires: %3
         <translation>Нет</translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation>Добро пожаловать в Gridcoin RPC консоль! </translation>
     </message>
@@ -4027,7 +5002,7 @@ Expires: %3
         <translation>Напишите &lt;b&gt;help&lt;/b&gt; для просмотра доступных команд.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation>%1 Б</translation>
     </message>
@@ -4088,10 +5063,8 @@ Expires: %3
         <translation>Исходящий</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+6"/>
         <source>Unknown</source>
-        <translation>Неизвестно</translation>
+        <translation type="vanished">Неизвестно</translation>
     </message>
 </context>
 <context>
@@ -4182,40 +5155,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation>Ожидание синхронизации...</translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation>Нет в белом списке</translation>
     </message>
     <message>
-        <location line="+32"/>
+        <location line="+3"/>
         <source>Not attached</source>
         <translation>Не прикреплен</translation>
     </message>
     <message>
-        <location line="-2"/>
+        <location line="+3"/>
         <source>Uses external adapter</source>
         <translation>Использует внешний адаптер</translation>
     </message>
@@ -4686,7 +5656,7 @@ Expires: %3
         <translation>Нажмите &quot;Далее&quot;, когда закончите.</translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation>Метка Адреса</translation>
     </message>
@@ -4807,7 +5777,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation>Все выглядит хорошо.</translation>
     </message>
@@ -4921,7 +5891,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4944,7 +5914,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation>Доступно (%1)</translation>
@@ -4956,7 +5926,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation>Неактивно</translation>
     </message>
@@ -5080,7 +6050,7 @@ Expires: %3
         <translation>Введите Gridcoin адрес (например S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Копировать количество</translation>
     </message>
@@ -5140,7 +6110,7 @@ Expires: %3
         <translation> и </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Адрес получателя неверный, пожалуйста, перепроверьте.</translation>
     </message>
@@ -5180,8 +6150,8 @@ Expires: %3
         <translation>Ошибка: Транзакция отклонена. Это может произойти, если некоторые из монет в вашем кошельке уже были потрачены, например, если вы использовали старую копию wallet.dat и монеты были потрачены в копии, но не отмечены здесь как потраченные.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(без метки)</translation>
     </message>
@@ -5288,7 +6258,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Адрес</translation>
     </message>
@@ -5426,42 +6396,42 @@ Expires: %3
         <translation>Введите подпись Gridcoin</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Введен неверный адрес.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Пожалуйста, проверьте адрес и попробуйте ещё раз.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Введённый адрес не связан с ключом.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Разблокировка кошелька была отменена.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Закрытый ключ для введенного адреса недоступен.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Не удалось подписать сообщение.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Сообщение подписано.</translation>
     </message>
@@ -5472,7 +6442,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Пожалуйста, проверьте подпись и попробуйте ещё раз.</translation>
     </message>
@@ -5523,7 +6493,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation>
             <numerusform>Открыть еще на %n блок(ов)</numerusform>
@@ -5532,32 +6502,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Открыто до %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>в противоречии</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/отключен</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/не подтверждено</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 подтверждений</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Статус</translation>
     </message>
@@ -5581,74 +6551,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Источник</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation>Сгенерировано в CoinBase</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation>Майнер - PoS</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation>Майнер - PoS+RR</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation>Майнер - Orphaned</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation>Побочная Ставка PoS Получена</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation>Побочная Ставка PoS+RR Получена</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation>Побочная Ставка PoS Отправлена</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation>Побочная Ставка PoS+RR Отправлена</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation>MRC Платёж Получен</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation>MRC Платёж Отправлен</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation>Майнер - Суперблок</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation>Майнер - неизвестно</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>От</translation>
     </message>
@@ -5659,13 +6629,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Для</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>свой адрес</translation>
@@ -5676,16 +6646,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>метка</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Кредит</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation>
             <numerusform>созревает еще %n блок(ов)</numerusform>
@@ -5699,31 +6669,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>не принято</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Дебет</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Комиссия</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Чистая сумма</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Сообщение</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Комментарий</translation>
     </message>
@@ -5733,38 +6703,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation>Хэш Блока</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation>Данные о Транзакциях</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Сгенерированные гридкойн-монеты должны созреть до значения в 110 блоков, прежде чем их можно будет потратить. Когда вы сгенерировали блок, он будет передан в сеть для добавления в цепочку блоков. Если он не сможет попасть в цепочку, его состояние изменится на «не принято», в таком случае вы не сможете потратить монеты. Это может произойти, если другой узел генерирует блок в течение нескольких секунд после вашего.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation>Дебеты/Кредиты Транзакции</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation>Данные Транзакции</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation>Входящие Транзакции</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Сумма</translation>
     </message>
@@ -5796,11 +6766,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation>З&amp;акрыть</translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
@@ -5820,7 +6795,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Сумма</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation>
             <numerusform>Открыто еще %n блок(ов)</numerusform>
@@ -5849,12 +6824,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Подтверждение (%1 из %2 гарантированных подтверждений)&lt;br&gt;</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Подтверждено (%1 подтверждений)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>В противоречии</translation>
     </message>
@@ -6079,7 +7054,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Статус транзакции. Подведите курсор к этому полю, чтобы увидеть количество подтверждений.</translation>
     </message>
@@ -6107,7 +7117,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation>История Транзакций</translation>
     </message>
@@ -6162,7 +7172,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Мин. сумма</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Копировать адрес</translation>
     </message>
@@ -6192,7 +7207,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Показать подробности транзакции</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Экспорт Данных Транзакции</translation>
     </message>
@@ -6203,7 +7218,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Файл с разделителями-запятыми</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Подтверждено</translation>
     </message>
@@ -6248,7 +7263,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Не удалось записать в файл %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Диапазон:</translation>
     </message>
@@ -6284,19 +7299,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation>В&amp;ыход</translation>
+        <translation type="vanished">В&amp;ыход</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation>Закрыть приложение</translation>
+        <translation type="vanished">Закрыть приложение</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation>&amp;Файл</translation>
+        <translation type="vanished">&amp;Файл</translation>
     </message>
 </context>
 <context>
@@ -6310,7 +7322,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation>Отправить Голос</translation>
     </message>
@@ -6336,18 +7348,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation>Пожалуйста, разблокируйте кошелек.</translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation>Опрос не найден.</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation>Не удалось загрузить опрос с диска</translation>
     </message>
@@ -6424,15 +7436,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Отправка...</translation>
+        <translation type="vanished">Отправка...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Произошла ошибка при открытии на прослушивание IPv6 RCP-порта %u, возвращаемся к IPv4: %s</translation>
     </message>
@@ -6442,33 +7453,33 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Произошла ошибка при открытии RPC-порта %u для прослушивания на IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Использование:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Список команд</translation>
     </message>
     <message>
-        <location line="-367"/>
-        <location line="+344"/>
+        <location line="-397"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-342"/>
+        <location line="-374"/>
         <source>The Gridcoin developers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+19"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation>Опрос с типом ответа &quot;Да/Нет/Воздержаться&quot; не может включать какие-либо дополнительные настраиваемые варианты.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6483,21 +7494,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Убедитесь, что BOINC установлен и что указан правильный путь в файле конфигурации, если вы установили его в нестандартное место.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+46"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation>Ошибка: расхождение часов составляет 5 минут или больше. Пожалуйста, проверьте настройки часов.</translation>
     </message>
@@ -6517,7 +7514,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Ошибка: Эта транзакция требует комиссии за транзакцию в размере не менее %s из-за ее суммы, сложности или использования недавно полученных средств</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+6"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6532,7 +7529,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Для опросов о представлении сообщества, связях с общественностью и коммуникации.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation>Пожалуйста, проверьте свою сеть, а также проверьте файл конфигурации и убедитесь, что ваши записи надстроек обновлены. Если вы недавно запустили кошелек, вы можете подождать еще несколько минут, пока не установится соединение, и снова повторите тестирование. Пожалуйста посмотрите https://gridcoin.us/wiki/config-file.html и https://addnodes.cycy.me/.</translation>
     </message>
@@ -6572,7 +7569,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation>В сети произошла низкоуровневая ошибка, которая, вероятно, означает, что ваш IP-адрес или другие параметры сетевого подключения настроены неправильно. Пожалуйста, проверьте конфигурацию сети на вашем компьютере.</translation>
     </message>
@@ -6607,7 +7604,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Доступна новая обязательная версия, и вам следует обновить её как можно скорее, чтобы обеспечить согласованность вашего кошелька с сетью.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+5"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation>Убедитесь, что (1) у вас правильно установлен BOINC, (2) что вы прикрепили хотя бы один проект из белого списка, (3) что вы объявили свой маяк с помощью того же адреса электронной почты, который вы используете для своих проект(ов) BOINC, и (4), что CPID на главном экране совпадает с CPID при входе в проект(ы) BOINC.</translation>
     </message>
@@ -6647,12 +7644,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Внимание: ETTS бесконечен. Нет монет для стейкинга - увеличьте баланс или используйте MRC</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation>Внимание: Завершение этого процесса после Этапа 2 приведет к синхронизации с 0 или неполной/поврежденной цепочке блоков.</translation>
+        <translation type="vanished">Внимание: Завершение этого процесса после Этапа 2 приведет к синхронизации с 0 или неполной/поврежденной цепочке блоков.</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation>У вас нулевой баланс и вы не сможете получать свои награды за исследования в одиночку. Вы можете использовать MRC для получения своих наград, или вам следует приобрести GRC, чтобы стейкать и для возможности получать свои награды за исследования. Смотрите https://gridcoin.us/guides/boinc-install.htm.</translation>
     </message>
@@ -6717,7 +7713,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Ваш кошелек все еще находится в начальной синхронизации. Если это синхронизация с самого начала (создания), то процесс синхронизации может занять от 2 до 4 часов, а на медленном компьютере дольше. Если вы уже синхронизировали свой кошелек раньше, но только что его запустили, подождите еще несколько минут и повторите попытку диагностики еще раз.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation>Вариант опроса не может быть пустым.</translation>
     </message>
@@ -6730,11 +7726,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <location line="+1"/>
         <source>Active</source>
         <translation type="unfinished">Активно</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6764,16 +7755,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6847,11 +7828,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation>Не удалось переименовать файл начальной загрузки в .old для резервного копирования.</translation>
@@ -6877,14 +7853,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Для опросов общественного мнения или случайных опросов без каких-либо особых требований.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>GB)</source>
-        <translation>ГБ)</translation>
+        <translation type="vanished">ГБ)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>GB/</source>
-        <translation>ГБ/</translation>
+        <translation type="vanished">ГБ/</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6927,12 +7901,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Недостаточно средств.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>KB/s</source>
-        <translation>КБ/с</translation>
+        <translation type="vanished">КБ/с</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+16"/>
         <source>Loading history for contract type </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6947,9 +7920,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Локальная версия: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MB/s</source>
-        <translation>МБ/с</translation>
+        <translation type="vanished">МБ/с</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -6982,9 +7954,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Множественный Выбор</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation>Нет данных</translation>
+        <translation type="vanished">Нет данных</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6992,9 +7963,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Нет доступных UTXO из-за зарезервированного баланса</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>No address contains %s GRC in %s UTXOs or fewer.</source>
-        <translation>Ни один адрес не содержит %s GRC в %s UTXO или меньшем количестве.</translation>
+        <translation type="vanished">Ни один адрес не содержит %s GRC в %s UTXO или меньшем количестве.</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -7010,6 +7980,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <location line="+1"/>
         <source>No mature coins</source>
         <translation>Нет зрелых монет</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -7212,46 +8187,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Отправьте команду -server или gridcoinresearchd</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+4"/>
         <source>Staking Only - Non-cruncher Mode</source>
         <translation type="unfinished"></translation>
@@ -7277,16 +8212,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+4"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation>Не удалось создать PID файл &apos;%s&apos;: %s</translation>
@@ -7297,7 +8222,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Неизвестный тип опроса. Это никогда не должно случаться.</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+9"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7388,6 +8318,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7412,22 +8352,90 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>неизвестный</translation>
     </message>
     <message>
-        <location line="-224"/>
+        <location line="-201"/>
         <source>Balance</source>
         <translation>Баланс</translation>
     </message>
     <message>
-        <location line="-281"/>
+        <location line="-318"/>
         <source>The %s developers</source>
         <translation>Разработчики %s</translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+15"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+31"/>
         <source>Error: Unsupported argument -socks found. Setting SOCKS version isn&apos;t possible anymore, only SOCKS5 proxies are supported.</source>
         <translation>Ошибка: найден неподдерживаемый аргумент -socks. Установка версии SOCKS больше невозможна, поддерживаются только SOCKS5 прокси.</translation>
     </message>
     <message>
-        <location line="+210"/>
+        <location line="+15"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Block Version</source>
         <translation>Версия Блока</translation>
     </message>
@@ -7462,7 +8470,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Награда BOINC</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+9"/>
         <source>Client Version</source>
         <translation>Версия Клиента</translation>
     </message>
@@ -7502,7 +8510,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Ошибка: Кошелёк заблокирован, невозможно создать транзакцию.</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+13"/>
         <source>GitHub version: </source>
         <translation>Версия на GitHub: </translation>
     </message>
@@ -7537,9 +8545,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Суперблок</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Latest Version GitHub data response:</source>
-        <translation>Ответ последней версии GitHub:</translation>
+        <translation type="vanished">Ответ последней версии GitHub:</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -7552,7 +8559,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Загрузка банлиста...</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+6"/>
         <source>Magnitude</source>
         <translation>Магнитуда</translation>
     </message>
@@ -7562,7 +8569,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Неправильный CPID</translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+14"/>
         <source>Organization</source>
         <translation>Организация</translation>
     </message>
@@ -7572,12 +8579,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Несоответствие электронной почты проекта</translation>
     </message>
     <message>
-        <location line="-251"/>
+        <location line="-239"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Внимание: установлено очень большое значение -paytxfee. Это комиссия, которую вы заплатите при проведении транзакции.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Внимание: wallet.dat повреждён, данные восстановлены! Оригинальный wallet.dat сохранён как wallet.{timestamp}.bak в %s; если ваш баланс или транзакции некорректны, вы должны восстановить файл из резервной копии.</translation>
     </message>
@@ -7587,7 +8594,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Внимание: ошибка чтения wallet.dat! Все ключи прочитаны верно, но данные транзакций или записи адресной книги могут отсутствовать или быть неправильными.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Ошибка: Не удалось создать транзакцию  </translation>
     </message>
@@ -7597,32 +8604,30 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Ошибка: транзакция была отклонена! Это могло произойти в случае, если некоторые монеты в вашем кошельке уже были потрачены, например, если вы используете копию wallet.dat, и монеты были использованы в копии, но не отмечены как потраченные здесь.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Не удалось начать прослушивание на порту. Используйте -listen=0 если вас это устраивает.</translation>
     </message>
     <message>
-        <location line="+107"/>
+        <location line="+100"/>
         <source>Single Choice</source>
         <translation>Единственный Выбор</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Snapshot Process Complete!</source>
-        <translation>Процесс создания Снимка Завершен!</translation>
+        <translation type="vanished">Процесс создания Снимка Завершен!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Snapshot Process Has Begun.</source>
-        <translation>Процесс создания Снимка Начался.</translation>
+        <translation type="vanished">Процесс создания Снимка Начался.</translation>
     </message>
     <message>
-        <location line="+26"/>
+        <location line="+12"/>
         <source>To use the %s option</source>
         <translation>Чтобы использовать опцию %s</translation>
     </message>
     <message>
-        <location line="-463"/>
+        <location line="-474"/>
         <source>%s, you must set a rpcpassword in the configuration file:
  %s
 It is recommended you use the following random password:
@@ -7647,27 +8652,25 @@ rpcpassword=%s
 </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+42"/>
         <source>Due to the failure to delete the blockchain data you will be required to manually delete the data before starting your wallet.</source>
         <translation>Из-за невозможности удалить данные блокчейна вам потребуется вручную удалить данные перед запуском кошелька.</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation>Не удалось загрузить снимок, так как доступен обязательный клиент.</translation>
+        <translation type="vanished">Не удалось загрузить снимок, так как доступен обязательный клиент.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+69"/>
         <source>Failure to do so will result in undefined behaviour or failure to start wallet.</source>
         <translation>Невыполнение этого требования приведет к неопределенному поведению или невозможности запуска кошелька.</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation>Не удалось загрузить снимок, так как кошелек обнаружил, что доступна новая обязательная версия для установки . Обязательное обновление должно быть установлено до загрузки и применения снимка.</translation>
+        <translation type="vanished">Не удалось загрузить снимок, так как кошелек обнаружил, что доступна новая обязательная версия для установки . Обязательное обновление должно быть установлено до загрузки и применения снимка.</translation>
     </message>
     <message>
-        <location line="+50"/>
+        <location line="+126"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7676,37 +8679,33 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Если файл не существует, создайте его и установите права доступа только для владельца.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Gridcoin версия</translation>
     </message>
     <message>
-        <location line="+92"/>
+        <location line="+88"/>
         <source>Resetting block chain index to prepare for reindexing...</source>
         <translation>Сброс индекса цепочки блоков для подготовки к переиндексации...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation>Этап (1/4): Загрузка snapshot.zip: </translation>
+        <translation type="vanished">Этап (1/4): Загрузка snapshot.zip: </translation>
+    </message>
+    <message>
+        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
+        <translation type="vanished">Этап (2/4): Проверка SHA256SUM snapshot.zip: </translation>
+    </message>
+    <message>
+        <source>Stage (3/4): Cleanup blockchain data:          </source>
+        <translation type="vanished">Стадия (3/4): Очистка данных блокчейна: </translation>
+    </message>
+    <message>
+        <source>Stage (4/4): Extracting snapshot.zip:          </source>
+        <translation type="vanished">Этап (4/4): Распаковка snapshot.zip: </translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation>Этап (2/4): Проверка SHA256SUM snapshot.zip: </translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation>Стадия (3/4): Очистка данных блокчейна: </translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
-        <translation>Этап (4/4): Распаковка snapshot.zip: </translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Staking Only - No Eligible Research Projects</source>
         <translation>Только Стейкинг — Нет Подходящих Исследовательских Проектов</translation>
     </message>
@@ -7716,7 +8715,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Версия только для тестовой сети</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+8"/>
         <source>Unknown error</source>
         <translation>Неизвестная ошибка</translation>
     </message>
@@ -7726,7 +8725,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Неизвестный</translation>
     </message>
     <message>
-        <location line="-21"/>
+        <location line="-19"/>
         <source>Staking Only - No active beacon</source>
         <translation>Только Стейкинг — Нет активного маяка</translation>
     </message>
@@ -7741,7 +8740,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Двоичный Размер Суперблока</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+6"/>
         <source>This update is </source>
         <translation>Это обновление </translation>
     </message>
@@ -7761,12 +8760,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Неизвестный тип веса опроса.</translation>
     </message>
     <message>
-        <location line="-85"/>
+        <location line="-69"/>
         <source>No current polls</source>
         <translation>Нет текущих опросов</translation>
     </message>
     <message>
-        <location line="-30"/>
+        <location line="-25"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Неверная сумма в параметре -paytxfee=&lt;кол-во&gt;: &apos;%s&apos;</translation>
     </message>
@@ -7781,7 +8780,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Инициализация проверки работоспособности не удалась. Gridcoin закрывается.</translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Кошелёк %s располагается вне каталога %s.</translation>
     </message>
@@ -7791,12 +8790,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Проверка целостности базы данных...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-404"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Ошибка инициализации среды базы данных %s! Чтобы восстановить, СДЕЛАЙТЕ БЕКАП ДАННОЙ ДИРЕКТОРИИ, затем удалите все, кроме него, за исключением wallet.dat.</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+436"/>
         <source>vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7806,7 +8805,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>wallet.dat повреждён, восстановление не удалось</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Неверный адрес -proxy: &apos;%s&apos;</translation>
     </message>
@@ -7816,7 +8815,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Недопустимый адрес -tor: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Не удаётся разрешить адрес в параметре -bind: &apos;%s&apos;</translation>
     </message>
@@ -7826,12 +8825,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Не удаётся разрешить адрес в параметре -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Недопустимая сумма для -reservebalance = &lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Ошибка при загрузке blkindex.dat</translation>
     </message>
@@ -7846,17 +8845,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Ошибка загрузки wallet.dat: Кошелёк требует более новой версии Gridcoin</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+68"/>
         <source>Offline</source>
         <translation>Не в сети</translation>
     </message>
     <message>
-        <location line="+83"/>
+        <location line="+66"/>
         <source>Verifying checkpoints...</source>
         <translation>Проверка контрольных точек...</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Wallet locked</source>
         <translation>Кошелёк заблокирован</translation>
     </message>
@@ -7866,37 +8865,37 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Необходимо перезаписать кошелёк: перезапустите Gridcoin для завершения операции</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Ошибка при загрузке wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Импорт файла данных блокировки bootstrap.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Загрузка адресов...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Ошибка: не удалось запустить узел</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Невозможно забиндиться %s на этом компьютере. Gridcoin вероятно уже запущен.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Невозможно привязаться к %s на этом компьютере (bind вернул ошибку %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Ошибка: кошелёк заблокирован, невозможно создать транзакцию  </translation>
     </message>
@@ -7911,42 +8910,41 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Ошибка: эта транзакция требует комиссию как минимум %s из-за суммы, сложности или использования недавно полученных средств  </translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Отправка...</translation>
+        <translation type="vanished">Отправка...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Неверная сумма</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Внимание: убедитесь, что дата и время на Вашем компьютере выставлены верно. Если Ваши часы идут неправильно, Gridcoin будет работать некорректно.</translation>
     </message>
     <message>
-        <location line="+291"/>
+        <location line="+265"/>
         <source>Vote signature failed. See debug.log.</source>
         <translation>Не удалось подписать голос. Смотрите debug.log.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Warning: Disk space is low!</source>
         <translation>Внимание: Недостаточно места на диске!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>В параметре -onlynet указана неизвестная сеть: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Недостаточно монет</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Загрузка индекса блоков...</translation>
     </message>
@@ -7956,17 +8954,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Загрузка кошелька...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Не удаётся записать адрес по умолчанию</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Сканирование...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Загрузка завершена</translation>
     </message>

--- a/src/qt/locale/bitcoin_sk.ts
+++ b/src/qt/locale/bitcoin_sk.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">áno</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nie</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Zmazať</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopírovať &amp;Popis</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Upraviť</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exportovať dáta z adresára</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Názov</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Len pre stávkovanie</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Zadané heslá nesúhlasia.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Peňaženka</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Prehľad</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>U&amp;končiť</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>O&amp;veriť správu...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Otvor konzolu pre ladenie a diagnostiku</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Súbor</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Nastavenia</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin klient</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,17 +969,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Posledný prijatý blok bol vytvorený %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Odoslané transakcie</translation>
     </message>
@@ -836,17 +997,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -866,7 +1017,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -884,7 +1035,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>URI manipulácia</translation>
@@ -901,7 +1062,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +1077,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Peňaženka je &lt;b&gt;zašifrovaná&lt;/b&gt; a momentálne &lt;b&gt;zamknutá&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -932,18 +1093,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Zálohovanie zlyhalo</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +1113,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1040,7 +1205,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1089,7 +1254,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,12 +1262,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Výstraha siete</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,7 +1326,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1216,37 +1381,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Suma</translation>
+        <translation type="vanished">Suma</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Názov</translation>
+        <translation type="obsolete">Názov</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Dátum</translation>
+        <translation type="vanished">Dátum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Potvrdenia</translation>
+        <translation type="vanished">Potvrdenia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Potvrdené</translation>
+        <translation type="vanished">Potvrdené</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Adresa</translation>
+        <translation type="vanished">Adresa</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1257,17 +1416,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1297,17 +1456,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>áno</translation>
     </message>
@@ -1347,20 +1506,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(bez popisu)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Názov</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresa</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Dátum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Potvrdenia</translation>
     </message>
 </context>
 <context>
@@ -1386,7 +1582,7 @@ Expires: %3
         <translation type="unfinished">Adresa</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1448,7 +1644,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,37 +1679,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Názov</translation>
+        <translation type="obsolete">Názov</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adresa</translation>
+        <translation type="obsolete">Adresa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Dátum</translation>
+        <translation type="obsolete">Dátum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Potvrdenia</translation>
+        <translation type="obsolete">Potvrdenia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Potvrdené</translation>
+        <translation type="obsolete">Potvrdené</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1548,7 +1734,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,25 +1744,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(bez popisu)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1726,7 +1901,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1751,7 +1931,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1927,7 +2107,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,6 +2122,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1950,7 +2135,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>verzia</translation>
     </message>
@@ -1978,7 +2163,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2053,22 +2247,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2132,7 +2326,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2251,6 +2445,373 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;Zmazať všetko</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">áno</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">nie</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2566,7 +3127,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>predvolené</translation>
     </message>
@@ -2581,7 +3142,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
@@ -2809,18 +3370,23 @@ Expires: %3
         <translation>Váš súčasný celkový zostatok</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2831,9 +3397,227 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Stav</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2947,7 +3731,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2987,6 +3771,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3022,7 +3811,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3032,7 +3821,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,7 +3844,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3098,6 +3897,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">áno</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nie</translation>
     </message>
 </context>
 <context>
@@ -3182,12 +4058,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3212,12 +4093,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3304,7 +4185,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3342,7 +4223,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">nie je k dispozícii</translation>
     </message>
@@ -3458,14 +4339,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4390,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,12 +4405,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,7 +4443,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3567,6 +4505,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4605,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>nie je k dispozícii</translation>
     </message>
@@ -3788,7 +4731,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4924,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3996,7 +4939,7 @@ Expires: %3
         <translation>Napíš &lt;b&gt;help&lt;/b&gt; pre prehľad dostupných príkazov.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4054,12 +4997,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4151,40 +5088,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4642,7 +5576,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4763,7 +5697,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4877,7 +5811,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4900,7 +5834,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4912,7 +5846,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5036,7 +5970,7 @@ Expires: %3
         <translation>&amp;Odoslať</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5096,7 +6030,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresa príjemcu je neplatná, overte ju prosím.</translation>
     </message>
@@ -5136,8 +6070,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
     </message>
@@ -5244,7 +6178,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresa</translation>
     </message>
@@ -5382,58 +6316,58 @@ Expires: %3
         <translation>Zadajte Gridcoin podpis</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Zadaná adresa je neplatná.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Prosím skontrolujte adresu a skúste znova.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Podpísanie správy zlyhalo.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Správa podpísaná.</translation>
     </message>
     <message>
         <location line="+61"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Prosím skontrolujte podpis a skúste znova.</translation>
     </message>
     <message>
-        <location line="-13"/>
+        <location line="-16"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>The signature did not match the message digest.</source>
         <translation>Podpis nezodpovedá súhrnu správy.</translation>
     </message>
@@ -5479,7 +6413,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5488,32 +6422,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Otvorené do %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>v rozpore</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepotvrdené</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potvrdení</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Stav</translation>
     </message>
@@ -5537,74 +6471,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Zdroj</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
@@ -5615,13 +6549,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Pre</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <source>label</source>
         <translation>popis</translation>
     </message>
@@ -5632,16 +6566,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+14"/>
+        <location line="+22"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5655,31 +6589,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Správa</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Komentár</translation>
     </message>
@@ -5689,38 +6623,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
@@ -5752,11 +6686,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
@@ -5776,7 +6715,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Hodnota</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5805,12 +6744,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Potvrdené (%1 potvrdení)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>V rozpore</translation>
     </message>
@@ -6035,7 +6974,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6063,7 +7037,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,7 +7092,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Min. množstvo</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6148,7 +7127,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6159,7 +7138,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Potvrdené</translation>
     </message>
@@ -6204,7 +7183,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Zlyhal zapís do súboru %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Rozsah:</translation>
     </message>
@@ -6240,19 +7219,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">U&amp;končiť</translation>
+        <translation type="obsolete">U&amp;končiť</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Ukončiť program</translation>
+        <translation type="obsolete">Ukončiť program</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Súbor</translation>
+        <translation type="obsolete">&amp;Súbor</translation>
     </message>
 </context>
 <context>
@@ -6266,7 +7242,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6292,18 +7268,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6380,30 +7356,57 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Posielam...</translation>
+        <translation type="vanished">Posielam...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+488"/>
+        <location filename="../bitcoinstrings.cpp" line="+499"/>
         <source>Usage:</source>
         <translation>Použitie:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Zoznam príkazov</translation>
     </message>
     <message>
-        <location line="-36"/>
+        <location line="-349"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+288"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Chyba počúvania na ktoromkoľvek porte. Použi -listen=0 ak toto chcete.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+10"/>
         <source>Gridcoin version</source>
         <translation>Gridcoin verzia</translation>
     </message>
@@ -6418,78 +7421,8 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Neplatná suma pre -mininput=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+80"/>
+        <location line="+75"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6540,16 +7473,6 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6620,6 +7543,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6724,6 +7652,16 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6758,18 +7696,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>wallet.dat je poškodený, záchrana zlyhala</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Neplatná adresa proxy: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-356"/>
-        <location line="+344"/>
+        <location line="-388"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6795,17 +7733,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6829,21 +7787,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6884,11 +7828,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6905,6 +7844,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6949,6 +7898,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6989,11 +7943,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7039,11 +7988,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7131,6 +8075,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7142,11 +8091,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7217,16 +8161,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7390,11 +8324,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7417,16 +8346,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7525,16 +8444,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7562,11 +8471,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7610,18 +8514,12 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">nie je k dispozícii</translation>
+        <translation type="obsolete">nie je k dispozícii</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7642,6 +8540,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7865,32 +8768,31 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sending...</source>
-        <translation>Posielam...</translation>
+        <translation type="vanished">Posielam...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-70"/>
         <source>Invalid amount</source>
         <translation>Neplatná suma</translation>
     </message>
     <message>
-        <location line="+126"/>
+        <location line="+106"/>
         <source>Warning: Disk space is low!</source>
         <translation>Upozornenie: Nedostatok miesta na disku!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Neznáma sieť upresnená v -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Nedostatok prostriedkov</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Načítavanie zoznamu blokov...</translation>
     </message>
@@ -7900,17 +8802,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Načítavam peňaženku...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Nie je možné zapísať predvolenú adresu.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Nové prehľadávanie...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Dokončené načítavanie</translation>
     </message>

--- a/src/qt/locale/bitcoin_sl_SI.ts
+++ b/src/qt/locale/bitcoin_sl_SI.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">da</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>I&amp;zbriši</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopiraj &amp;oznako</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Uredi</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Izvozi podatke imenika</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ni oznake)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Samo za staking.</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Vnesite staro in novo geslo denarnice.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Potrdi šifriranje denarnice</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ali ste prepri?ani, da želite šifrirati vašo denarnico?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Denarnica šifrirana</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin se bo sedaj zaprl, da dokon?a proces šifriranje. Pomnite, da tudi šifriranje vaše denarnice ne more v celoti zaš?ititi vaših kovancev pred krajo z zlonamernimi programi in ra?unalniškimi virusi, ?e ti okužijo vaš ra?unalnik.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>POMEMBNO: Vsaka predhodna varnostna kopija datoteke denarnice mora biti nadomeš?ena z novo datoteko šifrirane denarnice. Zaradi varnostnih razlogov bodo namre? prejšnje varnostne kopije datoteke nešifrirane denarnice postale neuporabne takoj ko boste pri?eli uporabljati novo, šifrirano denarnico.</translation>
+        <translation type="vanished">POMEMBNO: Vsaka predhodna varnostna kopija datoteke denarnice mora biti nadomeš?ena z novo datoteko šifrirane denarnice. Zaradi varnostnih razlogov bodo namre? prejšnje varnostne kopije datoteke nešifrirane denarnice postale neuporabne takoj ko boste pri?eli uporabljati novo, šifrirano denarnico.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Šifriranje denarnice je spodletelo</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Šifriranje denarnice spodletelo je zaradi notranje napake. Vaša denarnica ni šifrirana.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Vnešeno geslo se ne ujema</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Odklep denarnice spodletel</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Geslo za dešifriranje denarnice, ki ste ga vnesli, ni pravilno.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Geslo denarnice je bilo uspešno spremenjeno.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Prišlo je do usodne napake. Program Gridcoin se ne more ve? varno nadaljevati in se bo zato zaprl. </translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Denarnica</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>Pre&amp;gled</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>I&amp;zhod</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Preveri sporočilo ...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Izvozi...</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Odprite razhroščevalno in diagnostično konzolo</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Datoteka</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Nastavitve</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin program</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -819,17 +984,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Zadnji prejeti blok je bil ustvarjen %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Ta transakcija je prekora?ila limit. Še vedno jo lahko pošljete za pla?ilo %1 transakcije, ki je pla?ano vsem delom omrežja kot deležnina in pomaga zagotavljati njegovo varnost. Ali želite pla?ati provizijo?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Potrdi transakcijsko provizijo</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Odlivi</translation>
     </message>
@@ -847,17 +1012,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -877,7 +1032,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1050,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Rokovanje z URI</translation>
@@ -912,7 +1077,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -927,12 +1092,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Denarnica je &lt;b&gt;šifrirana&lt;/b&gt; in trenutno &lt;b&gt;zaklenjena&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Napravi varnostno kopijo denarnice</translation>
     </message>
@@ -943,18 +1108,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Ustvarjanje varnostne kopije je spodeltelo </translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Prišlo je do napake ob poskušanju shranjevanja datoteke denarnice na novo lokacijo.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -964,7 +1128,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1051,7 +1220,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1103,12 +1272,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Omrežno Opozorilo</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1167,7 +1336,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1222,37 +1391,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Znesek</translation>
+        <translation type="vanished">Znesek</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Datum</translation>
+        <translation type="vanished">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Potrditve</translation>
+        <translation type="vanished">Potrditve</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Potrjeno</translation>
+        <translation type="vanished">Potrjeno</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Oznaka</translation>
+        <translation type="vanished">Oznaka</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Naslov</translation>
+        <translation type="vanished">Naslov</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopiraj naslov</translation>
     </message>
@@ -1263,17 +1426,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopiraj koli?ino</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopiraj ID transakcije</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopiraj koli?ino</translation>
     </message>
@@ -1303,17 +1466,17 @@ Expires: %3
         <translation>Kopiraj spremembo</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>PRAH</translation>
     </message>
@@ -1363,20 +1526,65 @@ Expires: %3
  To pomeni, da je zahtevana provizija vsaj %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(ni oznake)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>spremeni iz %1 (%2)</translation>
+        <translation type="vanished">spremeni iz %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(spremeni)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(ni oznake)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">spremeni iz %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(spremeni)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(spremeni)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Oznaka</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Naslov</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Potrditve</translation>
     </message>
 </context>
 <context>
@@ -1402,7 +1610,7 @@ Expires: %3
         <translation type="unfinished">Naslov</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1464,7 +1672,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1499,37 +1707,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Oznaka</translation>
+        <translation type="obsolete">Oznaka</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Naslov</translation>
+        <translation type="obsolete">Naslov</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Datum</translation>
+        <translation type="obsolete">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Potrditve</translation>
+        <translation type="obsolete">Potrditve</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Potrjeno</translation>
+        <translation type="obsolete">Potrjeno</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1564,7 +1762,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1574,25 +1772,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(ni oznake)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">spremeni iz %1 (%2)</translation>
+        <translation type="obsolete">spremeni iz %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(spremeni)</translation>
+        <translation type="obsolete">(spremeni)</translation>
     </message>
 </context>
 <context>
@@ -1742,7 +1937,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1767,7 +1967,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1943,7 +2143,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1958,6 +2158,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1966,7 +2171,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>razli?ica</translation>
     </message>
@@ -1994,7 +2199,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2072,22 +2286,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2151,7 +2365,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2270,6 +2484,376 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Počisti &amp;vse </translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">da</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Odklepanje denarnice je bilo prekinjeno.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2585,7 +3169,7 @@ Expires: %3
         <translation>&amp;Prekliči</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>privzeto</translation>
     </message>
@@ -2600,7 +3184,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Napaka</translation>
@@ -2828,18 +3412,23 @@ Expires: %3
         <translation>Trenutna vsota vseh vaših sredstev</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopiraj koli?ino</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2850,9 +3439,231 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Stanje</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2966,7 +3777,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3006,6 +3817,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3041,7 +3857,7 @@ Expires: %3
         <translation type="unfinished">Oblika</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3051,7 +3867,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3064,7 +3890,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3117,6 +3943,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">da</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">ne</translation>
     </message>
 </context>
 <context>
@@ -3201,12 +4104,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3231,12 +4139,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3323,7 +4231,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3361,7 +4269,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">Neznano</translation>
     </message>
@@ -3483,14 +4391,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3500,7 +4442,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3515,12 +4457,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3530,7 +4495,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3592,6 +4557,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3687,7 +4657,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>Neznano</translation>
     </message>
@@ -3788,7 +4758,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4006,7 +4976,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -4021,7 +4991,7 @@ Expires: %3
         <translation>Vtipkajte &lt;b&gt;help&lt;/b&gt; za pregled razpoložljivih ukazov.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4079,12 +5049,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4176,40 +5140,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4667,7 +5628,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4788,7 +5749,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4902,7 +5863,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4925,7 +5886,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4937,7 +5898,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5061,7 +6022,7 @@ Expires: %3
         <translation>&amp;Pošlji</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopiraj koli?ino</translation>
     </message>
@@ -5121,7 +6082,7 @@ Expires: %3
         <translation>in</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Prejemnikov naslov ni veljaven, prosimo ?e ga ponovno preverite.</translation>
     </message>
@@ -5161,8 +6122,8 @@ Expires: %3
         <translation>Napaka: Transakcija je bila zavrnjena. To se je lahko zgodilo, ?e so bili kovanci v vaši denarnici že zapravljeni, na primer ?e ste uporabili kopijo wallet.dat in so bili kovanci zapravljeni v kopiji, a tu še niso bili ozna?eni kot zapravljeni.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(ni oznake)</translation>
     </message>
@@ -5269,7 +6230,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Naslov</translation>
     </message>
@@ -5407,42 +6368,42 @@ Expires: %3
         <translation>Vnesite Gridcoin podpis</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Vnešeni naslov ni veljaven.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Prosimo preverite naslov in poizkusite znova.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Vnešen naslov se ne nanaša na klju?.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Odklepanje denarnice je bilo prekinjeno.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Zasebni klju? vnešenega naslov ni na voljo.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Podpisovanje sporo?ila spodletelo.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Sporo?ilo podpisano.</translation>
     </message>
@@ -5453,7 +6414,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Prosimo preverite podpis in poizkusite znova.</translation>
     </message>
@@ -5504,7 +6465,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5514,32 +6475,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Odpri enoto %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>sporen</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepotrjeno</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potrdil</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Stanje</translation>
     </message>
@@ -5564,74 +6525,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Izvor</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Pošiljatelj</translation>
     </message>
@@ -5642,13 +6603,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Prejemnik</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>lasten naslov</translation>
@@ -5659,16 +6620,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>oznaka</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Kredit</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5683,31 +6644,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>ni bilo sprejeto</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Dolg</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Provizija transakcije</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Neto koli?ina</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Sporo?ilo</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Opomba</translation>
     </message>
@@ -5717,38 +6678,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Koli?ina</translation>
     </message>
@@ -5780,11 +6741,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -5804,7 +6770,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Koli?ina</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5834,12 +6800,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Potrjeno (%1 potrdil)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Sporen</translation>
     </message>
@@ -6064,7 +7030,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Stanje transakcije. Zapeljite z miško ?ez to polje za prikaz števila potrdil. </translation>
     </message>
@@ -6092,7 +7093,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6147,7 +7148,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minimalna koli?ina</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopiraj naslov</translation>
     </message>
@@ -6177,7 +7183,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Prikaži podrobnosti transakcije</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Izvozi podatke transakcij</translation>
     </message>
@@ -6188,7 +7194,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Potrjeno</translation>
     </message>
@@ -6233,7 +7239,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Napaka pri pisanju na datoteko %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Obmo?je:</translation>
     </message>
@@ -6269,19 +7275,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">I&amp;zhod</translation>
+        <translation type="obsolete">I&amp;zhod</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Ustavite program</translation>
+        <translation type="obsolete">Ustavite program</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Datoteka</translation>
+        <translation type="obsolete">&amp;Datoteka</translation>
     </message>
 </context>
 <context>
@@ -6295,7 +7298,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6321,18 +7324,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6409,15 +7412,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Pošiljanje...</translation>
+        <translation type="vanished">Pošiljanje...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Prišlo je do napake pri nastavljanju RPC porta %u za vhodne povezave na IPv6: %s</translation>
     </message>
@@ -6427,27 +7429,27 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Prišlo je do napake pri nastavljanju RPC porta %u za vhodne povezave na IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Uporaba:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Prikaži ukaze</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>Prikaži pomo? za ukaz</translation>
     </message>
     <message>
-        <location line="-167"/>
+        <location line="-159"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Opozorilo: -paytxfee je nastavljen zelo visoko! To je transakcijska provizija, ki jo boste pla?ali ob pošiljanju transakcije.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Opozorilo: wallet.dat je pokvarjena, podatki rešeni! Originalna wallet.dat je bila shranjena kot denarnica. {timestamp}.bak v %s; ?e imate napa?no prikazano stanje na ra?unu ali v transakcijah prenovite datoteko z varnostno kopijo. </translation>
     </message>
@@ -6457,7 +7459,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Opozorilo: napaka pri branju wallet.dat! Vsi klju?i so bili pravilno prebrani, podatki o transakciji ali imenik vnešenih naslovov so morda izgubljeni ali nepravilni.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Napaka: Ustvarjanje transakcije spodletelo</translation>
     </message>
@@ -6467,17 +7469,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Napaka: Transakcija je bila zavrnjena. To se je lahko zgodilo, ?e so bili kovanci v vaši denarnici že zapravljeni, na primer ?e ste uporabili kopijo wallet.dat in so bili kovanci zapravljeni v kopiji, a tu še niso bili ozna?eni kot zapravljeni.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ni mogoče poslušati na nobenih vratih. Če to zares želite, uporabite opcijo -listen=0.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>Za uporabo %s opcije</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -6486,7 +7488,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 ?e datoteka ne obstaja, jo ustvarite z lastniškimi dovoljenji za datoteke.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Gridcoin razli?ica</translation>
     </message>
@@ -6501,7 +7503,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Neveljavni znesek za -miniput=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+101"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Denarnica %s se nahaja zunaj datote?nega imenika %s.</translation>
     </message>
@@ -6511,12 +7513,85 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Potrdite neopore?nost baze podatkov...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Napaka pri zagonu podatkovne baze okolja %s! Za popravilo, NAPRAVITE VARNOSTNO KOPIJO IMENIKA, in iz njega odstranite vse razen datoteke wallet.dat</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6607,6 +7682,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6641,7 +7726,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>wallet.dat poškodovana, neuspešna obnova</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Neveljaven naslov -proxy: &apos;%s&apos;</translation>
     </message>
@@ -6651,7 +7736,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Neveljaven -tor naslov: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Ni mogo?e dolo?iti -bind naslova: &apos;%s&apos;</translation>
     </message>
@@ -6661,23 +7746,23 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Ni mogo?e dolo?iti -externalip naslova: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Neveljavni znesek za -reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Napaka pri nalaganju blkindex.dat</translation>
     </message>
     <message>
-        <location line="-316"/>
-        <location line="+344"/>
+        <location line="-351"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6702,12 +7787,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6727,21 +7812,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6767,11 +7838,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6791,7 +7857,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6831,7 +7897,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6867,11 +7933,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6911,12 +7972,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6981,7 +8037,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6993,11 +8049,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7068,16 +8119,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7206,11 +8247,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7233,16 +8269,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7321,16 +8347,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7353,11 +8369,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7401,18 +8412,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">Neznano</translation>
+        <translation type="obsolete">Neznano</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7433,6 +8438,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7656,78 +8666,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7782,16 +8722,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7841,7 +8771,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7851,37 +8781,37 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Denarnica mora biti prepisana: ponovno odprite Gridcoin za dokon?anje</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Napaka pri nalaganju wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Uvažanje podatkovne datoteke verige blokov.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Nalagam naslove ...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Napaka: ni mogo?e zagnati vozliš?a</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Navezava v %s  na tem ra?unalniku ni mogo?a Gridcoin aplikacija je verjetno že zagnana.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Na tem ra?unalniku je bilo nemogo?e vezati na %s (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Napaka: Zaklenjena denarnica, ni mogo?e opraviti transakcije</translation>
     </message>
@@ -7891,37 +8821,36 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Napaka: Ta transakcija zahteva transakcijsko provizijo vsaj %s zaradi svoje koli?ine, kompleksnosti ali uporabo sredstev, ki ste jih prejeli pred kratkim. </translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Pošiljanje...</translation>
+        <translation type="vanished">Pošiljanje...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Neveljavna koli?ina</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Opozorilo: Prosimo preverite svoj datum in ?as svojega ra?unalnika! ?e je vaša ura nastavljena napa?no Gridcoin ne bo deloval.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Opozorilo: Malo prostora na disku!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Neznano omrežje določeno v -onlynet: &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Premalo sredstev</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Nalagam kazalo blokov ...</translation>
     </message>
@@ -7931,17 +8860,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Nalagam denarnico ...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Ni mogoče zapisati privzetega naslova</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Ponovno pregledujem verigo ...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Nalaganje končano</translation>
     </message>

--- a/src/qt/locale/bitcoin_sq.ts
+++ b/src/qt/locale/bitcoin_sq.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">po</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">jo</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Fshi</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopjo &amp;Etiketë</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Ndrysho</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiketë</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(pa etiketë)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Futni frazkalimin e vjetër dhe të ri në portofol. </translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Konfirmoni enkriptimin e portofolit</translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Portofoli u enkriptua</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Enkriptimi i portofolit dështoi</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Enkriptimi i portofolit dështoi për shkak të një gabimi të brëndshëm. portofoli juaj nuk u enkriptua.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Frazkalimet e plotësuara nuk përputhen.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>ç&apos;kyçja e portofolit dështoi</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Frazkalimi i futur për dekriptimin e portofolit nuk ishte i saktë.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Portofol</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Përmbledhje</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Skedar</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Konfigurimet</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[testo rrjetin]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Dërgo transaksionin</translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Portofoli po &lt;b&gt; enkriptohet&lt;/b&gt; dhe është &lt;b&gt; i kyçur&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Sasia</translation>
+        <translation type="vanished">Sasia</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiketë</translation>
+        <translation type="obsolete">Etiketë</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Date</source>
-        <translation>Data</translation>
+        <translation type="vanished">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-13"/>
         <source>Address</source>
-        <translation>Adresë</translation>
+        <translation type="vanished">Adresë</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopjo adresën</translation>
     </message>
@@ -1251,17 +1402,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1442,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>po</translation>
     </message>
@@ -1341,19 +1492,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(pa etiketë)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(pa etiketë)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Sasia</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Etiketë</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresë</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1380,7 +1568,7 @@ Expires: %3
         <translation type="unfinished">Adresë</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1630,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1665,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Sasia</translation>
+        <translation type="obsolete">Sasia</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiketë</translation>
+        <translation type="obsolete">Etiketë</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adresë</translation>
+        <translation type="obsolete">Adresë</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Data</translation>
+        <translation type="obsolete">Data</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1716,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,25 +1726,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(pa etiketë)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1720,7 +1883,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1913,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2089,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2104,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2117,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2145,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2226,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2305,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2424,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">po</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">jo</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3103,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2572,7 +3118,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Problem</translation>
@@ -2800,18 +3346,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3373,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Sasia</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3703,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3743,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3783,7 @@ Expires: %3
         <translation type="unfinished">Formilarë</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3793,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3816,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,6 +3869,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">po</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">jo</translation>
     </message>
 </context>
 <context>
@@ -3173,12 +4030,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4065,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4157,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4195,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4305,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4356,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4371,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4409,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4471,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4586,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3803,7 +4727,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4890,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4905,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4963,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5054,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5542,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5663,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5777,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5800,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5812,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5936,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +5996,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6036,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(pa etiketë)</translation>
     </message>
@@ -5229,7 +6144,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adresë</translation>
     </message>
@@ -5367,42 +6282,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6328,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6379,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6387,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Hapur deri më %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/I pakonfirmuar</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 konfirmimet</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6435,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6513,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6530,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6552,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6586,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Sasia</translation>
     </message>
@@ -5734,11 +6649,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -5758,7 +6678,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Sasia</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6706,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>I/E konfirmuar(%1 konfirmime)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6936,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +6999,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7054,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopjo adresën</translation>
     </message>
@@ -6129,7 +7089,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7100,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6185,7 +7145,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6221,19 +7181,12 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Mbyllni aplikacionin</translation>
+        <translation type="obsolete">Mbyllni aplikacionin</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Skedar</translation>
+        <translation type="obsolete">&amp;Skedar</translation>
     </message>
 </context>
 <context>
@@ -6247,7 +7200,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7226,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,23 +7312,15 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
         <location filename="../bitcoinstrings.cpp" line="+12"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6401,17 +7346,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6435,21 +7400,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6490,11 +7441,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6514,7 +7460,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6554,7 +7500,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6595,11 +7541,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6645,11 +7586,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6736,7 +7672,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6748,11 +7684,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6823,16 +7754,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7007,11 +7928,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7038,16 +7954,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7177,16 +8083,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7232,11 +8128,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Magnitude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7277,21 +8168,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7308,6 +8237,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7537,82 +8471,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7663,16 +8522,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7753,6 +8602,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7862,6 +8716,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7896,7 +8760,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-188"/>
+        <location line="-167"/>
         <source>Error</source>
         <translation>Problem</translation>
     </message>

--- a/src/qt/locale/bitcoin_sr.ts
+++ b/src/qt/locale/bitcoin_sr.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Избриши</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>новчаник</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Општи преглед</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>I&amp;zlaz</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Фајл</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Подешавања</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,17 +969,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Послана трансакција</translation>
     </message>
@@ -836,17 +997,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -866,7 +1017,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -884,7 +1035,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -901,7 +1062,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +1077,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Новчаник јс &lt;b&gt;шифрован&lt;/b&gt; и тренутно &lt;b&gt;закључан&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -932,18 +1093,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +1113,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1040,7 +1205,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1089,7 +1254,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,12 +1262,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,7 +1326,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1216,37 +1381,19 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>iznos</translation>
+        <translation type="vanished">iznos</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>datum</translation>
+        <translation type="vanished">datum</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Potvrdjen</translation>
+        <translation type="vanished">Potvrdjen</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1257,17 +1404,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1297,17 +1444,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1347,19 +1494,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">iznos</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">datum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1386,7 +1570,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1448,7 +1632,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,37 +1667,19 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">iznos</translation>
+        <translation type="obsolete">iznos</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">datum</translation>
+        <translation type="obsolete">datum</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Potvrdjen</translation>
+        <translation type="obsolete">Potvrdjen</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1548,7 +1714,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,24 +1724,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1726,7 +1881,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1751,7 +1911,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1927,7 +2087,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,6 +2102,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1950,7 +2115,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1978,7 +2143,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2053,22 +2227,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2132,7 +2306,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2251,6 +2425,373 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2566,7 +3107,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2581,7 +3122,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Greška</translation>
@@ -2809,18 +3350,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2831,9 +3377,227 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">iznos</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2947,7 +3711,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2987,6 +3751,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3022,7 +3791,7 @@ Expires: %3
         <translation type="unfinished">Форма</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3032,7 +3801,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,7 +3824,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3097,6 +3876,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3182,12 +4038,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3212,12 +4073,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3304,7 +4165,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3342,7 +4203,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3458,14 +4319,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4370,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,12 +4385,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,7 +4423,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3567,6 +4485,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3677,7 +4600,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3818,7 +4741,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4904,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3996,7 +4919,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4054,12 +4977,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4151,40 +5068,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4642,7 +5556,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4763,7 +5677,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4877,7 +5791,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4900,7 +5814,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4912,7 +5826,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5036,7 +5950,7 @@ Expires: %3
         <translation>&amp;Пошаљи</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5096,7 +6010,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5136,8 +6050,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5244,7 +6158,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5382,42 +6296,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5428,7 +6342,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5479,7 +6393,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5488,32 +6402,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5537,74 +6451,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">datum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5615,13 +6529,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5632,16 +6546,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5655,31 +6569,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5689,38 +6603,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">iznos</translation>
     </message>
@@ -5752,11 +6666,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">datum</translation>
     </message>
@@ -5776,7 +6695,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">iznos</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5805,12 +6724,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6035,7 +6954,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6063,7 +7017,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,7 +7072,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6148,7 +7107,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6159,7 +7118,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">Potvrdjen</translation>
     </message>
@@ -6204,7 +7163,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6240,19 +7199,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">I&amp;zlaz</translation>
+        <translation type="obsolete">I&amp;zlaz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Напустите програм</translation>
+        <translation type="obsolete">Напустите програм</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Фајл</translation>
+        <translation type="obsolete">&amp;Фајл</translation>
     </message>
 </context>
 <context>
@@ -6266,7 +7222,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6292,18 +7248,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6378,33 +7334,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+381"/>
+        <location filename="../bitcoinstrings.cpp" line="+411"/>
         <source>Loading addresses...</source>
         <translation>učitavam adrese....</translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="-14"/>
         <source>Insufficient funds</source>
         <translation>Nedovoljno sredstava</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6430,17 +7378,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6464,21 +7432,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6519,11 +7473,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6540,6 +7489,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6584,6 +7543,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6624,11 +7588,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6674,11 +7633,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6766,6 +7720,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6777,11 +7736,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6852,16 +7806,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7031,11 +7975,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7062,16 +8001,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7196,16 +8125,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7242,11 +8161,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7291,17 +8205,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7322,6 +8226,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7551,82 +8460,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7677,16 +8511,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7767,6 +8591,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7876,6 +8705,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7910,12 +8749,40 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-200"/>
+        <location line="-179"/>
         <source>Done loading</source>
         <translation>Završeno učitavanje</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-295"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+278"/>
         <source>Error</source>
         <translation>Greška</translation>
     </message>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished">Namn</translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nej</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Radera</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Kopiera &amp;etikett</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Redigera</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Exportera adressboken</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etikett</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(Ingen etikett)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Endast för &quot;staking&quot;</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Ange plånbokens nya lösenord. &lt;br/&gt; Använd ett lösenord på &lt;b&gt;tio eller fler slumpmässiga tecken,&lt;/b&gt; eller &lt;b&gt;åtta eller fler ord.&lt;/b&gt;.</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Ange plånbokens gamla och nya lösenord.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Bekräfta kryptering av plånbok</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Är du säker på att du vill kryptera din plånbok?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Plånbok krypterad</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin plånboken kommer nu att stängas för att slutföra krypteringen: Kom ihåg att även en krypterad plånboks säkerhet kan äventyras genom keyloggers eller dylika malwares.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>VIKTIGT: Alla tidigare säkerhetskopior du har gjort av plånboksfilen ska ersättas med den nya genererade, krypterade plånboksfilen. Av säkerhetsskäl kommer tidigare säkerhetskopior av den okrypterade plånboksfilen blir oanvändbara när du börjar använda en ny, krypterad plånbok.</translation>
+        <translation type="vanished">VIKTIGT: Alla tidigare säkerhetskopior du har gjort av plånboksfilen ska ersättas med den nya genererade, krypterade plånboksfilen. Av säkerhetsskäl kommer tidigare säkerhetskopior av den okrypterade plånboksfilen blir oanvändbara när du börjar använda en ny, krypterad plånbok.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Kryptering av plånbok misslyckades</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Kryptering av plånbok misslyckades på grund av ett internt fel. Din plånbok blev inte krypterad.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>De angivna lösenorden överensstämmer inte.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Misslyckades låsa upp plånboken</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Lösenordet för dekryptering av plånboken var felaktig.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Plånbokens lösenord har ändrats.</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Ett fatalt fel uppstod. Gridcoin kan inte fortsätta och stänger programmet.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Plånbok</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Översikt</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Avsluta</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Verifiera meddelande...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Exportera...</translation>
@@ -652,17 +782,21 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Öppna debug- och diagnostikkonsolen</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
-        <translation>Ladda ner &amp;Snapshot</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Snapshot Download</source>
+        <translation type="vanished">Ladda ner &amp;Snapshot</translation>
+    </message>
+    <message>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +816,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Arkiv</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Inställningar</translation>
     </message>
@@ -722,19 +876,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin-klient</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -807,17 +976,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Senaste mottagna block genererades %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Denna transaktion är över gränsen. Du kan ändå skicka den med en %1 avgift, som går till noderna som processerar din transaktion och hjälper till med att upprätthålla nätverket. Vill du betala denna avgift?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>Bekräfta transaktionsavgiften</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Transaktion skickad</translation>
     </message>
@@ -838,17 +1007,11 @@ Typ: %3
 Adress: %4</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation>Varning: Att avbryta efter steg 2 kommer resultera i synkronisering från 0 eller korrupta blockchain-filer.</translation>
+        <translation type="vanished">Varning: Att avbryta efter steg 2 kommer resultera i synkronisering från 0 eller korrupta blockchain-filer.</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -868,7 +1031,7 @@ Adress: %4</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -886,7 +1049,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>URI-hantering</translation>
@@ -903,7 +1076,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation>Plånboken är &lt;b&gt;krypterad&lt;/b&gt; och för tillfället %1 </translation>
     </message>
@@ -918,12 +1091,12 @@ Are you sure you want to proceed?</source>
         <translation>&lt;b&gt;helt upplåst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Denna plånbok är &lt;b&gt;krypterad&lt;/b&gt; och för närvarande &lt;b&gt;låst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Säkerhetskopiera plånbok</translation>
     </message>
@@ -934,18 +1107,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Säkerhetskopieringen misslyckades</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Ett fel uppstod vid sparandet av plånboken till den nya platsen.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation>Säkerhetskopiera Inställningar</translation>
     </message>
@@ -955,7 +1127,12 @@ Are you sure you want to proceed?</source>
         <translation>Plånboksinställningar (*.conf)</translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation>inte tillgänglig</translation>
     </message>
@@ -1042,7 +1219,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1094,12 +1271,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Nätverkslarm</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,7 +1335,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1208,42 +1385,36 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Mängd</translation>
+        <translation type="vanished">Mängd</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Datum</translation>
+        <translation type="vanished">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Bekräftelser</translation>
+        <translation type="vanished">Bekräftelser</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Bekräftad</translation>
+        <translation type="vanished">Bekräftad</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>etikett</translation>
+        <translation type="vanished">etikett</translation>
     </message>
     <message>
-        <location line="-128"/>
+        <location line="-80"/>
         <source>&amp;List mode</source>
         <translation>&amp;Listvisning</translation>
     </message>
     <message>
-        <location line="+133"/>
         <source>Address</source>
-        <translation>Adress</translation>
+        <translation type="vanished">Adress</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Kopiera adress</translation>
     </message>
@@ -1254,17 +1425,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Kopiera belopp</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>Kopiera transaktions-ID</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Kopiera antal</translation>
     </message>
@@ -1294,17 +1465,17 @@ Expires: %3
         <translation>Kopiera förändringarna</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>STOFT</translation>
     </message>
@@ -1354,20 +1525,65 @@ Mängder under 0,546 gånger minimiavgiften visas som DUST.</translation>
 Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(Ingen etikett)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>ändra från %1(%2)</translation>
+        <translation type="vanished">ändra från %1(%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(ändra)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(Ingen etikett)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">ändra från %1(%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(ändra)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Mängd</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(ändra)</translation>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adress</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Bekräftelser</translation>
     </message>
 </context>
 <context>
@@ -1393,7 +1609,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished">Adress</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1455,7 +1671,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1490,37 +1706,27 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Mängd</translation>
+        <translation type="obsolete">Mängd</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adress</translation>
+        <translation type="obsolete">Adress</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Datum</translation>
+        <translation type="obsolete">Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Bekräftelser</translation>
+        <translation type="obsolete">Bekräftelser</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Bekräftad</translation>
+        <translation type="obsolete">Bekräftad</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1555,7 +1761,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1565,25 +1771,22 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(Ingen etikett)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">ändra från %1(%2)</translation>
+        <translation type="obsolete">ändra från %1(%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(ändra)</translation>
+        <translation type="obsolete">(ändra)</translation>
     </message>
 </context>
 <context>
@@ -1733,7 +1936,12 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation>Testar...</translation>
     </message>
@@ -1758,7 +1966,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Underkänt</translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1934,7 +2142,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1949,6 +2157,11 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1957,7 +2170,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1985,7 +2198,16 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2057,22 +2279,22 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2136,7 +2358,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2255,6 +2477,370 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Rensa &amp;alla</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">nej</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Upplåsningen av plånboken avbröts.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2570,7 +3156,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>&amp;Avbryt</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>standard</translation>
     </message>
@@ -2585,7 +3171,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Ljus</translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Fel</translation>
@@ -2813,18 +3399,23 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Aktuella omröstningar</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Kopiera belopp</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2835,9 +3426,223 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Mängd</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2951,7 +3756,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2991,6 +3796,11 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3026,7 +3836,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished">Formulär</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3846,17 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3049,7 +3869,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3102,6 +3922,83 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished">ingen</translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">ja</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">nej</translation>
     </message>
 </context>
 <context>
@@ -3186,12 +4083,17 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished">Saldo</translation>
     </message>
@@ -3216,12 +4118,12 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished">Flera alternativ</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3308,7 +4210,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
@@ -3346,14 +4248,48 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3363,7 +4299,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3378,12 +4314,35 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation>%1 har ännu inte avslutats säkert...</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation>ej tillgänglig</translation>
     </message>
@@ -3493,7 +4452,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3503,7 +4462,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3565,6 +4524,11 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3660,7 +4624,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>ej tillgänglig</translation>
     </message>
@@ -3741,7 +4705,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3979,7 +4943,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Nej</translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3994,7 +4958,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Skriv &lt;b&gt;help&lt;/b&gt; för en översikt av alla kommandon.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4055,10 +5019,8 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Utgående</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+6"/>
         <source>Unknown</source>
-        <translation>Okänd</translation>
+        <translation type="vanished">Okänd</translation>
     </message>
 </context>
 <context>
@@ -4149,40 +5111,37 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4640,7 +5599,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation>Adressetikett</translation>
     </message>
@@ -4761,7 +5720,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4875,7 +5834,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4898,7 +5857,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4910,7 +5869,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5034,7 +5993,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Ange en Gridcoin-address (t.ex. S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Kopiera antal</translation>
     </message>
@@ -5094,7 +6053,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation> och </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Mottagarens adress är inte giltig, vänligen kontrollera igen.</translation>
     </message>
@@ -5134,8 +6093,8 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Fel: Transaktionen nekades. Detta kan hända om vissa av mynten i din plånbok redan är använda, t.ex om du använder en kopia av wallet.dat och mynten redan var använda i kopia men inte markerade som använda här.</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(Ingen etikett)</translation>
     </message>
@@ -5242,7 +6201,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adress</translation>
     </message>
@@ -5380,42 +6339,42 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
         <translation>Fyll i Gridcoin-signatur</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Den angivna adressen är ogiltig.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Vad god kontrollera adressen och försök igen.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Den angivna adressen refererar inte till en nyckel.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Upplåsningen av plånboken avbröts.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Privat nyckel för den angivna adressen är inte tillgänglig.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>Signeringen av meddelandet misslyckades.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>Meddelande signerat.</translation>
     </message>
@@ -5426,7 +6385,7 @@ Detta betyder att en avgift på minst %2 krävs.</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Kontrollera signaturen och försök igen.</translation>
     </message>
@@ -5477,7 +6436,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5485,32 +6444,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>Öppet till %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>konflikt</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/nerkopplad</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/obekräftade</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 bekräftelser</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5533,74 +6492,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Källa</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation>Genererade i CoinBase</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Från</translation>
     </message>
@@ -5611,13 +6570,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Till</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>egen adress</translation>
@@ -5628,16 +6587,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>etikett</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Kredit</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5650,31 +6609,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>inte accepterad</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Belasta</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>Transaktionsavgift</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Nettobelopp</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>Meddelande</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
@@ -5684,38 +6643,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Gridcoin-genererade mynt måste mogna i 110 block innan de kan spenderas. När du skapade detta block skickades det ut på nätverket för att läggas till i blockkedjan. Om det misslyckas att läggas till kommer dess status ändras till &quot;ej accepterad&quot; och mynten kan inte spenderas. Detta kan hända om en annan nod skapar ett block inom några sekunder av ditt.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation>Transaktionsdata</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Mängd</translation>
     </message>
@@ -5747,11 +6706,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation>S&amp;täng</translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -5771,7 +6735,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Mängd</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5799,12 +6763,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bekräftad (%1 bekräftelser)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Konflikt</translation>
     </message>
@@ -6029,7 +6993,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transaktionsstatus. Håll muspekaren över för att se antal bekräftelser.</translation>
     </message>
@@ -6057,7 +7056,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6112,7 +7111,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Minsta mängd</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Kopiera adress</translation>
     </message>
@@ -6142,7 +7146,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Visa transaktionsdetaljer</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>Exportera transaktionsdata</translation>
     </message>
@@ -6153,7 +7157,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Bekräftad</translation>
     </message>
@@ -6198,7 +7202,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kan inte skriva till fil %1.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Intervall:</translation>
     </message>
@@ -6234,19 +7238,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Avsluta</translation>
+        <translation type="obsolete">&amp;Avsluta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Avsluta programmet</translation>
+        <translation type="obsolete">Avsluta programmet</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Arkiv</translation>
+        <translation type="obsolete">&amp;Arkiv</translation>
     </message>
 </context>
 <context>
@@ -6260,7 +7261,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6286,18 +7287,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6374,15 +7375,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Skickar...</translation>
+        <translation type="vanished">Skickar...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ett fel uppstod vid upprättandet av RPC port %u för att lyssna på IPv6, faller tillbaka till IPV4: %s</translation>
     </message>
@@ -6392,23 +7392,23 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Ett fel uppstod vid upprättandet av RPC port %u för att lyssna på IPv4: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Användning:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Lista kommandon</translation>
     </message>
     <message>
-        <location line="-367"/>
-        <location line="+344"/>
+        <location line="-397"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6434,11 +7434,31 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6458,21 +7478,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6498,11 +7504,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6519,6 +7520,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6563,6 +7574,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6598,11 +7614,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6642,12 +7653,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6713,6 +7719,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6724,11 +7735,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6789,16 +7795,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6897,11 +7893,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -6924,16 +7915,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7007,16 +7988,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Loading Network Averages...</source>
         <translation type="unfinished"></translation>
@@ -7040,11 +8011,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <location line="+2"/>
         <source>Local version: </source>
         <translation>Lokal version: </translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -7082,18 +8048,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Flera alternativ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation>ej tillgänglig</translation>
+        <translation type="vanished">ej tillgänglig</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7109,6 +8069,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7327,77 +8292,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Staking Only - No Eligible Research Projects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7447,16 +8342,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+4"/>
         <source>Unable to create the PID file &apos;%s&apos;: %s</source>
         <translation type="unfinished"></translation>
@@ -7493,6 +8378,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7588,6 +8478,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7612,17 +8512,45 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>okänd</translation>
     </message>
     <message>
-        <location line="-224"/>
+        <location line="-201"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="-271"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+249"/>
         <source>Boinc Reward</source>
         <translation>BOINC-belöning</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+9"/>
         <source>Client Version</source>
         <translation>Klientversion</translation>
     </message>
@@ -7637,7 +8565,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>FEL</translation>
     </message>
     <message>
-        <location line="+33"/>
+        <location line="+30"/>
         <source>Height</source>
         <translation>Höjd</translation>
     </message>
@@ -7652,22 +8580,22 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Ogiltigt team</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+11"/>
         <source>Magnitude</source>
         <translation>Magnitud</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+17"/>
         <source>Organization</source>
         <translation>Organisation</translation>
     </message>
     <message>
-        <location line="-223"/>
+        <location line="-211"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Varning: -paytxfee är satt väldigt hög! Detta är avgiften du kommer betala för varje transaktion.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Varning: wallet.dat korrupt, datan har räddats! Den ursprungliga wallet.dat har sparas som wallet.{timestamp}.bak i %s; om ditt saldo eller transaktioner är felaktiga ska du återställa från en säkerhetskopia.</translation>
     </message>
@@ -7677,7 +8605,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Varning: fel vid läsning av wallet.dat! Alla nycklar lästes korrekt, men transaktionsdatan eller adressbokens poster kanske saknas eller är felaktiga.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Fel: Skapandet av transaktion misslyckades  </translation>
     </message>
@@ -7687,22 +8615,22 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Fel: Transaktionen nekades. Detta kan hända om vissa av mynten i din plånbok redan är använda, t.ex om du använder en kopia av wallet.dat och mynten redan var använda i kopia men inte markerade som använda här.</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Misslyckades att lyssna på någon port. Använd -listen=0 om du vill detta.</translation>
     </message>
     <message>
-        <location line="+107"/>
+        <location line="+100"/>
         <source>Single Choice</source>
         <translation>Ett alternativ</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+12"/>
         <source>To use the %s option</source>
         <translation>Att använda %s alternativet</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7711,7 +8639,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägaren.</translation>
     </message>
     <message>
-        <location line="+266"/>
+        <location line="+240"/>
         <source>Unknown error</source>
         <translation>Okänt fel</translation>
     </message>
@@ -7726,12 +8654,12 @@ Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägar
         <translation>Den här uppdateringen är</translation>
     </message>
     <message>
-        <location line="-76"/>
+        <location line="-60"/>
         <source>No current polls</source>
         <translation>Inga pågående omröstningar</translation>
     </message>
     <message>
-        <location line="-30"/>
+        <location line="-25"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ogiltigt belopp för -paytxfee=&lt;belopp&gt;:&apos;%s&apos;</translation>
     </message>
@@ -7741,7 +8669,7 @@ Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägar
         <translation>Fel mängd för  -mininput=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+101"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>Plånbok %s ligger utanför datamappen %s.</translation>
     </message>
@@ -7751,12 +8679,12 @@ Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägar
         <translation>Verifierar integriteten i databasen...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-404"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Ett fel uppstod vid initialiseringen av databasen %s! För att återställa, SÄKERHETSKOPIERA MAPPEN, radera sedan allt från mappen förutom wallet.dat.</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+436"/>
         <source>vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7766,7 +8694,7 @@ Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägar
         <translation>wallet.dat korrupt, räddning misslyckades</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ogiltig -proxy adress: &apos;%s&apos;</translation>
     </message>
@@ -7776,7 +8704,7 @@ Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägar
         <translation>Fel -tor adress: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kan inte matcha -bind adress: &apos;%s&apos;</translation>
     </message>
@@ -7786,12 +8714,12 @@ Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägar
         <translation>Kan inte matcha -externalip adress: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>Fel mängd för -reservebalance=&lt;amount&gt;</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>Fel vid laddande av blkindex.dat</translation>
     </message>
@@ -7806,42 +8734,42 @@ Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägar
         <translation>Kunde inte ladda wallet.dat: En nyare version av Gridcoin krävs</translation>
     </message>
     <message>
-        <location line="+163"/>
+        <location line="+140"/>
         <source>Wallet needed to be rewritten: restart Gridcoin to complete</source>
         <translation>Plånboken måste skrivas om: Starta om Gridcoin för att slutföra</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>Fel vid inläsning av plånboksfilen wallet.dat</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Importerar bootstrap blockchain data fil.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Laddar adresser...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Fel: kunde inte starta noden</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>Kan inte binda till %s på denna dator. Gridcoin är sannolikt redan startad.</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Det går inte att binda till %s på den här datorn (bind returnerade felmeddelande %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Fel: Plånboken låst, kan inte utföra transaktion  </translation>
     </message>
@@ -7856,37 +8784,36 @@ Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägar
         <translation>Fel: Transaktionen kräver en transaktionsavgift på min %s på grund av dess storlek, komplexitet eller användning av nyligen mottagna kapital  </translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Skickar...</translation>
+        <translation type="vanished">Skickar...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Ogiltig mängd</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Varning: Kolla att din dators tid och datum är rätt. Gridcoin kan inte fungera ordentligt om tiden i datorn är fel.</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>Varning: Lågt skivutrymme!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Okänt nätverk som anges i -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Otillräckligt med bitcoins</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Laddar blockindex...</translation>
     </message>
@@ -7896,17 +8823,17 @@ Om filen inte existerar, skapa den med filrättigheten endast läsbar för ägar
         <translation>Laddar plånbok...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Kan inte skriva standardadress</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Söker igen...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Klar med laddning</translation>
     </message>

--- a/src/qt/locale/bitcoin_th_TH.ts
+++ b/src/qt/locale/bitcoin_th_TH.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;ลบ</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>กระเป๋าเงิน</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;ภาพรวม</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;ออก</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;ยืนยันข้อความ...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>เปิด แผลงควบคุม debugging และ diagnostic</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;ไฟล์</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;การตั้งค่า</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -796,17 +957,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>รายการที่ส่ง</translation>
     </message>
@@ -824,17 +985,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -854,7 +1005,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -872,7 +1023,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1050,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -904,12 +1065,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>กระเป๋าเงินถูก &lt;b&gt;เข้ารหัส&lt;/b&gt; และในปัจจุบัน &lt;b&gt;ล็อค &lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -920,18 +1081,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -941,7 +1101,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1028,7 +1193,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1077,7 +1242,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,12 +1250,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1314,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1369,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>จำนวน</translation>
+        <translation type="vanished">จำนวน</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>วันที่</translation>
+        <translation type="vanished">วันที่</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>การยืนยัน</translation>
+        <translation type="vanished">การยืนยัน</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>ยืนยันแล้ว</translation>
+        <translation type="vanished">ยืนยันแล้ว</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1245,17 +1396,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1285,17 +1436,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1335,20 +1486,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">จำนวน</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">วันที่</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">การยืนยัน</translation>
     </message>
 </context>
 <context>
@@ -1374,7 +1562,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,7 +1624,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1471,37 +1659,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">จำนวน</translation>
+        <translation type="obsolete">จำนวน</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">วันที่</translation>
+        <translation type="obsolete">วันที่</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">การยืนยัน</translation>
+        <translation type="obsolete">การยืนยัน</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">ยืนยันแล้ว</translation>
+        <translation type="obsolete">ยืนยันแล้ว</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1536,7 +1710,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,24 +1720,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1714,7 +1877,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,7 +1907,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1915,7 +2083,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,6 +2098,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1938,7 +2111,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1966,7 +2139,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2035,22 +2217,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,7 +2296,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2233,6 +2415,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2548,7 +3091,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2563,7 +3106,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">ข้อผิดพลาด</translation>
@@ -2791,18 +3334,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2813,9 +3361,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">จำนวน</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2929,7 +3687,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2969,6 +3727,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3004,7 +3767,7 @@ Expires: %3
         <translation type="unfinished">รูป</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,7 +3777,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3027,7 +3800,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3079,6 +3852,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3164,12 +4014,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3194,12 +4049,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3286,7 +4141,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3324,7 +4179,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3428,14 +4283,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,7 +4334,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,12 +4349,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4387,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,6 +4449,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3647,7 +4564,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3788,7 +4705,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3951,7 +4868,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4883,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4024,12 +4941,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4121,40 +5032,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,7 +5520,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4733,7 +5641,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4847,7 +5755,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4870,7 +5778,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4882,7 +5790,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,7 +5914,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5066,7 +5974,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5106,8 +6014,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,7 +6122,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5352,42 +6260,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5398,7 +6306,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5449,39 +6357,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5503,74 +6411,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">วันที่</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5581,13 +6489,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5598,16 +6506,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5619,31 +6527,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5653,38 +6561,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">จำนวน</translation>
     </message>
@@ -5716,11 +6624,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">วันที่</translation>
     </message>
@@ -5740,7 +6653,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">จำนวน</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5767,12 +6680,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5997,7 +6910,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6025,7 +6973,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6080,7 +7028,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6110,7 +7063,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6121,7 +7074,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">ยืนยันแล้ว</translation>
     </message>
@@ -6166,7 +7119,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6202,19 +7155,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;ออก</translation>
+        <translation type="obsolete">&amp;ออก</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">ออกจากโปรแกรม</translation>
+        <translation type="obsolete">ออกจากโปรแกรม</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;ไฟล์</translation>
+        <translation type="obsolete">&amp;ไฟล์</translation>
     </message>
 </context>
 <context>
@@ -6228,7 +7178,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6254,18 +7204,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6340,23 +7290,15 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
         <location filename="../bitcoinstrings.cpp" line="+12"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6382,17 +7324,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6416,21 +7378,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6471,11 +7419,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6495,7 +7438,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6535,7 +7478,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6576,11 +7519,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6626,11 +7564,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6717,7 +7650,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6729,11 +7662,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6804,16 +7732,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6993,11 +7911,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7024,16 +7937,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7163,16 +8066,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7218,11 +8111,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Magnitude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7263,21 +8151,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7294,6 +8220,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7523,82 +8454,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7649,16 +8505,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7739,6 +8585,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7844,6 +8695,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>poll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -34,7 +34,7 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,11 +43,51 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished">İsim</translation>
     </message>
@@ -60,6 +100,41 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">evet</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">hayır</translation>
     </message>
 </context>
 <context>
@@ -145,7 +220,17 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation>&amp;Sil</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>&amp;Etiketi Kopyala</translation>
     </message>
@@ -155,7 +240,7 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation>&amp;Değiştir</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>Adres Defteri Verisini Dışa Aktar</translation>
     </message>
@@ -179,7 +264,7 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
@@ -190,8 +275,19 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(etiket yok)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -227,7 +323,7 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation>Sadece pay almak için</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Cüzdan için yeni parolayı giriniz.&lt;br/&gt;Lütfen &lt;b&gt;on ya da daha fazla rastgele karakter&lt;/b&gt; veya &lt;b&gt;sekiz ya da daha fazla kelime&lt;/b&gt; içeren bir parola kullanınız.</translation>
     </message>
@@ -257,7 +353,7 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation>Cüzdan için eski ve yeni parolaları giriniz.</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Cüzdan şifrelemesini onayla</translation>
     </message>
@@ -272,58 +368,82 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation>Cüzdanınızı şifrelemek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Cüzdan şifrelendi</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin, şifreleme işlemini tamamlamak için şimdi kapatılacak. Cüzdanınızı şifrelemenin; coinlerinizin, bilgisayarınızı etkileyen zararlı yazılımlar tarafından çalınmasını bütünüyle engelleyemeyebileceğini unutmayınız.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>ÖNEMLİ: Önceden yapmış olduğunuz cüzdan dosyası yedeklemelerinin yeni oluşturulan şifrelenmiş cüzdan dosyası ile değiştirilmeleri gerekir. Güvenlik nedenleriyle yeni, şifrelenmiş cüzdanı kullanmaya başladığınızda eski şifrelenmemiş cüzdan dosyaları işe yaramaz hale gelecektir.</translation>
+        <translation type="vanished">ÖNEMLİ: Önceden yapmış olduğunuz cüzdan dosyası yedeklemelerinin yeni oluşturulan şifrelenmiş cüzdan dosyası ile değiştirilmeleri gerekir. Güvenlik nedenleriyle yeni, şifrelenmiş cüzdanı kullanmaya başladığınızda eski şifrelenmemiş cüzdan dosyaları işe yaramaz hale gelecektir.</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Cüzdan şifreleme başarısız</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Dahili bir hata yüzünden cüzdan şifrelemesi başarısız oldu. Cüzdanınız şifrelenmedi.</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Girilen parolalar birbiriyle eşleşmiyor.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Cüzdan kilidini kaldırma başarısız oldu</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Cüzdan şifresinin açılması için girilen parola yanlıştı.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Cüzdan parolası başarılı bir şekilde değiştirildi.</translation>
     </message>
@@ -348,7 +468,7 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -361,12 +481,12 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>Önemli bir hata oluştu. Gridcoin artık güvenli bir şekilde devam edemez ve şimdi kapatılacak.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Cüzdan</translation>
     </message>
@@ -376,7 +496,12 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Genel bakış</translation>
     </message>
@@ -512,7 +637,7 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>Ç&amp;ık</translation>
     </message>
@@ -637,6 +762,11 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation>İletiyi &amp;kontrol et...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>&amp;Dışa aktar...</translation>
@@ -657,17 +787,25 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation>Hata ayıklama ve teşhis penceresini aç</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Snapshot Download</source>
-        <translation>&amp;Snapshot İndir</translation>
+        <translation type="vanished">&amp;Snapshot İndir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Download and apply latest snapshot</source>
-        <translation>En yeni snapshotu indir ve uygula</translation>
+        <translation type="vanished">En yeni snapshotu indir ve uygula</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -687,12 +825,32 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Dosya</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ayarlar</translation>
     </message>
@@ -727,19 +885,34 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>Gridcoin istemcisi</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation>Gridcoin ağına aktif bağlantı yok. Eğer bu durum bir kaç dakikadan fazla sürerse lütfen konfigürasyonunuzu ve ağ bağlantınızı kontrol edin.</translation>
     </message>
@@ -806,17 +979,17 @@ Bu proje OpenSSL Project tarafından yazılmış OpenSSL Toolkit&apos;i (https:/
         <translation>Son alınan blok, üretildi %1.</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Bu işlem, büyüklük sınırının üzerindedir. İşleminizi gerçekleştirecek ağ noktalarına gidecek ve ağı desteklemeye yardımcı olacak %1 ücretle coin gönderebilirsiniz. Ücreti ödemek istiyor musunuz?</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>İşlem ücretini onayla</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Giden İşlem</translation>
     </message>
@@ -837,17 +1010,15 @@ Tür: %3
 Adres: %4</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation>En yeni snapshotu indirip kurmak istiyor musunuz? (Evet derseniz cüzdanınız kendini kapatıp snapshotu uygulayacaktır.)</translation>
+        <translation type="vanished">En yeni snapshotu indirip kurmak istiyor musunuz? (Evet derseniz cüzdanınız kendini kapatıp snapshotu uygulayacaktır.)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation>Uyarı: İkinci aşamadan sonra iptal etmek blockchain dosyalarının sıfırlanmasına ya da bozulmasına sebep olur.</translation>
+        <translation type="vanished">Uyarı: İkinci aşamadan sonra iptal etmek blockchain dosyalarının sıfırlanmasına ya da bozulmasına sebep olur.</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -867,7 +1038,7 @@ Adres: %4</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -885,7 +1056,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>URI işleme</translation>
@@ -902,7 +1083,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation>Cüzdanınız &lt;b&gt;şifreli&lt;/b&gt; ve şuanda %1 </translation>
     </message>
@@ -917,12 +1098,12 @@ Are you sure you want to proceed?</source>
         <translation>&lt;b&gt;tamamen açık&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Cüzdan &lt;b&gt;şifrelenmiştir&lt;/b&gt; ve şu anda &lt;b&gt;kilitlidir&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>Cüzdanı Yedekle</translation>
     </message>
@@ -933,18 +1114,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>Yedekleme Başarısız Oldu</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>Cüzdan verisi, yeni bir konuma kaydedilmeye çalışılırken bir hata oluştu.</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation>Konfigi Yedekle</translation>
     </message>
@@ -954,7 +1134,12 @@ Are you sure you want to proceed?</source>
         <translation>Cüzdan Konfigi (*.conf)</translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation>mevcut değil</translation>
     </message>
@@ -1046,7 +1231,7 @@ Yayımlamayan scraperlar: %5.</translation>
         <translation>Scraper: Uzlaşım başarısız. Birkaç dakika içerisinde tekrar denencek.</translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1101,12 +1286,12 @@ Bitiş süresi: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>Ağ Uyarısı</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1165,7 +1350,7 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1215,42 +1400,36 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Tutar</translation>
+        <translation type="vanished">Tutar</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>Tarih</translation>
+        <translation type="vanished">Tarih</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Doğrulamalar</translation>
+        <translation type="vanished">Doğrulamalar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Doğrulandı</translation>
+        <translation type="vanished">Doğrulandı</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>Etiket</translation>
+        <translation type="vanished">Etiket</translation>
     </message>
     <message>
-        <location line="-128"/>
+        <location line="-80"/>
         <source>&amp;List mode</source>
         <translation>&amp;Liste modu</translation>
     </message>
     <message>
-        <location line="+133"/>
         <source>Address</source>
-        <translation>Adres</translation>
+        <translation type="vanished">Adres</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Adresi kopyala</translation>
     </message>
@@ -1261,17 +1440,17 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>Tutarı kopyala</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>İşlem ID&apos;sini kopyala</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>Miktarı kopyala</translation>
     </message>
@@ -1301,17 +1480,17 @@ Bitiş süresi: %3
         <translation>Para üstünü kopyala</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation>BOZUKLUK</translation>
     </message>
@@ -1361,20 +1540,65 @@ Bitiş süresi: %3
  Bu, en az %2 bir ücretin gerektiği anlamına gelir.</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(etiket yok)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>%1 ögesinden para üstü (%2)</translation>
+        <translation type="vanished">%1 ögesinden para üstü (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(para üstü)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(etiket yok)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">%1 ögesinden para üstü (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(para üstü)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(para üstü)</translation>
+        <source>Label</source>
+        <translation type="unfinished">Etiket</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Adres</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Tarih</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Doğrulamalar</translation>
     </message>
 </context>
 <context>
@@ -1400,7 +1624,7 @@ Bitiş süresi: %3
         <translation type="unfinished">Adres</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1462,7 +1686,7 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1497,37 +1721,27 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <source>Amount</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Etiket</translation>
+        <translation type="obsolete">Etiket</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Adres</translation>
+        <translation type="obsolete">Adres</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Tarih</translation>
+        <translation type="obsolete">Tarih</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Doğrulamalar</translation>
+        <translation type="obsolete">Doğrulamalar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Doğrulandı</translation>
+        <translation type="obsolete">Doğrulandı</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1562,7 +1776,7 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1572,25 +1786,22 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(etiket yok)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">%1 ögesinden para üstü (%2)</translation>
+        <translation type="obsolete">%1 ögesinden para üstü (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(para üstü)</translation>
+        <translation type="obsolete">(para üstü)</translation>
     </message>
 </context>
 <context>
@@ -1740,7 +1951,12 @@ Bitiş süresi: %3
         <translation>Test et</translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation>Test ediliyor...</translation>
     </message>
@@ -1765,7 +1981,7 @@ Bitiş süresi: %3
         <translation>Başarısız</translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1941,7 +2157,7 @@ Bitiş süresi: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1956,6 +2172,11 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1964,7 +2185,7 @@ Bitiş süresi: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>versiyon</translation>
     </message>
@@ -1992,7 +2213,16 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2061,22 +2291,22 @@ Bitiş süresi: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2140,7 +2370,7 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2259,6 +2489,367 @@ Bitiş süresi: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Tümünü &amp;temizle</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">evet</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">hayır</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Cüzdan kilidinin açılması iptal edildi.</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2574,7 +3165,7 @@ Bitiş süresi: %3
         <translation>&amp;İptal</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>varsayılan</translation>
     </message>
@@ -2589,7 +3180,7 @@ Bitiş süresi: %3
         <translation>Aydınlık</translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Hata</translation>
@@ -2817,18 +3408,23 @@ Bitiş süresi: %3
         <translation>Aktif Anketler</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">Tutarı kopyala</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished">Havuz</translation>
     </message>
@@ -2839,9 +3435,219 @@ Bitiş süresi: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">Durum</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2955,7 +3761,7 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2995,6 +3801,11 @@ Bitiş süresi: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3030,7 +3841,7 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3040,7 +3851,17 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3053,7 +3874,7 @@ Bitiş süresi: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3106,6 +3927,83 @@ Bitiş süresi: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished">yok</translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">evet</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">hayır</translation>
     </message>
 </context>
 <context>
@@ -3190,12 +4088,17 @@ Bitiş süresi: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished">Bakiye</translation>
     </message>
@@ -3220,12 +4123,12 @@ Bitiş süresi: %3
         <translation type="unfinished">Çoklu Seçim</translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3312,7 +4215,7 @@ Bitiş süresi: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
@@ -3350,14 +4253,48 @@ Bitiş süresi: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3367,7 +4304,7 @@ Bitiş süresi: %3
         <translation>Hata: Seçilen veri dizini &quot;%1&quot; bulunamadı.</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation>Hata: Seçilen veri dizini kitlenemiyor. Başka bir Gridcoin İstemcisi çalışıyor olabilir.</translation>
     </message>
@@ -3382,12 +4319,35 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation>%1 henüz güvenli bir şekilde kapanmadı...</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">Mevcut değil</translation>
     </message>
@@ -3491,7 +4451,7 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3501,7 +4461,7 @@ Bitiş süresi: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3563,6 +4523,11 @@ Bitiş süresi: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3658,7 +4623,7 @@ Bitiş süresi: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>Mevcut değil</translation>
     </message>
@@ -3734,7 +4699,7 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation>Detaylı bilgi almak için eş seçin.</translation>
     </message>
@@ -3977,7 +4942,7 @@ Bitiş süresi: %3
         <translation>Hayır</translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation>Gridcoin RPC konsoluna hoş geldiniz!</translation>
     </message>
@@ -3992,7 +4957,7 @@ Bitiş süresi: %3
         <translation>Mevcut komutların listesi için &lt;b&gt;help&lt;/b&gt; yazınız.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4053,10 +5018,8 @@ Bitiş süresi: %3
         <translation>Dışarı</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+6"/>
         <source>Unknown</source>
-        <translation>Bilinmiyor</translation>
+        <translation type="vanished">Bilinmiyor</translation>
     </message>
 </context>
 <context>
@@ -4147,40 +5110,37 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation>Beyaz listelenmemiş.</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation>Bağlı değil</translation>
     </message>
@@ -4651,7 +5611,7 @@ Bitiş süresi: %3
         <translation>İşiniz bittiğinde &quot;İleri&quot; düğmesine basın.</translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation>Adres Etiketi</translation>
     </message>
@@ -4772,7 +5732,7 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation>Her şey iyi görünüyor.</translation>
     </message>
@@ -4886,7 +5846,7 @@ Bitiş süresi: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4909,7 +5869,7 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4921,7 +5881,7 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5045,7 +6005,7 @@ Bitiş süresi: %3
         <translation>Bir Gridcoin adresi girin (ör. S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>Miktarı kopyala</translation>
     </message>
@@ -5105,7 +6065,7 @@ Bitiş süresi: %3
         <translation>ve</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Alıcı adresi geçerli değildir, lütfen denetleyiniz.</translation>
     </message>
@@ -5145,8 +6105,8 @@ Bitiş süresi: %3
         <translation>Hata: İşlem reddedildi. Bu durum, wallet.dat dosyasının bir kopyasını kullandıysanız ve coinler, kopyada harcanmış ve burada harcanmış olarak işaretlenmemesinden kaynaklanabilir. </translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(etiket yok)</translation>
     </message>
@@ -5253,7 +6213,7 @@ Bitiş süresi: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Adres</translation>
     </message>
@@ -5391,42 +6351,42 @@ Bitiş süresi: %3
         <translation>Gridcoin imzası gir</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>Girilen adres geçersizdir.</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Lütfen adresi kontrol edip tekrar deneyiniz.</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Girilen adres herhangi bir anahtara işaret etmemektedir.</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Cüzdan kilidinin açılması iptal edildi.</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Girilen adres için özel anahtar mevcut değildir.</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>İleti imzalaması başarısız oldu.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>İleti imzalandı.</translation>
     </message>
@@ -5437,7 +6397,7 @@ Bitiş süresi: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>Lütfen imzayı kontrol edip tekrar deneyiniz.</translation>
     </message>
@@ -5488,39 +6448,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>%1 değerine dek açık</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>Çakışma</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/Çevrimdışı</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/Doğrulanmadı</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 Doğrulama</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>Durum</translation>
     </message>
@@ -5542,74 +6502,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Tarih</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>Kaynak</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>Gönderen</translation>
     </message>
@@ -5620,13 +6580,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>Alıcı</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>Kendi Adresiniz</translation>
@@ -5637,16 +6597,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Etiket</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>Alınan Tutar</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5658,31 +6618,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Kabul Edilmedi</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>Çekilen Tutar</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>İşlem ücreti</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>Net tutar</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>İleti</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>Yorum</translation>
     </message>
@@ -5692,38 +6652,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation>Blok Hash&apos;i</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Tutar</translation>
     </message>
@@ -5755,11 +6715,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation>K&amp;apat</translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>Tarih</translation>
     </message>
@@ -5779,7 +6744,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Meblağ</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5806,12 +6771,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Onaylanıyor (%1/%2 önerilen onay)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Doğrulandı (%1 doğrulama)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>Uyuşmadı</translation>
     </message>
@@ -6036,7 +7001,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>İşlem durumu. Doğrulama sayısını görüntülemek için fare imlecini bu alanın üzerinde tutunuz.</translation>
     </message>
@@ -6064,7 +7064,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation>İşlem Geçmişi</translation>
     </message>
@@ -6119,7 +7119,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>En düşük tutar</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>Adres kopyala</translation>
     </message>
@@ -6149,7 +7154,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>İşlem ayrıntılarını göster</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>İşlem Verisini Dışarı Aktar</translation>
     </message>
@@ -6160,7 +7165,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>Doğrulandı</translation>
     </message>
@@ -6205,7 +7210,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>%1 dosyasına yazılamadı.</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>Tarih Aralığı:</translation>
     </message>
@@ -6241,19 +7246,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">Ç&amp;ık</translation>
+        <translation type="obsolete">Ç&amp;ık</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Uygulamadan çık</translation>
+        <translation type="obsolete">Uygulamadan çık</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Dosya</translation>
+        <translation type="obsolete">&amp;Dosya</translation>
     </message>
 </context>
 <context>
@@ -6267,7 +7269,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6293,18 +7295,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6381,15 +7383,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>Gönderiyor...</translation>
+        <translation type="vanished">Gönderiyor...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>IPv6 üzerinde dinlemek için %u numaralı RPC portu kurulurken bir hata meydana geldi, IPv4&apos;e dönülüyor: %s</translation>
     </message>
@@ -6399,23 +7400,23 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>IPv4 üzerinde dinlemek için %u numaral? RPC portunun kurulumu sırasında hata meydana geldi: %s</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>Kullanım:</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>Komutları Listele</translation>
     </message>
     <message>
-        <location line="-367"/>
-        <location line="+344"/>
+        <location line="-397"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6440,12 +7441,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+18"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6465,21 +7466,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6505,11 +7492,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6529,7 +7511,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6569,7 +7551,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6610,11 +7592,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6654,12 +7631,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6724,7 +7696,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6736,11 +7708,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6801,16 +7768,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6914,11 +7871,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -6941,16 +7893,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7034,14 +7976,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>KB/s</source>
-        <translation>KB/sn</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">KB/sn</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -7069,9 +8005,8 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Yerel sürüm: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MB/s</source>
-        <translation>MB/sn</translation>
+        <translation type="vanished">MB/sn</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -7114,18 +8049,12 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Çoklu Seçim</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">Mevcut değil</translation>
+        <translation type="obsolete">Mevcut değil</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7146,6 +8075,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7364,77 +8298,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Staking Only - No Eligible Research Projects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7481,16 +8345,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7544,7 +8398,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7584,7 +8438,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Evet/Hayır/Kararsız</translation>
     </message>
     <message>
-        <location line="-208"/>
+        <location line="-183"/>
         <source>Balance</source>
         <translation>Bakiye</translation>
     </message>
@@ -7594,7 +8448,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Blok Sürümü</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+15"/>
         <source>Client Version</source>
         <translation>İstemci Sürümü</translation>
     </message>
@@ -7609,17 +8463,17 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>HATA</translation>
     </message>
     <message>
-        <location line="+83"/>
+        <location line="+76"/>
         <source>Organization</source>
         <translation>Organizasyon</translation>
     </message>
     <message>
-        <location line="-223"/>
+        <location line="-211"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Uyarı: -paytxfee çok yüksek bir değere ayarlanmış! Bu, coin gönderirseniz ödeyeceğiniz işlem ücretidir.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Uyarı: wallet.dat bozuk, veriler geri kazanıldı! Özgün wallet.dat, wallet.{zamandamgası}.bak olarak %s klasörüne kaydedildi; bakiyeniz ya da işlemleriniz yanlışsa bir yedeklemeden tekrar yüklemeniz gerekir.</translation>
     </message>
@@ -7629,7 +8483,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Uyarı: wallet.dat dosyasının okunması sırasında bir hata meydana geldi! Tüm anahtarlar doğru bir şekilde okundu, ancak işlem verileri ya da adres defteri unsurları hatalı veya eksik olabilir.</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>Hata: İşlem yaratma başarısız oldu</translation>
     </message>
@@ -7639,22 +8493,22 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation>Hata: İşlem reddedildi. Bu durum, wallet.dat dosyasının bir kopyasını kullandıysanız ve coinler, kopyada harcanmış ve burada harcanmış olarak işaretlenmemesinden kaynaklanabilir. </translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Herhangi bir portun dinlenmesi başarısız oldu. Bunu istiyorsanız -listen=0 seçeneğini kullanınız.</translation>
     </message>
     <message>
-        <location line="+107"/>
+        <location line="+100"/>
         <source>Single Choice</source>
         <translation>Tek Seçim</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+12"/>
         <source>To use the %s option</source>
         <translation>%s seçeneğini kullanmak için</translation>
     </message>
     <message>
-        <location line="-263"/>
+        <location line="-237"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
@@ -7663,7 +8517,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
 Dosya mevcut deilse, sadece sahibi için okumayla sınırlı izin ile oluşturunuz.</translation>
     </message>
     <message>
-        <location line="+140"/>
+        <location line="+135"/>
         <source>Gridcoin version</source>
         <translation>Gridcoin Versiyonu</translation>
     </message>
@@ -7678,17 +8532,90 @@ Dosya mevcut deilse, sadece sahibi için okumayla sınırlı izin ile oluşturun
         <translation>Başlatma kontrolü başarışız oldu. Gridcoin kapanıyor.</translation>
     </message>
     <message>
-        <location line="+129"/>
+        <location line="+108"/>
         <source>Verifying database integrity...</source>
         <translation>Veritabanı bütünlüğü doğrulanıyor...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-404"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Veritabanı ortamı %s başlatılırken hata oluştu! Kurtarmak için, İLGİLİ KLASÖRÜ YEDEKLEYİN, ardından wallet.dat dışındaki herşeyi silin.</translation>
     </message>
     <message>
-        <location line="+441"/>
+        <location line="-69"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
         <source>You are running the latest release.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7744,6 +8671,16 @@ Dosya mevcut deilse, sadece sahibi için okumayla sınırlı izin ile oluşturun
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7778,7 +8715,7 @@ Dosya mevcut deilse, sadece sahibi için okumayla sınırlı izin ile oluşturun
         <translation>wallet.dat bozuk, geri kazanım başarısız oldu</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Geçersiz -proxy adresi: &apos;%s&apos;</translation>
     </message>
@@ -7788,7 +8725,7 @@ Dosya mevcut deilse, sadece sahibi için okumayla sınırlı izin ile oluşturun
         <translation>Geçersiz -tor adresi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>-bind adresi çözümlenemedi: &apos;%s&apos;</translation>
     </message>
@@ -7798,12 +8735,12 @@ Dosya mevcut deilse, sadece sahibi için okumayla sınırlı izin ile oluşturun
         <translation>-externalip adresi çözümlenemedi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>-reservebalance=&lt;amount&gt; için geçersiz miktar</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-40"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>wallet.dat dosyasının yüklenmesinde hata oluştu: bozuk cüzdan</translation>
     </message>
@@ -7813,37 +8750,37 @@ Dosya mevcut deilse, sadece sahibi için okumayla sınırlı izin ile oluşturun
         <translation>HATA: wallet.dat yüklenemedi, wallet.dat daha yeni bir Gridcoin istemcisine ihtiyaç duyuyor.</translation>
     </message>
     <message>
-        <location line="+163"/>
+        <location line="+140"/>
         <source>Wallet needed to be rewritten: restart Gridcoin to complete</source>
         <translation>Cüzdanın tekrardan oluşturulması gerekiyor: Gridcoin istemcisini yeniden başlatın</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>wallet.dat dosyasının yüklenmesinde hata oluştu</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>Önyükleme blok zinciri veri dosyası içeri aktarılıyor.</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>Adresler yükleniyor...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>Ağ Noktası Başlatılamadı</translation>
     </message>
     <message>
-        <location line="+141"/>
+        <location line="+117"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Bu bilgisayarda %s unsuruna bağlanılamadı. (bind şu hatayı iletti: %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>Hata: Cüzdan kilitli, işlem yapılamıyor.</translation>
     </message>
@@ -7858,42 +8795,41 @@ Dosya mevcut deilse, sadece sahibi için okumayla sınırlı izin ile oluşturun
         <translation>Hata: Bu işlem; miktarı, karmaşıklığı veya son alınan miktarın kullanımı nedeniyle en az %s işlem ücreti gerektirir</translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>Gönderiliyor...</translation>
+        <translation type="vanished">Gönderiliyor...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>Geçersiz meblağ</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Uyarı: Lütfen bilgisayarınızın tarih ve saatinin doğruluğunu kontrol ediniz! Saatiniz yanlış ise, Gridcoin düzgün çalışmayacaktır.</translation>
     </message>
     <message>
-        <location line="+291"/>
+        <location line="+265"/>
         <source>Vote signature failed. See debug.log.</source>
         <translation>Oy imzası başarısız. Daha fazla bilgi için debug.log dosyasına bakınız.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Warning: Disk space is low!</source>
         <translation>Uyarı: Disk alanınız düşük!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>-onlynet için bilinmeyen bir ağ belirtildi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Yetersiz Bakiye</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>Blok indeksi yükleniyor...</translation>
     </message>
@@ -7903,17 +8839,17 @@ Dosya mevcut deilse, sadece sahibi için okumayla sınırlı izin ile oluşturun
         <translation>Cüzdan yükleniyor...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>Varsayılan adres yazılamadı</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Yeniden taranıyor...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Yükleme Tamamlandı</translation>
     </message>

--- a/src/qt/locale/bitcoin_uk.ts
+++ b/src/qt/locale/bitcoin_uk.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>&amp;Видалити</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Гаманець</translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Огляд</translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>&amp;Вихід</translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>П&amp;еревірити повідомлення...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>Відкрити консоль зневадження і діагностики</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>&amp;Налаштування</translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -808,17 +969,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>Надіслані транзакції</translation>
     </message>
@@ -836,17 +997,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -866,7 +1017,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -884,7 +1035,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -901,7 +1062,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +1077,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>&lt;b&gt;Зашифрований&lt;/b&gt; гаманець &lt;b&gt;заблоковано&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -932,18 +1093,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +1113,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1040,7 +1205,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1089,7 +1254,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,12 +1262,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1161,7 +1326,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1216,37 +1381,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Кількість</translation>
+        <translation type="vanished">Кількість</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>Дата</translation>
+        <translation type="vanished">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>Підтверджень</translation>
+        <translation type="vanished">Підтверджень</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>Підтверджені</translation>
+        <translation type="vanished">Підтверджені</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1257,17 +1408,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1297,17 +1448,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1347,20 +1498,57 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Кількість</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">Дата</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">Підтверджень</translation>
     </message>
 </context>
 <context>
@@ -1386,7 +1574,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1448,7 +1636,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,37 +1671,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Кількість</translation>
+        <translation type="obsolete">Кількість</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">Дата</translation>
+        <translation type="obsolete">Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">Підтверджень</translation>
+        <translation type="obsolete">Підтверджень</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">Підтверджені</translation>
+        <translation type="obsolete">Підтверджені</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1548,7 +1722,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1558,24 +1732,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1726,7 +1889,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1751,7 +1919,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1927,7 +2095,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,6 +2110,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1950,7 +2123,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1978,7 +2151,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2053,22 +2235,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2132,7 +2314,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2251,6 +2433,373 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Очистити &amp;все</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2566,7 +3115,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>типово</translation>
     </message>
@@ -2581,7 +3130,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Помилка</translation>
@@ -2809,18 +3358,23 @@ Expires: %3
         <translation>Ваш поточний сукупний баланс</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2831,9 +3385,227 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Кількість</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2947,7 +3719,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2987,6 +3759,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3022,7 +3799,7 @@ Expires: %3
         <translation type="unfinished">Форма</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3032,7 +3809,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,7 +3832,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3097,6 +3884,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3182,12 +4046,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3212,12 +4081,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3304,7 +4173,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3342,7 +4211,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">Н/Д</translation>
     </message>
@@ -3458,14 +4327,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4378,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,12 +4393,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3505,7 +4431,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3567,6 +4493,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4593,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>Н/Д</translation>
     </message>
@@ -3793,7 +4724,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4912,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3996,7 +4927,7 @@ Expires: %3
         <translation>Наберіть &lt;b&gt;help&lt;/b&gt; для перегляду доступних команд.</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation>%1 Б</translation>
     </message>
@@ -4054,12 +4985,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4151,40 +5076,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4642,7 +5564,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4763,7 +5685,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4877,7 +5799,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4900,7 +5822,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4912,7 +5834,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5036,7 +5958,7 @@ Expires: %3
         <translation>&amp;Відправити</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5096,7 +6018,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5136,8 +6058,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5244,7 +6166,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5382,42 +6304,42 @@ Expires: %3
         <translation>Скинути всі поля перевірки повідомлення</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5428,7 +6350,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5479,7 +6401,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5488,32 +6410,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5537,74 +6459,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Дата</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5615,13 +6537,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5632,16 +6554,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5655,31 +6577,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5689,38 +6611,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">Кількість</translation>
     </message>
@@ -5752,11 +6674,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">Дата</translation>
     </message>
@@ -5776,7 +6703,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">Кількість</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5805,12 +6732,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6035,7 +6962,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6063,7 +7025,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,7 +7080,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6148,7 +7115,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6159,7 +7126,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished">Підтверджені</translation>
     </message>
@@ -6204,7 +7171,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6240,19 +7207,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Вихід</translation>
+        <translation type="obsolete">&amp;Вихід</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Вийти</translation>
+        <translation type="obsolete">Вийти</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Файл</translation>
+        <translation type="obsolete">&amp;Файл</translation>
     </message>
 </context>
 <context>
@@ -6266,7 +7230,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6292,18 +7256,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6378,38 +7342,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Не вдалося слухати на жодному порту. Використовуйте -listen=0, якщо ви хочете цього.</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Помилка в адресі проксі-сервера: «%s»</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>Завантаження адрес...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6453,18 +7404,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">Н/Д</translation>
+        <translation type="obsolete">Н/Д</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6485,6 +7430,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6699,42 +7649,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6788,7 +7703,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6818,18 +7733,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Невідома мережа вказана в -onlynet: «%s»</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>Недостатньо коштів</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6855,17 +7770,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6889,21 +7824,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6944,11 +7865,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6965,6 +7881,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7009,6 +7935,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7049,11 +7980,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7099,11 +8025,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7191,6 +8112,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7202,11 +8128,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7277,16 +8198,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7450,11 +8361,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7477,16 +8383,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7606,16 +8502,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7650,7 +8536,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Завантаження гаманця...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7660,57 +8546,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+20"/>
         <source>Unknown poll response type.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7757,6 +8593,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7866,6 +8707,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7900,17 +8751,45 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>Неможливо записати типову адресу</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+383"/>
         <source>Rescanning...</source>
         <translation>Сканування...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Завантаження завершене</translation>
     </message>

--- a/src/qt/locale/bitcoin_ur_PK.ts
+++ b/src/qt/locale/bitcoin_ur_PK.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,6 +94,41 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>مٹا</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -185,7 +270,18 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,58 +363,78 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +459,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +472,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -366,7 +482,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -502,7 +623,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -627,6 +748,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +773,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +803,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -717,19 +863,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -802,17 +963,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -830,17 +991,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -860,7 +1011,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -878,7 +1029,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -895,7 +1056,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -910,12 +1071,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -926,18 +1087,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,7 +1107,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1199,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1083,7 +1248,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1091,12 +1256,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,7 +1320,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,37 +1375,15 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>رقم</translation>
+        <translation type="vanished">رقم</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>تاریخ</translation>
+        <translation type="vanished">تاریخ</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1251,17 +1394,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,17 +1434,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1341,19 +1484,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">رقم</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">تاریخ</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1380,7 +1560,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1442,7 +1622,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1477,37 +1657,15 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">رقم</translation>
+        <translation type="obsolete">رقم</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">تاریخ</translation>
+        <translation type="obsolete">تاریخ</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,7 +1700,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1552,24 +1710,13 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1720,7 +1867,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,7 +1897,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,7 +2073,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1936,6 +2088,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1944,7 +2101,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1972,7 +2129,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2210,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2289,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2408,370 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3087,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2572,7 +3102,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">نقص</translation>
@@ -2800,18 +3330,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3357,223 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">رقم</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3687,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3727,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3767,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3777,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3800,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3088,6 +3852,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3173,12 +4014,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4049,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4141,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4179,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3443,14 +4289,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,7 +4340,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,12 +4355,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3490,7 +4393,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3552,6 +4455,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3662,7 +4570,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3803,7 +4711,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4874,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3981,7 +4889,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4039,12 +4947,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4136,40 +5038,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4627,7 +5526,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4748,7 +5647,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4862,7 +5761,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4885,7 +5784,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4897,7 +5796,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5021,7 +5920,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +5980,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,8 +6020,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5229,7 +6128,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5367,42 +6266,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5413,7 +6312,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,7 +6363,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5472,32 +6371,32 @@ Operations such as beacon management, voting, and sending transactions should no
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5520,74 +6419,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">تاریخ</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5598,13 +6497,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5615,16 +6514,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5637,31 +6536,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5671,38 +6570,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation type="unfinished">رقم</translation>
     </message>
@@ -5734,11 +6633,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
     </message>
@@ -5758,7 +6662,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">رقم</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5786,12 +6690,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6920,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6044,7 +6983,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6099,7 +7038,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6129,7 +7073,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6140,7 +7084,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6185,7 +7129,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6219,24 +7163,6 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>UpgradeQt</name>
-    <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
-        <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Quit application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>VoteWizard</name>
     <message>
         <location filename="../forms/voting/votewizard.ui" line="+20"/>
@@ -6247,7 +7173,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6273,18 +7199,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,23 +7285,15 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
         <location filename="../bitcoinstrings.cpp" line="+12"/>
-        <location line="+344"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6401,17 +7319,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6435,21 +7373,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6490,11 +7414,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6514,7 +7433,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6554,7 +7473,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6595,11 +7514,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6645,11 +7559,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6736,7 +7645,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6748,11 +7657,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6823,16 +7727,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7007,11 +7901,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7038,16 +7927,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7177,16 +8056,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7232,11 +8101,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>MB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Magnitude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7277,21 +8141,59 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
+        <location line="-366"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+103"/>
         <source>No coins</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7308,6 +8210,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7537,82 +8444,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7663,16 +8495,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>The latest release is </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7753,6 +8575,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7862,6 +8689,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7896,7 +8733,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-188"/>
+        <location line="-167"/>
         <source>Error</source>
         <translation>نقص</translation>
     </message>

--- a/src/qt/locale/bitcoin_vi.ts
+++ b/src/qt/locale/bitcoin_vi.ts
@@ -14,7 +14,7 @@
         <translation>Gridcoin</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -34,7 +34,7 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -43,11 +43,51 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
@@ -60,6 +100,41 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <location line="+1"/>
         <source>Required</source>
         <translation>Yêu cầu</translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -145,7 +220,17 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation>&amp;Xóa</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>Sao chép &amp;nhãn dữ liệu</translation>
     </message>
@@ -155,7 +240,7 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation>&amp;Chỉnh sửa</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -179,7 +264,7 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>Nhãn dữ liệu</translation>
     </message>
@@ -190,8 +275,19 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(chưa có nhãn)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -227,7 +323,7 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Nhập cụm mật khẩu mới vào ví. &lt;br/&gt;Vui lòng sử dụng cụm mật khẩu gồm &lt;b&gt;mười ký tự ngẫu nhiên trở lên&lt;/b&gt; hoặc &lt;b&gt;tám từ trở lên&lt;/b&gt;.</translation>
     </message>
@@ -257,7 +353,7 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation>Nhập cụm mật khẩu cũ và cụm mật khẩu mới vào ví</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>Xác nhận mã hóa ví</translation>
     </message>
@@ -272,58 +368,78 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation>Bạn có chắc chắn muốn mã hóa ví của mình không?</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>Ví đã được mã hóa</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>Gridcoin sẽ đóng để hoàn tất quá trình mã hóa. Hãy nhớ rằng việc mã hóa ví của bạn không thể bảo vệ hoàn toàn tiền của bạn khỏi việc bị đánh cắp trong trường hợp máy bạn bị lây nhiễm mã độc (virus).</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>Mã hóa ví thất bại</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Cụm mật khẩu được cung cấp không khớp.</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>Mở khóa ví thất bại</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Cụm mật khẩu được nhập để giải mã ví không chính xác.</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Cụm mật khẩu ví đã được thay đổi thành công.</translation>
     </message>
@@ -348,7 +464,7 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -361,7 +477,7 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>Ví</translation>
     </message>
@@ -371,7 +487,12 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>&amp;Tổng quan</translation>
     </message>
@@ -507,7 +628,7 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>T&amp;hoát</translation>
     </message>
@@ -632,6 +753,11 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -652,17 +778,17 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +808,32 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>&amp;Tệp</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -722,19 +868,34 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -801,17 +962,17 @@ Sản phẩm này bao gồm phần mềm do Dự án OpenSSL phát triển để
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -829,17 +990,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -859,7 +1010,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -877,7 +1028,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>Xử lý URI</translation>
@@ -894,7 +1055,7 @@ Are you sure you want to proceed?</source>
         <translation>Ví &lt;b&gt;chưa được mã hóa&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -909,12 +1070,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -925,18 +1086,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -946,7 +1106,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1033,7 +1198,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1082,7 +1247,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1090,12 +1255,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation>Độ khó thấp!;</translation>
     </message>
@@ -1139,7 +1304,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation>Chọn tất cả</translation>
     </message>
@@ -1189,27 +1354,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>Số lượng</translation>
+        <translation type="vanished">Số lượng</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-146"/>
+        <location line="-80"/>
         <source>&amp;List mode</source>
         <translation>&amp;Chế độ danh sách</translation>
     </message>
@@ -1229,17 +1378,15 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+373"/>
         <source>Label</source>
-        <translation type="unfinished">Nhãn dữ liệu</translation>
+        <translation type="obsolete">Nhãn dữ liệu</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>Địa chỉ</translation>
+        <translation type="vanished">Địa chỉ</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>Sao chép địa chỉ</translation>
     </message>
@@ -1250,17 +1397,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,17 +1437,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>DUST</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1340,19 +1487,56 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(chưa có nhãn)</translation>
     </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
     <message>
-        <location line="-10"/>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(chưa có nhãn)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+9"/>
+        <location line="+572"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">Số lượng</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Label</source>
+        <translation type="unfinished">Nhãn dữ liệu</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">Địa chỉ</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1379,7 +1563,7 @@ Expires: %3
         <translation type="unfinished">Địa chỉ</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1441,7 +1625,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished">Chọn tất cả</translation>
     </message>
@@ -1476,37 +1660,19 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">Số lượng</translation>
+        <translation type="obsolete">Số lượng</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">Nhãn dữ liệu</translation>
+        <translation type="obsolete">Nhãn dữ liệu</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">Địa chỉ</translation>
+        <translation type="obsolete">Địa chỉ</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Confirmations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Confirmed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1541,7 +1707,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1551,25 +1717,14 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(chưa có nhãn)</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>(change)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1719,7 +1874,12 @@ Expires: %3
         <translation>Kiểm tra</translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation>Đang kiểm tra...</translation>
     </message>
@@ -1744,7 +1904,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1920,7 +2080,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1935,6 +2095,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1943,7 +2108,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1971,7 +2136,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2040,22 +2214,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2119,7 +2293,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2238,6 +2412,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2553,7 +3088,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2568,7 +3103,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Lỗi</translation>
@@ -2796,18 +3331,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2818,9 +3358,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">Số lượng</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2934,7 +3684,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2974,6 +3724,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3009,7 +3764,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3019,7 +3774,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3032,7 +3797,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3084,6 +3849,83 @@ Expires: %3
     <message>
         <location line="+1"/>
         <source>Stale Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3169,12 +4011,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3199,12 +4046,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3291,7 +4138,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished">Tên</translation>
     </message>
@@ -3329,7 +4176,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3433,14 +4280,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3450,7 +4331,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3465,12 +4346,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3480,7 +4384,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3542,6 +4446,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3652,7 +4561,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3793,7 +4702,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3956,7 +4865,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3971,7 +4880,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4029,12 +4938,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4126,40 +5029,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4617,7 +5517,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4738,7 +5638,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4852,7 +5752,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4875,7 +5775,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4887,7 +5787,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5011,7 +5911,7 @@ Expires: %3
         <translation>G&amp;ửi</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5071,7 +5971,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5111,8 +6011,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(chưa có nhãn)</translation>
     </message>
@@ -5219,7 +6119,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">Địa chỉ</translation>
     </message>
@@ -5357,42 +6257,42 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5403,7 +6303,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5454,39 +6354,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5508,74 +6408,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5586,13 +6486,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
@@ -5603,16 +6503,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5624,31 +6524,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5658,38 +6558,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>Số lượng</translation>
     </message>
@@ -5721,11 +6621,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Address</source>
         <translation>Địa chỉ</translation>
     </message>
@@ -5745,7 +6650,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5772,12 +6677,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6002,7 +6907,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6030,7 +6970,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6085,7 +7025,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation type="unfinished">Sao chép địa chỉ</translation>
     </message>
@@ -6115,7 +7060,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6126,7 +7071,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6171,7 +7116,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6207,19 +7152,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">T&amp;hoát</translation>
+        <translation type="obsolete">T&amp;hoát</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">Thoát ứng dụng</translation>
+        <translation type="obsolete">Thoát ứng dụng</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation>&amp;Tệp</translation>
+        <translation type="vanished">&amp;Tệp</translation>
     </message>
 </context>
 <context>
@@ -6233,7 +7175,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6259,18 +7201,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6345,33 +7287,48 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+374"/>
+        <location filename="../bitcoinstrings.cpp" line="+406"/>
         <source>Invalid amount</source>
         <translation>Số tiền không hợp lệ</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>Cảnh báo: Vui lòng kiểm tra xem ngày và giờ trên máy tính của bạn có chính xác không! Nếu đồng hồ của bạn sai, Gridcoin sẽ không hoạt động bình thường.</translation>
     </message>
     <message>
-        <location line="+187"/>
-        <source>Local version: </source>
+        <location line="-177"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>MB/s</source>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+328"/>
+        <source>Local version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6416,17 +7373,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>N/A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6447,6 +7394,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6661,42 +7613,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6750,7 +7667,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6831,6 +7748,11 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6870,18 +7792,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>Cảnh báo: Dung lượng ổ đĩa thấp!</translation>
     </message>
     <message>
-        <location line="-135"/>
+        <location line="-115"/>
         <source>Insufficient funds</source>
         <translation>Nguồn tiền không đủ</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6907,17 +7829,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6941,21 +7883,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6996,11 +7924,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7017,6 +7940,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7061,6 +7994,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7101,11 +8039,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7150,12 +8083,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
+        <location line="+5"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7238,6 +8166,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7249,11 +8182,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7324,16 +8252,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7498,11 +8416,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7529,16 +8442,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7658,16 +8561,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7707,7 +8600,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>Đang tải ví...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7717,57 +8610,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
+        <location line="+39"/>
         <source>Wrong Payload version specified for current block height.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7833,6 +8676,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7867,17 +8720,17 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>Không thể ghi địa chỉ mặc định</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>Đang quét lại...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>Đã tải xong</translation>
     </message>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -14,7 +14,7 @@
         <translation>&lt;b&gt;格雷德币&lt;/b&gt; </translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">否</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>删除(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>复制标签(&amp;L)</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>编辑(&amp;E)</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation>导出地址簿数据</translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>标签</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(没有标签)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>仅用于权益增值</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>输入钱包的新密码。&lt;br/&gt;使用的密码请至少包含&lt;b&gt;10个以上随机字符&lt;/&gt;，或者是&lt;b&gt;8个以上的单词&lt;/b&gt;。</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>请输入该钱包的旧密码与新密码。</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>确认加密钱包</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>您确定需要为钱包加密吗？</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>钱包已加密</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation>格雷德币客户端即将关闭以完成加密过程。请记住，加密钱包并不能完全防止您的电子货币被入侵您计算机的木马软件盗窃。</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>重要提示：您以前备份的钱包文件应该替换成最新生成的加密钱包文件（重新备份）。从安全性上考虑，您以前备份的未加密的钱包文件，在您使用新的加密钱包后将无效，请重新备份。</translation>
+        <translation type="vanished">重要提示：您以前备份的钱包文件应该替换成最新生成的加密钱包文件（重新备份）。从安全性上考虑，您以前备份的未加密的钱包文件，在您使用新的加密钱包后将无效，请重新备份。</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>钱包加密失败</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>由于一个本地错误，加密钱包的操作已经失败。您的钱包没能被加密。</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>密码不匹配。</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>钱包解锁失败</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>用于解密钱包的密码不正确。</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>修改钱包密码成功。</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,12 +476,12 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation>发生致命错误。格雷德币不再安全，即将退出。</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Gridcoin</source>
         <translation>格雷德币</translation>
     </message>
@@ -371,7 +491,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>钱包</translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>概况(&amp;O)</translation>
     </message>
@@ -507,7 +632,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>退出(&amp;X)</translation>
     </message>
@@ -632,6 +757,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>验证消息(&amp;V)...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation>导出(&amp;E)</translation>
@@ -652,17 +782,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>打开调试和诊断控制台</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,12 +812,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>文件(&amp;F)</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>设置(&amp;S)</translation>
     </message>
@@ -722,19 +872,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation>[测试网络]</translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation>格雷德币客户端</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -801,17 +966,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>最新收到的区块产生于 %1。</translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>交易数据量超限。您仍可发送这笔交易，只需为节点确认您的交易以及支持网络运行提供%1的交易费。您希望付费吗？</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation>确认交易费</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>发送交易</translation>
     </message>
@@ -829,17 +994,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -859,7 +1014,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -877,7 +1032,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation>URI处理</translation>
@@ -894,7 +1059,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -909,12 +1074,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>钱包已被&lt;b&gt;加密&lt;/b&gt;，当前为&lt;b&gt;锁定&lt;/b&gt;状态</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation>备份钱包</translation>
     </message>
@@ -925,18 +1090,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation>备份失败</translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>存储地址列表到新位置时发生错误。</translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -946,7 +1110,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1033,7 +1202,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1085,12 +1254,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation>网络警报</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1318,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1373,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>金额</translation>
+        <translation type="vanished">金额</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Date</source>
-        <translation>日期</translation>
+        <translation type="vanished">日期</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>确认数</translation>
+        <translation type="vanished">确认数</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>已确认</translation>
+        <translation type="vanished">已确认</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Label</source>
-        <translation>标签</translation>
+        <translation type="vanished">标签</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation>地址</translation>
+        <translation type="vanished">地址</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>复制地址</translation>
     </message>
@@ -1245,17 +1408,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>复制金额</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>复制转账ID</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>复制数量</translation>
     </message>
@@ -1285,17 +1448,17 @@ Expires: %3
         <translation>复制零钱</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>是</translation>
     </message>
@@ -1344,20 +1507,65 @@ Expires: %3
 这意味着要求至少%2的费用。</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(无标签)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>来自%1的零钱 (%2)</translation>
+        <translation type="vanished">来自%1的零钱 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(零钱)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">来自%1的零钱 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(零钱)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">金额</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(零钱)</translation>
+        <source>Label</source>
+        <translation type="unfinished">标签</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">地址</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">日期</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">确认数</translation>
     </message>
 </context>
 <context>
@@ -1383,7 +1591,7 @@ Expires: %3
         <translation type="unfinished">地址</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1445,7 +1653,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1480,37 +1688,31 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">金额</translation>
+        <translation type="obsolete">金额</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Label</source>
-        <translation type="unfinished">标签</translation>
+        <translation type="obsolete">标签</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">地址</translation>
+        <translation type="obsolete">地址</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">日期</translation>
+        <translation type="obsolete">日期</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">确认数</translation>
+        <translation type="obsolete">确认数</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">已确认</translation>
+        <translation type="obsolete">已确认</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1545,7 +1747,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1555,25 +1757,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">来自%1的零钱 (%2)</translation>
+        <translation type="obsolete">来自%1的零钱 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(零钱)</translation>
+        <translation type="obsolete">(零钱)</translation>
     </message>
 </context>
 <context>
@@ -1723,7 +1922,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1748,7 +1952,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1924,7 +2128,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1939,6 +2143,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1947,7 +2156,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation>版本</translation>
     </message>
@@ -1975,7 +2184,16 @@ Expires: %3
         <translation type="unfinished">格雷德币</translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2044,22 +2262,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2123,7 +2341,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2242,6 +2460,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">清除所有(&amp;A)</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">否</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">钱包解锁动作取消。</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2557,7 +3136,7 @@ Expires: %3
         <translation>取消(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>默认</translation>
     </message>
@@ -2572,7 +3151,7 @@ Expires: %3
         <translation>轻</translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
@@ -2800,18 +3379,23 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">复制金额</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2822,9 +3406,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">状态</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">金额</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2938,7 +3732,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2978,6 +3772,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3013,7 +3812,7 @@ Expires: %3
         <translation type="unfinished">表单</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3023,7 +3822,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3036,7 +3845,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,6 +3898,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">否</translation>
     </message>
 </context>
 <context>
@@ -3173,12 +4059,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3203,12 +4094,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,7 +4186,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3333,7 +4224,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">不可用</translation>
     </message>
@@ -3437,14 +4328,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3454,7 +4379,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3469,12 +4394,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3484,7 +4432,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3546,6 +4494,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3641,7 +4594,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>不可用</translation>
     </message>
@@ -3712,7 +4665,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3960,7 +4913,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation>欢迎来到格雷德币RPC控制台！</translation>
     </message>
@@ -3975,7 +4928,7 @@ Expires: %3
         <translation>使用 &lt;b&gt;help&lt;/b&gt; 命令显示帮助信息。</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4033,12 +4986,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4130,40 +5077,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4621,7 +5565,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4742,7 +5686,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4856,7 +5800,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4879,7 +5823,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4891,7 +5835,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5015,7 +5959,7 @@ Expires: %3
         <translation>输入一个格雷德币地址(例如S67nL4vELWwdDVzjgtEP4MxryarTZ9a8GB)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation type="unfinished">复制数量</translation>
     </message>
@@ -5075,7 +6019,7 @@ Expires: %3
         <translation> 和 </translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>接收者地址不合法，请检查。</translation>
     </message>
@@ -5115,8 +6059,8 @@ Expires: %3
         <translation>错误: 交易被拒绝. 如果您使用的是备份钱包，可能存在两个钱包不同步的情况，另一个钱包中的比特币已经被使用，但本地的这个钱包尚没有记录。</translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(无标签)</translation>
     </message>
@@ -5223,7 +6167,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">地址</translation>
     </message>
@@ -5361,42 +6305,42 @@ Expires: %3
         <translation>输入格雷德币签名</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>输入的地址非法</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>请检查地址后重试。</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>输入的地址没有关联的公私钥对。</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>钱包解锁动作取消。</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>找不到输入地址关联的私钥。</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>消息签名失败。</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>消息已签名。</translation>
     </message>
@@ -5407,7 +6351,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>请检查签名后重试。</translation>
     </message>
@@ -5458,39 +6402,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>至 %1 个数据块时开启</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation>冲突</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1 / 离线</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1 / 未确认</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 个确认</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
@@ -5512,74 +6456,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>源</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>来自</translation>
     </message>
@@ -5590,13 +6534,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>到</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>自己的地址</translation>
@@ -5607,16 +6551,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>标签</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>收入</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5628,31 +6572,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>未被接受</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>支出</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>交易费</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>净额</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>消息</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>备注</translation>
     </message>
@@ -5662,38 +6606,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>生成的格雷德币必须经过 110 个区块的成熟期后才可以使用。区块被生成后，它将被广播到网络中以加入区块链。如果它未能进入区块链，其状态将变为“未被接受”并且不可使用。有些时候，可能会有另一个节点比你早几秒钟成功生成一个区块，此时就可能发生这种情况。</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>金额</translation>
     </message>
@@ -5725,11 +6669,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation>关闭(&amp;l)</translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
@@ -5749,7 +6698,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>金额</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5776,12 +6725,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>确认中 (推荐 %2个确认，已经有 %1个确认)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>已确认 (%1 条确认信息)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>冲突的</translation>
     </message>
@@ -6006,7 +6955,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>交易状态。 鼠标移到此区域可显示确认项数量。</translation>
     </message>
@@ -6034,7 +7018,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6089,7 +7073,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>最小金额</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>复制地址</translation>
     </message>
@@ -6119,7 +7108,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>编辑标签</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation>导出交易历史</translation>
     </message>
@@ -6130,7 +7119,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>已确认</translation>
     </message>
@@ -6175,7 +7164,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>无法写入文件 %1 .</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>范围：</translation>
     </message>
@@ -6211,19 +7200,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">退出(&amp;X)</translation>
+        <translation type="obsolete">退出(&amp;X)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">退出程序</translation>
+        <translation type="obsolete">退出程序</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">文件(&amp;F)</translation>
+        <translation type="obsolete">文件(&amp;F)</translation>
     </message>
 </context>
 <context>
@@ -6237,7 +7223,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6263,18 +7249,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6351,15 +7337,14 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
         <source>Sending...</source>
-        <translation>正在发送...</translation>
+        <translation type="vanished">正在发送...</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+33"/>
+        <location filename="../bitcoinstrings.cpp" line="+40"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>当设置RPC端口%u以进行IPv6监听时出错，回到IPv4: %s</translation>
     </message>
@@ -6369,35 +7354,35 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>设置RPC端口%u以监听IPv4:%s时出现错误</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+461"/>
         <source>Usage:</source>
         <translation>使用：</translation>
     </message>
     <message>
-        <location line="-109"/>
+        <location line="-90"/>
         <source>List commands</source>
         <translation>命令列表
 </translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-26"/>
         <source>Get help for a command</source>
         <translation>得到关于某个命令的帮助
 </translation>
     </message>
     <message>
-        <location line="-339"/>
-        <location line="+344"/>
+        <location line="-371"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation>格雷德币</translation>
     </message>
     <message>
-        <location line="-172"/>
+        <location line="-164"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>警告：-paytxfee 被设置得非常高！若您发送一个转账，这是您将支付的转账费。</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+19"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>警告：wallet.dat损坏，数据已抢救! 原始的wallet.dat文件已在%s中保存为wallet.{timestamp}.bak.若您的余额或转账记录有误，您应该从备份中恢复。</translation>
     </message>
@@ -6407,7 +7392,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>警告： 读取wallet.dat时出现错误！所有密钥均已正确解读，但转账数据或地址簿条目可能缺失或不正确。</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+128"/>
         <source>Error: Transaction creation failed  </source>
         <translation>错误：交易创建失败 </translation>
     </message>
@@ -6417,17 +7402,17 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>交易被拒绝。您钱包中的钱币可能已经被花费，例如当您使用wallet.dat文件的副本，钱币在该副本中被花费但未在这里标记为已花费时。</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+271"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>监听任意端口失败。 若您希望如此，使用 -listen=0.</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+112"/>
         <source>To use the %s option</source>
         <translation>使用 %s 选项</translation>
     </message>
     <message>
-        <location line="-463"/>
+        <location line="-474"/>
         <source>%s, you must set a rpcpassword in the configuration file:
  %s
 It is recommended you use the following random password:
@@ -6462,12 +7447,12 @@ rpcpassword=%s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+19"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running and using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6487,21 +7472,7 @@ rpcpassword=%s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="+43"/>
         <source>Error: Clock skew is 5 minutes or greater. Please check your clock settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6527,11 +7498,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6551,7 +7517,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+10"/>
         <source>Please check your network and also check the config file and ensure your addnode entries are up-to-date. If you recently started the wallet, you may want to wait another few minutes for connections to build up and test again. Please see https://gridcoin.us/wiki/config-file.html and https://addnodes.cycy.me/.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6591,7 +7557,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6627,11 +7593,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+5"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6671,12 +7632,7 @@ Gridcoin detected bad index entries. This may occur because of a late software u
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
+        <location line="+12"/>
         <source>You have no balance and will be unable to retrieve your research rewards when solo crunching by staking. You can use MRC to retrieve your rewards, or you should acquire GRC to stake so you can retrieve your research rewards. Please see https://gridcoin.us/guides/boinc-install.htm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6752,7 +7708,7 @@ rpcpassword=&lt;password&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6764,11 +7720,6 @@ rpcpassword=&lt;password&gt;
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6839,16 +7790,6 @@ rpcpassword=&lt;password&gt;
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6962,11 +7903,6 @@ rpcpassword=&lt;password&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -6989,16 +7925,6 @@ rpcpassword=&lt;password&gt;
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7077,7 +8003,7 @@ rpcpassword=&lt;password&gt;
         <translation>初始化完整性检查失败。格雷德币正在停止运行。</translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Wallet %s resides outside data directory %s.</source>
         <translation>钱包%s位于数据目录%s之外。</translation>
     </message>
@@ -7087,12 +8013,85 @@ rpcpassword=&lt;password&gt;
         <translation>检查数据库完整性...</translation>
     </message>
     <message>
-        <location line="-428"/>
+        <location line="-473"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>初始化数据库环境 %s 时出错！为恢复，备份该目录，然后删除除wallet.dat之外的全部文件</translation>
     </message>
     <message>
-        <location line="+433"/>
+        <location line="+38"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+147"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+180"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Warning: 45 days &lt; ETTS = %1 &lt;= 90 days</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7183,6 +8182,16 @@ rpcpassword=&lt;password&gt;
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7217,7 +8226,7 @@ rpcpassword=&lt;password&gt;
         <translation>wallet.dat损坏，抢救失败</translation>
     </message>
     <message>
-        <location line="-152"/>
+        <location line="-134"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>无效的代理地址: &apos;%s&apos;</translation>
     </message>
@@ -7227,7 +8236,7 @@ rpcpassword=&lt;password&gt;
         <translation>无效的 -tor 地址: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-62"/>
+        <location line="-59"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>无法解析 -bind 端口地址: &apos;%s&apos;</translation>
     </message>
@@ -7237,12 +8246,12 @@ rpcpassword=&lt;password&gt;
         <translation>无法解析 -externalip 地址: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+62"/>
         <source>Invalid amount for -reservebalance=&lt;amount&gt;</source>
         <translation>对-reservebalance=&lt;amount&gt; 无效的金额</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-42"/>
         <source>Error loading blkindex.dat</source>
         <translation>blkindex.dat文件加载错误</translation>
     </message>
@@ -7257,7 +8266,7 @@ rpcpassword=&lt;password&gt;
         <translation>wallet.dat钱包文件加载错误：请升级到最新格雷德币客户端</translation>
     </message>
     <message>
-        <location line="+41"/>
+        <location line="+38"/>
         <source>Invalid amount for -peertimeout=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7269,16 +8278,6 @@ rpcpassword=&lt;password&gt;
     <message>
         <location line="+1"/>
         <source>Is Superblock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7304,11 +8303,6 @@ rpcpassword=&lt;password&gt;
     <message>
         <location line="+2"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7352,18 +8346,12 @@ rpcpassword=&lt;password&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">不可用</translation>
+        <translation type="obsolete">不可用</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7384,6 +8372,11 @@ rpcpassword=&lt;password&gt;
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7607,78 +8600,8 @@ rpcpassword=&lt;password&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7733,16 +8656,6 @@ rpcpassword=&lt;password&gt;
     </message>
     <message>
         <location line="+1"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7792,7 +8705,7 @@ rpcpassword=&lt;password&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Wallet locked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7802,37 +8715,37 @@ rpcpassword=&lt;password&gt;
         <translation>钱包文件需要重写：请退出并重新启动格雷德币客户端</translation>
     </message>
     <message>
-        <location line="-165"/>
+        <location line="-142"/>
         <source>Error loading wallet.dat</source>
         <translation>wallet.dat钱包文件加载错误</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+27"/>
         <source>Importing bootstrap blockchain data file.</source>
         <translation>导入引导程序区块链数据文件。</translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
         <source>Loading addresses...</source>
         <translation>正在加载地址...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-38"/>
         <source>Error: could not start node</source>
         <translation>错误: 无法启动节点</translation>
     </message>
     <message>
-        <location line="-175"/>
+        <location line="-166"/>
         <source>Unable to bind to %s on this computer. Gridcoin is probably already running.</source>
         <translation>无法在本机绑定 %s 端口。比特币客户端软件可能已经在运行。</translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+283"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>无法绑定本机端口 %s  (返回错误消息 %d, %s)</translation>
     </message>
     <message>
-        <location line="-144"/>
+        <location line="-120"/>
         <source>Error: Wallet locked, unable to create transaction  </source>
         <translation>错误：钱包已锁定，不能创建交易</translation>
     </message>
@@ -7847,37 +8760,36 @@ rpcpassword=&lt;password&gt;
         <translation>错误：转账需要至少 %s 的转账费，因为其数额，复杂度或使用了近期收到的存款  </translation>
     </message>
     <message>
-        <location line="+370"/>
         <source>Sending...</source>
-        <translation>发送中...</translation>
+        <translation type="vanished">发送中...</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="+292"/>
         <source>Invalid amount</source>
         <translation>无效金额</translation>
     </message>
     <message>
-        <location line="-174"/>
+        <location line="-169"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation>警告：请确定您当前计算机的日期和时间是正确的！格雷德币将无法在错误的时间下正常工作。</translation>
     </message>
     <message>
-        <location line="+300"/>
+        <location line="+275"/>
         <source>Warning: Disk space is low!</source>
         <translation>警告：磁盘剩余空间低!</translation>
     </message>
     <message>
-        <location line="-18"/>
+        <location line="-19"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>被指定的是未知网络 -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>存款不足</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+16"/>
         <source>Loading block index...</source>
         <translation>加载区块索引...</translation>
     </message>
@@ -7887,17 +8799,17 @@ rpcpassword=&lt;password&gt;
         <translation>正在加载钱包...</translation>
     </message>
     <message>
-        <location line="-77"/>
+        <location line="-72"/>
         <source>Cannot write default address</source>
         <translation>无法写入缺省地址</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+128"/>
         <source>Rescanning...</source>
         <translation>正在重新扫描...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>加载完成</translation>
     </message>

--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -14,7 +14,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+77"/>
         <source>
 This is experimental software.
 
@@ -29,7 +29,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="+37"/>
+        <location filename="../aboutdialog.cpp" line="+59"/>
         <source>Version information and update check has been disabled by config or startup parameter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,11 +38,51 @@ This product includes software developed by the OpenSSL Project for use in the O
         <source>Version information is not available on testnet.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+20"/>
+        <source>unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&lt;b&gt;Multiprocess connection&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>GUI version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node built: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>IPC schema %1, protocol %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Node identity: %1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Socket: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AdditionalFieldsTableDataModel</name>
     <message>
-        <location filename="../voting/additionalfieldstablemodel.cpp" line="+23"/>
+        <location filename="../voting/additionalfieldstablemodel.cpp" line="+21"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,6 +95,41 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+1"/>
         <source>Required</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+56"/>
+        <source>Field &quot;%1&quot;, value &quot;%2&quot;, %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Value: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Required: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">否</translation>
     </message>
 </context>
 <context>
@@ -140,7 +215,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>刪掉</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+75"/>
+        <location filename="../addressbookpage.cpp" line="+65"/>
+        <source>Sending addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Receiving addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Copy &amp;Label</source>
         <translation>複製標記</translation>
     </message>
@@ -150,7 +235,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>編輯</translation>
     </message>
     <message>
-        <location line="+267"/>
+        <location line="+273"/>
         <source>Export Address Book Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+149"/>
+        <location filename="../addresstablemodel.cpp" line="+141"/>
         <source>Label</source>
         <translation>標記</translation>
     </message>
@@ -185,8 +270,19 @@ This product includes software developed by the OpenSSL Project for use in the O
     </message>
     <message>
         <location line="+38"/>
+        <location line="+20"/>
         <source>(no label)</source>
         <translation>(無標記)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Label &quot;%1&quot;, address %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -222,7 +318,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+41"/>
+        <location filename="../askpassphrasedialog.cpp" line="+38"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>輸入錢包的新密碼。&lt;br/&gt;密碼請用&lt;b&gt;10 個以上的隨機字元&lt;/b&gt;，或是&lt;b&gt;8 個以上的字詞&lt;/b&gt;。</translation>
     </message>
@@ -252,7 +348,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+53"/>
         <source>Confirm wallet encryption</source>
         <translation>確認錢包加密</translation>
     </message>
@@ -267,58 +363,82 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+54"/>
+        <location line="+12"/>
+        <source>IMPORTANT: Any earlier backups of your wallet file are not just useless once you use the new encrypted wallet; they are a security risk. They still contain your UNENCRYPTED private keys, so anyone who obtains one can take your coins even after the live wallet is encrypted. This includes the automatic backups Gridcoin writes to the wallet backups directory (&quot;walletbackups&quot; by default, or the directory set by -backupdir). After making a fresh backup of the new encrypted wallet, securely delete every backup taken before encryption, including those in that directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+79"/>
         <source>Wallet encrypted</source>
         <translation>錢包已加密</translation>
     </message>
     <message>
-        <location line="-52"/>
+        <location line="-77"/>
         <source>Gridcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your coins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+15"/>
+        <source>Wallet encrypted - restart the core to finish</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your wallet is now fully encrypted and has been locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You are running in multiprocess mode, so the wallet lives in the separate Gridcoin core process, which is still running. To finish the encryption cleanly, restart the core process now (the running &lt;code&gt;gridcoinresearchd&lt;/code&gt;). The encryption on disk is already complete; the restart is only so the core drops the pre-encryption database state it still holds in memory and reloads the encrypted wallet fresh.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Note: closing this window will not restart the core. Only stopping and starting the core process does that; stopping it will also close this window, so reopen the wallet once the core is back up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>重要: 請改用新產生有加密的錢包檔，來取代舊錢包檔的備份。為了安全性的理由，當你開始使用新的有加密的錢包後，舊錢包檔的備份就不能再使用了。</translation>
+        <translation type="vanished">重要: 請改用新產生有加密的錢包檔，來取代舊錢包檔的備份。為了安全性的理由，當你開始使用新的有加密的錢包後，舊錢包檔的備份就不能再使用了。</translation>
     </message>
     <message>
         <location line="+8"/>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation>錢包加密失敗</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-63"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>因為內部錯誤導致錢包加密失敗。你的錢包還是沒加密。</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location line="+57"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation>提供的密碼不一樣。</translation>
     </message>
     <message>
-        <location line="-46"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>Wallet unlock failed</source>
         <translation>錢包解鎖失敗</translation>
     </message>
     <message>
         <location line="-2"/>
-        <location line="+31"/>
+        <location line="+30"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>輸入要用來解密錢包的密碼不對。</translation>
     </message>
     <message>
-        <location line="-28"/>
+        <location line="-27"/>
         <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 5.4.6, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+19"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>錢包密碼改成功了。</translation>
     </message>
@@ -343,7 +463,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+88"/>
+        <location filename="../bantablemodel.cpp" line="+83"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -356,7 +476,7 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+170"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Wallet</source>
         <translation>錢包</translation>
     </message>
@@ -366,7 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
+        <location line="+68"/>
+        <source>Dismiss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+108"/>
         <source>&amp;Overview</source>
         <translation>總覽</translation>
     </message>
@@ -502,7 +627,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+35"/>
         <source>E&amp;xit</source>
         <translation>結束</translation>
     </message>
@@ -627,6 +752,11 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>驗證訊息...</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>&amp;Multisign (PSGT)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
@@ -647,17 +777,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>開啓除錯和診斷主控台</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&amp;Snapshot Download</source>
+        <location line="+1002"/>
+        <source>Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Download and apply latest snapshot</source>
+        <source>This is not available in multiprocess mode. The blockchain data belongs to the separate Gridcoin core process, which keeps running when this window closes. Stop the core and reset its data directly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-1000"/>
         <source>&amp;Reset blockchain data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,12 +807,32 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+17"/>
+        <source>PSGT &amp;pool...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig transactions awaiting signatures (PSGT pool)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
         <source>&amp;File</source>
         <translation>檔案</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+11"/>
+        <source>Sign &amp;message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>MultiSig &amp;Txns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>&amp;Settings</source>
         <translation>設定</translation>
     </message>
@@ -717,19 +867,34 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+11"/>
+        <source>The GUI (%1) and the Gridcoin daemon (%2) were built from different commits. Mixed builds can behave unexpectedly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>&amp;Reset blockchain data (not available in multiprocess mode)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The blockchain data belongs to the separate Gridcoin core process. Stop the core and reset it there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
         <location line="+7"/>
         <source>[testnet]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
-        <location line="+142"/>
+        <location line="+225"/>
         <source>Gridcoin client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+146"/>
         <source>No active connections to the Gridcoin network. If this persists more than a few minutes, please check your configuration and your network connectivity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -796,17 +961,17 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
+        <location filename="../sendcoinsdialog.cpp" line="+232"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>Confirm transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location filename="../bitcoingui.cpp" line="+161"/>
         <source>Sent transaction</source>
         <translation>付款交易</translation>
     </message>
@@ -824,17 +989,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <source>Do you wish to download and apply the latest snapshot? If yes the wallet will shutdown and perform the task.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Warning: Canceling after stage 2 will result in sync from 0 or corrupted blockchain files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+28"/>
         <source>Do you want to delete blockchain data and sync from zero?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -854,7 +1009,7 @@ Address: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+146"/>
         <location line="+25"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
@@ -872,7 +1027,17 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+62"/>
+        <source>Multisig signature requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A multisig transaction is waiting for your signature. Open the PSGT pool to review and sign it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
         <location line="+15"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
@@ -889,7 +1054,7 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+22"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently %1 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -904,12 +1069,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>錢包&lt;b&gt;已加密&lt;/b&gt;並且&lt;b&gt;上鎖中&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+58"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -920,18 +1085,17 @@ Are you sure you want to proceed?</source>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Backup Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
-        <location line="+6"/>
+        <location line="-7"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="+4"/>
         <source>Backup Config</source>
         <translation type="unfinished"></translation>
     </message>
@@ -941,7 +1105,12 @@ Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
+        <location line="+3"/>
+        <source>There was an error trying to save the config file to the new location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1028,7 +1197,7 @@ Scraper(s) not publishing: %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+27"/>
         <source>CPID: %1
 Time left to activate: %2
 %3</source>
@@ -1077,7 +1246,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+244"/>
+        <location filename="../bitcoin.cpp" line="+323"/>
         <source>A fatal error occurred. Gridcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1085,12 +1254,12 @@ Expires: %3
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+166"/>
+        <location filename="../clientmodel.cpp" line="+167"/>
         <source>Network Alert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+64"/>
         <source>Low difficulty!; </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1149,7 +1318,7 @@ Expires: %3
     </message>
     <message>
         <location line="+3"/>
-        <location filename="../coincontroldialog.cpp" line="+224"/>
+        <location filename="../coincontroldialog.cpp" line="+277"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1204,37 +1373,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation>金額</translation>
+        <translation type="vanished">金額</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">位址</translation>
+        <translation type="obsolete">位址</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation>日期</translation>
+        <translation type="vanished">日期</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation>確認次數</translation>
+        <translation type="vanished">確認次數</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation>已確認</translation>
+        <translation type="vanished">已確認</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="-177"/>
+        <location filename="../coincontroldialog.cpp" line="-222"/>
         <source>Copy address</source>
         <translation>複製位址</translation>
     </message>
@@ -1245,17 +1404,17 @@ Expires: %3
     </message>
     <message>
         <location line="+1"/>
-        <location line="+26"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation>複製金額</translation>
     </message>
     <message>
-        <location line="-25"/>
+        <location line="-18"/>
         <source>Copy transaction ID</source>
         <translation>複製交易識別碼</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+17"/>
         <source>Copy quantity</source>
         <translation>複製數目</translation>
     </message>
@@ -1285,17 +1444,17 @@ Expires: %3
         <translation>複製找零金額</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Flips the filter mode between selecting inputs less than or equal to the provided value (&lt;=) and greater than or equal to the provided value (&gt;=). The filter also automatically limits the number of inputs to %1, in ascending order for &lt;= and descending order for &gt;=.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+138"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
+        <location line="+314"/>
         <source>yes</source>
         <translation>是</translation>
     </message>
@@ -1335,20 +1494,65 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+57"/>
+        <location line="-235"/>
         <source>(no label)</source>
         <translation>(無標記)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation>找零前是 %1 (%2)</translation>
+        <translation type="vanished">找零前是 %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="vanished">(找零)</translation>
+    </message>
+</context>
+<context>
+    <name>CoinSelectionModel</name>
+    <message>
+        <location filename="../coinselectionmodel.cpp" line="+357"/>
+        <location line="+24"/>
+        <location line="+10"/>
+        <location line="+566"/>
+        <location line="+5"/>
+        <source>(no label)</source>
+        <translation type="unfinished">(無標記)</translation>
+    </message>
+    <message>
+        <location line="-582"/>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">找零前是 %1 (%2)</translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+572"/>
+        <source>(change)</source>
+        <translation type="unfinished">(找零)</translation>
+    </message>
+    <message>
+        <location line="-524"/>
+        <source>Amount</source>
+        <translation type="unfinished">金額</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>(change)</source>
-        <translation>(找零)</translation>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address</source>
+        <translation type="unfinished">位址</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Date</source>
+        <translation type="unfinished">日期</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Confirmations</source>
+        <translation type="unfinished">確認次數</translation>
     </message>
 </context>
 <context>
@@ -1374,7 +1578,7 @@ Expires: %3
         <translation type="unfinished">位址</translation>
     </message>
     <message>
-        <location filename="../consolidateunspentdialog.cpp" line="+27"/>
+        <location filename="../consolidateunspentdialog.cpp" line="+28"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,7 +1640,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+141"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="+161"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1471,37 +1675,27 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Amount</source>
-        <translation type="unfinished">金額</translation>
+        <translation type="obsolete">金額</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Address</source>
-        <translation type="unfinished">位址</translation>
+        <translation type="obsolete">位址</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
-        <translation type="unfinished">日期</translation>
+        <translation type="obsolete">日期</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished">確認次數</translation>
+        <translation type="obsolete">確認次數</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
-        <translation type="unfinished">已確認</translation>
+        <translation type="obsolete">已確認</translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+82"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1536,7 +1730,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-71"/>
+        <location filename="../consolidateunspentwizardselectinputspage.cpp" line="-86"/>
         <source>Note: The number of inputs selected for consolidation has been limited to %1 to prevent a transaction failure due to too many inputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,25 +1740,22 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+87"/>
         <source>Select None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+57"/>
+        <location line="+127"/>
         <source>(no label)</source>
         <translation type="unfinished">(無標記)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">找零前是 %1 (%2)</translation>
+        <translation type="obsolete">找零前是 %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished">(找零)</translation>
+        <translation type="obsolete">(找零)</translation>
     </message>
 </context>
 <context>
@@ -1714,7 +1905,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../diagnosticsdialog.cpp" line="+80"/>
+        <location filename="../diagnosticsdialog.cpp" line="+99"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Testing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1739,7 +1935,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+132"/>
         <source>One or more tests have generated a warning status. Wallet operation may be degraded. Please see the individual test tooltips for details and recommended action(s).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1915,7 +2111,7 @@ Expires: %3
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+73"/>
+        <location filename="../intro.cpp" line="+74"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,6 +2126,11 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+12"/>
+        <source>This location is on a temporary filesystem. Anything stored here, including the wallet, is lost when the program exits.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"></translation>
@@ -1938,7 +2139,7 @@ Expires: %3
 <context>
     <name>GUIUtil::HelpMessageBox</name>
     <message>
-        <location filename="../guiutil.cpp" line="+705"/>
+        <location filename="../guiutil.cpp" line="+748"/>
         <source>version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1966,7 +2167,16 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+122"/>
+        <source>Error: The data directory &quot;%1&quot; could not be created and secured.
+
+%2
+
+Please choose a different location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2035,22 +2245,22 @@ Expires: %3
 <context>
     <name>MRCModel</name>
     <message>
-        <location filename="../mrcmodel.cpp" line="+273"/>
+        <location filename="../mrcmodel.cpp" line="+292"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+37"/>
         <source>Too soon to submit an MRC request. At least 14 days must elapse from your original beacon advertisement or last research reward payment, whether by stake or MRC, whichever is later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+8"/>
         <source>The total fee (the minimum fee + fee boost) is greater than the rewards due.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+29"/>
         <source>Your MRC was successfully submitted earlier but has now become stale without being bound to the just received block by a staker. This may be because your MRC was submitted just before the block was staked and the MRC didn&apos;t make it to the staker in time, or your MRC was pushed down in the queue past the pay limit. Please wait for the next block to clear the queue and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,7 +2324,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../mrcrequestpage.cpp" line="+205"/>
+        <location filename="../mrcrequestpage.cpp" line="+203"/>
         <location line="+27"/>
         <location line="+20"/>
         <source>Your Projected MRC Request Position in Queue</source>
@@ -2233,6 +2443,367 @@ Expires: %3
     <message>
         <location line="+6"/>
         <source>You must have a mature balance of at least 1 GRC to submit an MRC.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultisignPSGTDialog</name>
+    <message>
+        <location filename="../forms/multisigndialog.ui" line="+14"/>
+        <source>Multisign (PSGT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>PSGT (base64):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Paste a base64 PSGT (e.g. from createpsgt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Decode the PSGT and show its inputs, outputs and signing status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Sign every input this wallet has keys for, then update the working PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Sign with wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Relay this PSGT to co-signers through the network PSGT pool (requires v15 and at least one of your signatures)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Submit to &amp;pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>If fully signed, extract the completed raw transaction (hex) for broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Finalize → hex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Clear all fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">全部清掉</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Decoded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Click &quot;Inspect&quot; to decode the PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Out-of-band: co-signers&apos; PSGTs to combine (one base64 PSGT per line):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Out-of-band combine: paste one or more co-signers&apos; PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>One base64 PSGT per line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Merge the co-signers&apos; PSGTs into the working PSGT (out-of-band)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Combine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Result (signed PSGT base64, or finalized transaction hex):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Copy the result to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cop&amp;y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../multisigndialog.cpp" line="+60"/>
+        <source>Transaction id: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Version: %1   Time: %2   Locktime: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs: %1   Outputs: %2
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Inputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <location line="+8"/>
+        <source>(prev tx not loaded)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>(prev tx mismatch)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>finalized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n partial sig(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>unsigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>no metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>        multisig %1-of-%2   image P2SH:%3 (hash %4)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>        image P2SH:%1 (hash %2)
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>
+Outputs:
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>(non-standard)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>
+Signed inputs: %1/%2   Complete: %3
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <location line="-159"/>
+        <location line="+107"/>
+        <location line="+52"/>
+        <source>no</source>
+        <translation type="unfinished">否</translation>
+    </message>
+    <message>
+        <location line="-114"/>
+        <source>PSGT support is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Paste a base64 PSGT first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <location line="+9"/>
+        <location line="+180"/>
+        <location line="+45"/>
+        <source>Could not decode PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-234"/>
+        <location line="+134"/>
+        <source>invalid base64</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-88"/>
+        <source>This wallet&apos;s signature present: %1
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Decoded %1 input(s), %2 output(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">錢包解鎖已取消。</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Signed %1 input(s) with this wallet. Complete: %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) still need a previous transaction or redeem script before they can be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+5"/>
+        <source>%n input(s) the wallet holds keys for could not be signed.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+18"/>
+        <source>Could not decode a co-signer PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-10"/>
+        <source>Add at least one co-signer PSGT to combine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>PSGTs do not refer to the same transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Combined %1 PSGT(s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The PSGT pool is unavailable: block v15 has not activated on this network, or this node is still syncing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Sign the PSGT with this wallet before submitting it to the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>The pool rejected this PSGT (%1): %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Submitted to the pool, superseding your earlier PSGT. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Submitted to the pool. Co-signers have been notified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The pool did not accept this PSGT: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>PSGT is not complete yet; cannot finalize.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2548,7 +3119,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+83"/>
+        <location filename="../optionsdialog.cpp" line="+82"/>
         <source>default</source>
         <translation>預設值</translation>
     </message>
@@ -2563,7 +3134,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+240"/>
+        <location line="+246"/>
         <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">錯誤</translation>
@@ -2791,18 +3362,23 @@ Expires: %3
         <translation>目前全部餘額</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+175"/>
+        <location filename="../overviewpage.cpp" line="+167"/>
+        <source>Recent transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <location line="+1"/>
         <source>Out of Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+19"/>
         <source>Copy amount</source>
         <translation type="unfinished">複製金額</translation>
     </message>
     <message>
-        <location line="+311"/>
+        <location line="+317"/>
         <source>Pool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2813,9 +3389,219 @@ Expires: %3
     </message>
 </context>
 <context>
+    <name>PSGTPoolPage</name>
+    <message>
+        <location filename="../psgtpoolpage.cpp" line="+27"/>
+        <source>PSGT Pool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Multisig transactions awaiting signatures.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>&amp;Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sign the selected PSGT with this wallet and, if it completes the multisig, broadcast the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove the selected PSGT from this node&apos;s pool (local only; other nodes keep their copies)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Details...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the selected PSGT in the Multisign dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Re&amp;fresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>The PSGT pool is not active yet: it activates with the block v15 network upgrade. Pending multisig transactions will appear here once it does.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The PSGT pool is unavailable while this node is syncing. Pending multisig transactions will appear here once the node has caught up with the network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+55"/>
+        <location line="+5"/>
+        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+5"/>
+        <location line="+4"/>
+        <source>Sign PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-24"/>
+        <source>The multisig is complete. The transaction was broadcast:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added and relayed to the other co-signers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your signature was added, but this exact revision is already known to the network (a co-signer may have signed it first). Nothing more to do.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>This wallet holds no key that can add a signature to this PSGT.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Signing failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>This PSGT is no longer in the pool (it may have completed or expired).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Remove PSGT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Remove this PSGT from your node&apos;s pool? Other nodes keep their copies, and a new revision from the network would be accepted again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>PSGT details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This PSGT is no longer in the pool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PSGTPoolTableModel</name>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="+139"/>
+        <source>Awaiting your signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Awaiting others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location line="+20"/>
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location line="+1"/>
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Status</source>
+        <translation type="unfinished">狀態</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount</source>
+        <translation type="unfinished">金額</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Signatures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Age</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Multisig address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+109"/>
+        <location filename="../peertablemodel.cpp" line="+99"/>
         <source>Node ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2929,7 +3715,7 @@ Expires: %3
     </message>
     <message>
         <location line="+20"/>
-        <location filename="../voting/pollcard.cpp" line="+125"/>
+        <location filename="../voting/pollcard.cpp" line="+132"/>
         <source>Voting finished.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2969,6 +3755,11 @@ Expires: %3
         <source>Top Answer:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../voting/polldetails.cpp" line="+29"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PollResultChoiceItem</name>
@@ -3004,7 +3795,7 @@ Expires: %3
         <translation type="unfinished">表單</translation>
     </message>
     <message>
-        <location filename="../voting/polltab.cpp" line="+25"/>
+        <location filename="../voting/polltab.cpp" line="+23"/>
         <source>Press &quot;Refresh&quot; to update the list.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3014,7 +3805,17 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
+        <location line="+149"/>
+        <source>Polls (card view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Polls (table view)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+110"/>
         <source>Show Results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3027,7 +3828,7 @@ Expires: %3
 <context>
     <name>PollTableDataModel</name>
     <message>
-        <location filename="../voting/polltablemodel.cpp" line="+24"/>
+        <location filename="../voting/polltablemodel.cpp" line="+23"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3080,6 +3881,83 @@ Expires: %3
         <location line="+1"/>
         <source>Stale Results</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+81"/>
+        <source>Poll &quot;%1&quot;, type %2, expires %3, top answer %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+5"/>
+        <source>(legacy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+21"/>
+        <source>none</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-19"/>
+        <source>Poll type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Duration: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Expires: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Weight type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total votes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Total weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Percent of active vote weight: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Validated: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Top answer: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Stale results: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>no</source>
+        <translation type="unfinished">否</translation>
     </message>
 </context>
 <context>
@@ -3164,12 +4042,17 @@ Expires: %3
     </message>
     <message>
         <location filename="../voting/pollwizarddetailspage.cpp" line="+175"/>
-        <location line="+168"/>
+        <location line="+164"/>
         <source>Create Poll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-149"/>
+        <location line="-146"/>
+        <source>Poll additional fields</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3194,12 +4077,12 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
+        <location line="+30"/>
         <source>Cannot have more than 20 choices in a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+110"/>
         <source>This poll will cost %1 plus a transaction fee. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3286,7 +4169,7 @@ Expires: %3
 <context>
     <name>ProjectTableModel</name>
     <message>
-        <location filename="../researcher/projecttablemodel.cpp" line="+131"/>
+        <location filename="../researcher/projecttablemodel.cpp" line="+129"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3324,7 +4207,7 @@ Expires: %3
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../guiutil.cpp" line="-657"/>
+        <location filename="../guiutil.cpp" line="-689"/>
         <source>N/A</source>
         <translation type="unfinished">未知</translation>
     </message>
@@ -3428,14 +4311,48 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+74"/>
+        <location filename="../bitcoin.cpp" line="+115"/>
+        <source>The wallet in this data directory appears to have changed since you last connected to the Gridcoin daemon from here (it may have been replaced or restored).
+
+Trust this wallet and remember it, or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Trust this wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+39"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-4"/>
+        <source>The Gridcoin daemon is no longer reporting a wallet identity, though this front end was bound to one for this data directory. Proceed this time (the existing binding is kept), or quit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Proceed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+315"/>
         <source>Error: Cannot parse command line arguments. Please check the arguments and ensure they are valid and formatted correctly: 
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
+        <location line="+136"/>
+        <location line="+44"/>
+        <source>Error: Cannot access the data directory. Check that it exists and that you have permission to read and write it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-33"/>
         <source>Error: Cannot read configuration file. Please check the path and format of the file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3445,7 +4362,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+33"/>
         <source>Error: Cannot obtain a lock on the specified data directory. An instance is probably already using that directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3460,12 +4377,35 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
+        <location line="+111"/>
+        <source>Could not connect to the Gridcoin daemon:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>This build was compiled without multiprocess (IPC) support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Lost connection to the Gridcoin daemon during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>An error occurred during startup:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+326"/>
         <source>%1 didn&apos;t yet exit safely...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researchermodel.cpp" line="+211"/>
+        <location filename="../researcher/researchermodel.cpp" line="+126"/>
         <source>Wallet Not In Sync</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +4415,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../transactionrecord.cpp" line="+376"/>
+        <location filename="../transactionview.cpp" line="+51"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,6 +4477,11 @@ Expires: %3
     <message>
         <location filename="../voting/pollcard.cpp" line="+8"/>
         <source>%1 remaining.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../psgtpooltablemodel.cpp" line="-133"/>
+        <source>(nonstandard)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3632,7 +4577,7 @@ Expires: %3
         <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+493"/>
+        <location filename="../rpcconsole.cpp" line="+595"/>
         <source>N/A</source>
         <translation>未知</translation>
     </message>
@@ -3763,7 +4708,7 @@ Expires: %3
     </message>
     <message>
         <location line="+69"/>
-        <location filename="../rpcconsole.cpp" line="+380"/>
+        <location filename="../rpcconsole.cpp" line="+374"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3951,7 +4896,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+62"/>
         <source>Welcome to the Gridcoin RPC console! </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3966,7 +4911,7 @@ Expires: %3
         <translation>請打 &lt;b&gt;help&lt;/b&gt; 來看可用指令的簡介。</translation>
     </message>
     <message>
-        <location line="+116"/>
+        <location line="+139"/>
         <source>%1 B</source>
         <translation>%1 B (位元組)</translation>
     </message>
@@ -4024,12 +4969,6 @@ Expires: %3
     <message>
         <location line="+0"/>
         <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+6"/>
-        <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4121,40 +5060,37 @@ Expires: %3
     </message>
     <message>
         <location line="+2"/>
-        <location line="+258"/>
+        <location line="+217"/>
         <source>Waiting for sync...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
-        <location line="+79"/>
+        <location line="+108"/>
         <source>Manually Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Automatically Greylisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
-        <location line="+79"/>
+        <location line="+3"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
+        <location line="+10"/>
         <source>Not whitelisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+6"/>
         <source>Uses external adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-3"/>
         <source>Not attached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,7 +5548,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+89"/>
+        <location filename="../researcher/researcherwizardpoolpage.cpp" line="+95"/>
         <source>Address Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4733,7 +5669,7 @@ Expires: %3
     </message>
     <message>
         <location line="+124"/>
-        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+145"/>
+        <location filename="../researcher/researcherwizardsummarypage.cpp" line="+144"/>
         <source>Everything looks good.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4847,7 +5783,7 @@ Expires: %3
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+195"/>
+        <location filename="../sendcoinsdialog.cpp" line="+15"/>
         <location line="+5"/>
         <location line="+5"/>
         <location line="+5"/>
@@ -4870,7 +5806,7 @@ Expires: %3
     </message>
     <message>
         <location line="+10"/>
-        <location filename="../sendcoinsdialog.cpp" line="+156"/>
+        <location filename="../sendcoinsdialog.cpp" line="+158"/>
         <location line="+11"/>
         <source>Available (%1)</source>
         <translation type="unfinished"></translation>
@@ -4882,7 +5818,7 @@ Expires: %3
     </message>
     <message>
         <location line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+241"/>
+        <location filename="../sendcoinsdialog.cpp" line="+248"/>
         <source>Inactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,7 +5942,7 @@ Expires: %3
         <translation>付款</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-582"/>
+        <location filename="../sendcoinsdialog.cpp" line="-650"/>
         <source>Copy quantity</source>
         <translation>複製數目</translation>
     </message>
@@ -5066,7 +6002,7 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+88"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5106,8 +6042,8 @@ Expires: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+291"/>
-        <location line="+49"/>
+        <location line="+293"/>
+        <location line="+56"/>
         <source>(no label)</source>
         <translation>(無標記)</translation>
     </message>
@@ -5214,7 +6150,7 @@ Expires: %3
 <context>
     <name>SideStakeTableModel</name>
     <message>
-        <location filename="../sidestaketablemodel.cpp" line="+116"/>
+        <location filename="../sidestaketablemodel.cpp" line="+123"/>
         <source>Address</source>
         <translation type="unfinished">位址</translation>
     </message>
@@ -5352,42 +6288,42 @@ Expires: %3
         <translation>請按一下「簽署訊息」來產生簽章</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+110"/>
-        <location line="+83"/>
+        <location filename="../signverifymessagedialog.cpp" line="+106"/>
+        <location line="+85"/>
         <source>The entered address is invalid.</source>
         <translation>輸入的位址無效。</translation>
     </message>
     <message>
-        <location line="-83"/>
+        <location line="-85"/>
         <location line="+8"/>
-        <location line="+75"/>
+        <location line="+77"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>請檢查位址是否正確後再試一次。</translation>
     </message>
     <message>
-        <location line="-83"/>
-        <location line="+83"/>
+        <location line="-85"/>
+        <location line="+85"/>
         <source>The entered address does not refer to a key.</source>
         <translation>輸入的位址沒有對應到你的任何密鑰。</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-77"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>錢包解鎖已取消。</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
         <source>Private key for the entered address is not available.</source>
         <translation>沒有對應輸入位址的密鑰。</translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+4"/>
         <source>Message signing failed.</source>
         <translation>訊息簽署失敗。</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Message signed.</source>
         <translation>訊息簽署好了。</translation>
     </message>
@@ -5398,7 +6334,7 @@ Expires: %3
     </message>
     <message>
         <location line="+0"/>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Please check the signature and try again.</source>
         <translation>請檢查簽章是否正確後再試一次。</translation>
     </message>
@@ -5449,39 +6385,39 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+36"/>
+        <location filename="../transactiondesc.cpp" line="+21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Open until %1</source>
         <translation>到 %1 前可修改</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+2"/>
         <source>conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1 次/離線中</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1 次/未確認</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>確認 %1 次</translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+35"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
@@ -5503,74 +6439,74 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+5"/>
+        <location line="+6"/>
+        <location line="+3"/>
         <source>Source</source>
         <translation>來源</translation>
     </message>
     <message>
-        <location line="-5"/>
+        <location line="-3"/>
         <source>Generated in CoinBase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-42"/>
         <source>Mined - PoS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - PoS+RR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Orphaned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>PoS+RR Side Stake Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>MRC Payment Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Superblock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>Mined - Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+18"/>
+        <location line="+38"/>
+        <location line="+5"/>
         <source>From</source>
         <translation>來源</translation>
     </message>
@@ -5581,13 +6517,13 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <location line="+25"/>
-        <location line="+63"/>
+        <location line="+17"/>
+        <location line="+32"/>
         <source>To</source>
         <translation>目的</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-45"/>
         <location line="+3"/>
         <source>own address</source>
         <translation>自己的位址</translation>
@@ -5598,16 +6534,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>標記</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+14"/>
+        <location line="+25"/>
+        <location line="+12"/>
+        <location line="+23"/>
+        <location line="+12"/>
         <location line="+50"/>
-        <location line="+20"/>
-        <location line="+63"/>
         <source>Credit</source>
         <translation>入帳</translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-94"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5619,31 +6555,31 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>不被接受</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+63"/>
+        <location line="+23"/>
+        <location line="+5"/>
+        <location line="+10"/>
+        <location line="+50"/>
         <source>Debit</source>
         <translation>出帳</translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-55"/>
         <source>Transaction fee</source>
         <translation>交易手續費</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+12"/>
         <source>Net amount</source>
         <translation>淨額</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+20"/>
+        <location line="+3"/>
+        <location line="+15"/>
         <source>Message</source>
         <translation>訊息</translation>
     </message>
     <message>
-        <location line="-17"/>
+        <location line="-12"/>
         <source>Comment</source>
         <translation>附註</translation>
     </message>
@@ -5653,38 +6589,38 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <location line="+3"/>
+        <location line="+2"/>
         <source>Block Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+12"/>
         <source>Transaction Stake Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-188"/>
         <source>Gridcoin generated coins must mature 110 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+203"/>
         <source>Transaction Debits/Credits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+8"/>
         <source>Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Transaction Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+10"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
@@ -5716,11 +6652,16 @@ Operations such as beacon management, voting, and sending transactions should no
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../transactiondescdialog.cpp" line="+15"/>
+        <source>Transaction details unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+263"/>
+        <location filename="../transactiontablemodel.cpp" line="+40"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
@@ -5740,7 +6681,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished">金額</translation>
     </message>
     <message numerus="yes">
-        <location line="+63"/>
+        <location line="+53"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -5767,12 +6708,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+23"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>已確認(%1 次)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Conflicted</source>
         <translation>有衝突</translation>
     </message>
@@ -5997,7 +6938,42 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+67"/>
+        <source>%1, %2 %3, amount %4, %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>confirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>unconfirmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Address: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Amount: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-454"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>交易狀態。把游標停在欄位上會顯示確認次數。</translation>
     </message>
@@ -6025,7 +7001,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+51"/>
+        <location filename="../transactionview.cpp" line="+26"/>
         <source>Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6080,7 +7056,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>最小金額</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+17"/>
+        <source>Transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>Copy address</source>
         <translation>複製位址</translation>
     </message>
@@ -6110,7 +7091,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>顯示交易明細</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+232"/>
         <source>Export Transaction Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6121,7 +7102,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Confirmed</source>
         <translation>已確認</translation>
     </message>
@@ -6166,7 +7147,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+126"/>
         <source>Range:</source>
         <translation>範圍:</translation>
     </message>
@@ -6202,19 +7183,16 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>UpgradeQt</name>
     <message>
-        <location filename="../upgradeqt.cpp" line="+70"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished">結束</translation>
+        <translation type="obsolete">結束</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
-        <translation type="unfinished">結束應用程式</translation>
+        <translation type="obsolete">結束應用程式</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;File</source>
-        <translation type="unfinished">檔案</translation>
+        <translation type="obsolete">檔案</translation>
     </message>
 </context>
 <context>
@@ -6228,7 +7206,7 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VoteWizardBallotPage</name>
     <message>
-        <location filename="../voting/votewizardballotpage.cpp" line="+37"/>
+        <location filename="../voting/votewizardballotpage.cpp" line="+38"/>
         <source>Submit Vote</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6254,18 +7232,18 @@ Operations such as beacon management, voting, and sending transactions should no
 <context>
     <name>VotingModel</name>
     <message>
-        <location filename="../voting/votingmodel.cpp" line="+489"/>
-        <location line="+40"/>
+        <location filename="../voting/votingmodel.cpp" line="+351"/>
+        <location line="+23"/>
         <source>Please unlock the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+12"/>
         <source>Poll not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+2"/>
         <source>Failed to load poll from disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6340,38 +7318,25 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
 </context>
 <context>
-    <name>WalletModel</name>
-    <message>
-        <location filename="../walletmodel.cpp" line="+338"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+343"/>
+        <location filename="../bitcoinstrings.cpp" line="+377"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>在任意的通訊埠聽候失敗。如果你希望這樣的話，可以設定 -listen=0.</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+23"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>無效的 -proxy 位址: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+11"/>
         <source>Loading addresses...</source>
         <translation>正在載入位址資料...</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Local version: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6415,18 +7380,12 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>N/A</source>
-        <translation type="unfinished">未知</translation>
+        <translation type="obsolete">未知</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>No UTXOs available due to reserve balance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>No address contains %s GRC in %s UTXOs or fewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6447,6 +7406,11 @@ Operations such as beacon management, voting, and sending transactions should no
     <message>
         <location line="+1"/>
         <source>No mature coins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No single address has the required %s GRC balance to create a poll.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6661,42 +7625,7 @@ Operations such as beacon management, voting, and sending transactions should no
     </message>
     <message>
         <location line="+1"/>
-        <source>Sending...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Single Choice</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Complete!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot Process Has Begun.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stage (1/4): Downloading snapshot.zip:         </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data:          </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip:          </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6750,7 +7679,7 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
         <source>This update is </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6780,18 +7709,18 @@ Operations such as beacon management, voting, and sending transactions should no
         <translation>在 -onlynet 指定了不明的網路別: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-117"/>
+        <location line="-96"/>
         <source>Insufficient funds</source>
         <translation>累積金額不足</translation>
     </message>
     <message>
-        <location line="-353"/>
-        <location line="+344"/>
+        <location line="-385"/>
+        <location line="+376"/>
         <source>Gridcoin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
+        <location line="-375"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6817,17 +7746,37 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+13"/>
+        <source>-rpcssl is no longer supported, and -rpcconnect=%s does not resolve to a loopback address. Sending RPC credentials to it would transmit them unencrypted. Remove -rpcssl to proceed deliberately, and tunnel the connection (for example over SSH) if it crosses an untrusted network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>A poll with a yes/no/abstain response type cannot include any additional custom choices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>An error occurred while setting up the RPC port %u for listening on %s: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Block file corruption detected and automatic recovery failed. Please restart with -reindex to rebuild the chain state.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Cannot access the data directory; check that it exists and that you have permission to read and write it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6851,21 +7800,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Gridcoin Alert&quot; admin@foo
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
-
-Gridcoin detected bad index entries. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+40"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6906,11 +7841,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+3"/>
-        <source>Failed to download snapshot as mandatory client is available for download.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Failed: 80 block difficulty is less than %1. This wallet is almost certainly forked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6927,6 +7857,16 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     <message>
         <location line="+3"/>
         <source>For polls about community representation, public relations, and communications.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Gridcoin detected a multi-superblock chain reorganization and is rebuilding the beacon registry to maintain consensus with the network. The wallet may be briefly unresponsive while the rebuild runs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>No single address can attest to %s GRC in %u or fewer UTXOs. Consider consolidating UTXOs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6971,6 +7911,11 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+6"/>
+        <source>The default data directory is on a temporary filesystem, so the block chain and wallet would be lost when the program exits. Pass -datadir with a location on persistent storage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>The network has experienced a low-level error and this probably means your IP address or other network connection parameters are not configured correctly. Please check your network configuration on your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7011,11 +7956,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to download a snapshot, as the wallet has detected that a new mandatory version is available for install. The mandatory upgrade must be installed before the snapshot can be downloaded and applied.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
         <source>Verify (1) that you have BOINC installed correctly, (2) that you have attached at least one whitelisted project, (3) that you advertised your beacon with the same email as you use for your BOINC project(s), and (4) that the CPID on the overview screen matches the CPID when you login to your BOINC project(s) online.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7061,11 +8001,6 @@ Gridcoin detected bad index entries. This may occur because of a late software u
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: Ending this process after Stage 2 will result in syncing from 0 or an incomplete/corrupted blockchain.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Gridcoin will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7153,6 +8088,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+5"/>
+        <source>-maxmempool must be between %d and %d MB.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>A poll choice cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7164,11 +8104,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Active</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Are you sure you want to cancel the snapshot operation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7239,16 +8174,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>CPID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel snapshot operation?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7412,11 +8337,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Failed to download snapshot.zip; See debug.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location line="+2"/>
         <source>Failed to rename bootstrap file to .old for backup purposes.</source>
         <translation type="unfinished"></translation>
@@ -7439,16 +8359,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>For opinion or casual polls without any particular requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>GB/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7568,16 +8478,6 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
-        <source>KB/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Latest Version GitHub data response:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>List commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7612,7 +8512,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation>正在載入錢包資料...</translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+57"/>
         <source>Reset Blockchain Data: Blockchain data removal failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7622,57 +8522,7 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Snapshot extraction failed! Cleaning up any extracted data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled due to an invalid snapshot zip.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation canceled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Snapshot operation successful!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (1/4): Downloading snapshot.zip: Speed </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Stage (2/4): Verify SHA256SUM of snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (3/4): Cleanup blockchain data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Stage (4/4): Extracting snapshot.zip</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>The wallet is now shutting down. Please restart your wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The wallet will now shutdown.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+20"/>
         <source>Unknown poll response type.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7719,6 +8569,11 @@ If the file does not exist, create it with owner-readable-only file permissions.
     <message>
         <location line="+1"/>
         <source>Wallet %s resides outside data directory %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet balance of %s in top %s UTXOs is less than required %s GRC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7828,6 +8683,16 @@ If the file does not exist, create it with owner-readable-only file permissions.
     </message>
     <message>
         <location line="+1"/>
+        <source>pool_approve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>pool_register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>project</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7862,17 +8727,45 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
+        <location line="-190"/>
         <source>Cannot write default address</source>
         <translation>沒辦法把預設位址寫進去</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="-284"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Block index integrity check failed: Blockchain data may be corrupted.
+
+Gridcoin detected a block index entry with a broken pprev linkage. This may occur because of a late software upgrade, unexpected exit, or a power failure that left the on-disk block index database in an inconsistent state. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Please run gridcoinresearchd with the -resetblockchaindata parameter. Your wallet will re-download the blockchain. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>ERROR: Checkpoint mismatch: Blockchain data may be corrupted.
+
+Gridcoin&apos;s compiled-in hardened checkpoint does not match the block at that height in your local block index. This may occur because of a late software upgrade, unexpected exit, or a power failure. Your blockchain data is being reset and your wallet will resync from genesis when you restart. Your balance may appear incorrect until the synchronization finishes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+383"/>
         <source>Rescanning...</source>
         <translation>正在重新掃描...</translation>
     </message>
     <message>
-        <location line="-124"/>
+        <location line="-117"/>
         <source>Done loading</source>
         <translation>載入完成</translation>
     </message>


### PR DESCRIPTION
Runs steps 1 and 2 of `contrib/devtools/update-translations.sh` against current `development`.
**No Transifex traffic** — nothing has been pushed to translators and nothing pulled. This is the
reviewable half, deliberately separated from the half that starts a string freeze.

## Why now

The catalogue was last regenerated on **2026-04-03** (`d819888fd`). Five months of GUI work has
landed since, and none of it has ever been offered to a translator.

```
Found 1626 source text(s) (209 new and 1417 already existing)
```

| | |
|---|---|
| New strings | **209** |
| PSGT multisig UI | 0 entries before → **47** now |
| Multiprocess | 0 → 5 |
| `_()` catalogue (`bitcoinstrings.cpp`) | 304 → 287 (11 added, 28 removed) |

The `_()` side **shrinks**, which is correct: the removals are the snapshot-download strings and
the `-rpcssl` options deleted in #3281.

The 24-word seed phrase contributes **no** strings, and that is right rather than a gap — it is
RPC-only and has no Qt GUI, so there is nothing there to translate. (Worth stating because its
absence from the catalogue looks like an omission until you check.)

## No translations were lost

Verified per language rather than assumed. Every one of the 62 catalogues has **at least as many**
translated strings after as before, and lupdate's same-text heuristic recovered **+547** across
the set:

| Language | translated before | translated after |
|---|---|---|
| ru | 1234 | 1234 |
| de | 812 | 817 |
| zh_CN | 467 | 479 |
| fr | 445 | 455 |
| es | 440 | 452 |

`.qm` binaries are **untouched** — `lrelease` is a later step and is not part of this PR.

## On the diff size

93k insertions / 39k deletions across 61 files looks alarming and is not. Regeneration rewrites
the `<location>` elements throughout every catalogue. The substance is the 209 new entries plus
reordering; no message text was altered by hand.

## Verification

- `update-translations.sh extract` and `... lupdate` both exit 0 (`lupdate6` 6.9.1).
- `src/qt/bitcoinstrings.cpp` is generated C++ and compiles: `g++ -fsyntax-only -std=c++17` clean.
- `lint-all.sh` exits 0 with `COMMIT_RANGE` set.
- Per-language translated-count comparison against `origin/development`, shown above.

## What this PR deliberately does not do

Pushing the source catalogue to Transifex (`tx push`) starts the translator cycle and requires a
**string freeze held from push until pull**. That is a scheduling decision and belongs with
whoever is coordinating the release, not in a mechanical regeneration commit.

Current coverage for context, against the *new* catalogue — the case for doing this early is that
translator time, not tooling, is the long pole:

| ru | de | zh_CN | fr | es |
|---|---|---|---|---|
| 74% | 49% | 29% | 27% | 27% |



---

### Correction (post-merge)

Three figures above were off. They came from a scratch probe I ran before using the script's own
entry points, and the probe passed slightly different environment variables to
`extract_strings_qt.py` than `update-translations.sh` does:

| Figure | Was | Actual |
|---|---|---|
| `_()` catalogue after regeneration | 286 | **287** |
| `_()` entries removed | 29 | **28** |
| French coverage | 28% | **27%** |

Corrected in the table above. All three are measured against the merged tree at `30a89f2ab`.
Everything else — 209 new strings, 47 PSGT entries, 62 catalogues, the per-language
translated-count table, and the +547 same-text recovery — is confirmed correct.

The substance is unchanged: the `_()` catalogue still shrinks (the `-rpcssl` and snapshot-download
strings are genuinely gone), and no language lost a translated string.
