### PR TITLE
test: install an adequately sized alternate signal stack before Boost does

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -4,6 +4,8 @@ if(NOT SYSTEM_XXD)
 endif()
 
 add_executable(test_gridcoin
+    alt_signal_stack.cpp
+    alt_signal_stack_tests.cpp
     bip68_tests.cpp
     block_version_tests.cpp
     checkpoints_tests.cpp
@@ -210,32 +212,18 @@ if(ENABLE_MULTIPROCESS AND NOT WIN32)
     target_link_libraries(test_gridcoin PRIVATE gridcoin_ipc)
 endif()
 
-# --use_alt_stack=no is not optional on musl.
+# BOTH halves are required on musl; neither is sufficient alone.
 #
-# Boost.Test installs an alternate signal stack at framework startup, sized
-# BOOST_TEST_ALT_STACK_SIZE == SIGSTKSZ, and sigaltstack(2) returns ENOMEM when
-# that is below the kernel's minimum. The kernel derives its minimum from the
-# CPU's XSAVE area and publishes it as auxv AT_MINSIGSTKSZ. glibc 2.34+ made
-# SIGSTKSZ dynamic -- sysconf(_SC_SIGSTKSZ), i.e. that same value -- but musl
-# hardcodes 8192. On a CPU whose requirement exceeds 8192 the test binary
-# therefore dies before running a single test:
+# alt_signal_stack.cpp installs an adequately sized alternate stack during static
+# initialisation, which is what covers framework::init() -- the switch below is
+# applied only in unit_test_monitor_t::execute_and_translate and so cannot reach
+# the init path, which is where the abort actually happens.
 #
-#   Test setup error: system_error produced by: exp: Out of memory
+# But Boost's signal_handler DESTRUCTOR disables the alternate stack
+# unconditionally, ours included, so the pre-install protects exactly the first
+# monitored scope. Every later test case would get Boost's own SIGSTKSZ-sized
+# install -- 8192 on musl -- which is the switch's job to suppress.
 #
-# measured on a CI runner reporting AT_MINSIGSTKSZ = 11952 with 14.5 GB of its
-# 16 GB free -- an undersized stack, never memory pressure. It presented as an
-# intermittent Alpine failure only because it depends on which physical CPU the
-# job lands on; hosts reporting ~3632 can never reproduce it.
-#
-# It cannot be fixed at compile time here: BOOST_TEST_DYN_LINK means
-# execution_monitor.ipp is compiled inside libboost_unit_test_framework, so
-# -DBOOST_TEST_DISABLE_ALT_STACK would be ignored. The runtime switch is the
-# supported control. The cost is that Boost can no longer report a
-# stack-overflow SIGSEGV from a separate stack, which is a small price for a
-# suite that starts at all.
-#
-# Only THIS suite needs it. gridcoin_qt_tests is a QTest binary: it does not
-# link Boost::unit_test_framework, and its main() never forwards argc/argv to
-# QTest::qExec -- so it installs no alternate signal stack and would silently
-# ignore the option anyway.
+# Verified by strace: the pre-install alone leaves Boost installing per test case;
+# the switch alone leaves framework::init() installing. Together, neither happens.
 add_test(NAME gridcoin_tests COMMAND test_gridcoin --use_alt_stack=no)

--- a/src/test/alt_signal_stack.cpp
+++ b/src/test/alt_signal_stack.cpp
@@ -135,7 +135,39 @@ AltSignalStackReport& MutableReport()
     // Boost's runs a longjmp and formats a message.
     wanted += 8192;
 
+    // Record the sizes BEFORE anything that can throw. If resize() below fails,
+    // the report should say what was asked for rather than zero -- a failure
+    // message reporting "0 bytes" describes the uninitialised struct, not what
+    // went wrong.
+    report.requested = wanted;
+    report.kernel_minimum = static_cast<std::size_t>(::getauxval(AT_MINSIGSTKSZ));
+
     AltSignalStackStorage().resize(wanted);
+
+    // Do not clobber an alternate stack somebody else installed.
+    //
+    // A sanitizer runtime or a crash handler may have installed one before this
+    // runs, and replacing it would break whatever depends on it. Query first --
+    // the same courtesy Boost extends, and the absence of which in Boost's
+    // TEARDOWN is what makes this file need the --use_alt_stack=no switch
+    // alongside it.
+    //
+    // The one case worth overriding is an existing stack too small for the
+    // kernel's minimum, which is the very failure this file exists to prevent:
+    // leaving that in place would be deferring to a setting that cannot work.
+    stack_t existing{};
+    const bool queried = ::sigaltstack(nullptr, &existing) == 0;
+    const bool someone_else_has_one = queried && !(existing.ss_flags & SS_DISABLE);
+    const bool theirs_is_adequate = someone_else_has_one
+        && existing.ss_size >= report.kernel_minimum;
+
+    if (theirs_is_adequate) {
+        report.installed = true;
+        report.deferred_to_existing = true;
+        report.requested = existing.ss_size;
+
+        return true;
+    }
 
     stack_t alt_stack{};
     alt_stack.ss_sp = AltSignalStackStorage().data();
@@ -149,8 +181,6 @@ AltSignalStackReport& MutableReport()
     const bool ok = ::sigaltstack(&alt_stack, nullptr) == 0;
 
     report.installed = ok;
-    report.requested = wanted;
-    report.kernel_minimum = static_cast<std::size_t>(::getauxval(AT_MINSIGSTKSZ));
 
     return ok;
 

--- a/src/test/alt_signal_stack.cpp
+++ b/src/test/alt_signal_stack.cpp
@@ -101,7 +101,22 @@ AltSignalStackReport& MutableReport()
     return report;
 }
 
-const bool g_alt_signal_stack_installed = [] {
+//! Runs during static initialisation, before main() and therefore before Boost's
+//! framework::init(). The value is never read; the side effect is the point, and
+//! [[maybe_unused]] keeps a translation-unit const from drawing
+//! -Wunused-const-variable on toolchains that warn about it.
+[[maybe_unused]] const bool g_alt_signal_stack_installed = [] {
+    AltSignalStackReport& report = MutableReport();
+    report.attempted = true;
+
+    // Nothing below may escape this lambda.
+    //
+    // Dynamic initialisation is not a context that tolerates exceptions: one
+    // escaping here calls std::terminate and kills the binary before a single
+    // test runs, which is exactly the failure this file exists to prevent.
+    // resize() can throw std::bad_alloc, so record a failure rather than
+    // propagate one.
+    try {
     // What the kernel requires on THIS cpu, not what a header hardcodes. Zero
     // means the kernel did not publish it, in which case the constants below
     // are all we have.
@@ -133,13 +148,18 @@ const bool g_alt_signal_stack_installed = [] {
     // situation into an unconditional one.
     const bool ok = ::sigaltstack(&alt_stack, nullptr) == 0;
 
-    AltSignalStackReport& report = MutableReport();
-    report.attempted = true;
     report.installed = ok;
     report.requested = wanted;
     report.kernel_minimum = static_cast<std::size_t>(::getauxval(AT_MINSIGSTKSZ));
 
     return ok;
+
+    } catch (...) {
+        // Same reasoning as the sigaltstack failure above: without this file the
+        // suite was no better off, so record the failure and let Boost proceed.
+        report.installed = false;
+        return false;
+    }
 }();
 } // namespace
 

--- a/src/test/alt_signal_stack.cpp
+++ b/src/test/alt_signal_stack.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+//! Install an adequately sized alternate signal stack before Boost.Test can
+//! install an undersized one.
+//!
+//! Boost.Test installs an alternate signal stack sized BOOST_TEST_ALT_STACK_SIZE,
+//! which is SIGSTKSZ. glibc 2.34+ made SIGSTKSZ dynamic -- sysconf(_SC_SIGSTKSZ),
+//! which resolves to what the kernel actually requires. **musl hardcodes 8192.**
+//!
+//! The kernel derives its minimum from the CPU's XSAVE area and publishes it as
+//! auxv AT_MINSIGSTKSZ. Measured, that value tracks the XSAVE size plus roughly
+//! 940 bytes of signal-frame overhead:
+//!
+//!     Xeon E5-2687W v2 (AVX)     XSAVE   832 -> AT_MINSIGSTKSZ  1776
+//!     Core i9-13900K   (AVX2)    XSAVE  2696 -> AT_MINSIGSTKSZ  3632
+//!     CI runner (observed)                   -> AT_MINSIGSTKSZ 11952
+//!
+//! 11952 implies an XSAVE area near 11 KB, which only AMX reaches (tile data is
+//! 8192 bytes on top of AVX-512's ~2.7 KB). So on musl, any host with AMX-class
+//! register state -- Sapphire Rapids and later -- has a kernel minimum above
+//! 8192, sigaltstack(2) rejects Boost's buffer with ENOMEM, and the binary dies
+//! before running a single test:
+//!
+//!     Test setup error: system_error produced by: exp: Out of memory
+//!
+//! (Both halves of that message mislead. `exp` is a Boost bug --
+//! BOOST_TEST_SYS_ASSERT stringizes the literal token `exp` rather than the
+//! condition, so all six of its call sites report the same name. And it is an
+//! undersized buffer, never memory pressure.)
+//!
+//! **Why the --use_alt_stack=no runtime switch does not fix it.** That parameter
+//! is applied in exactly one place, unit_test_monitor_t::execute_and_translate,
+//! which runs test cases and fixtures. The failing call happens earlier, from
+//! framework::init() -- which is where the command line is parsed -- under an
+//! execution_monitor still holding its constructor default of true. Confirmed by
+//! backtrace: the install survives with the switch set. The switch does suppress
+//! the per-test-case installs, so it is not inert; it simply cannot reach the one
+//! that matters.
+//!
+//! **Why installing our own works.** Boost queries before it installs and only
+//! installs when no alternate stack is active:
+//!
+//!     BOOST_TEST_SYS_ASSERT( ::sigaltstack( 0, &sigstk ) != -1 );
+//!     if( sigstk.ss_flags & SS_DISABLE ) { ...install SIGSTKSZ bytes... }
+//!
+//! A stack installed before main() therefore makes Boost skip its own install for
+//! that scope -- including framework::init(), which is the one that aborts. It
+//! needs no Boost recompilation, so it works under BOOST_TEST_DYN_LINK where
+//! -DBOOST_TEST_DISABLE_ALT_STACK is inert. Checked against 1.84 (Alpine's) and
+//! 1.86.
+//!
+//! **This alone is not enough, and --use_alt_stack=no alone is not either.**
+//! Boost's signal_handler DESTRUCTOR disables the alternate stack
+//! unconditionally -- it is not guarded by the alt_stack argument -- so it tears
+//! down whatever is installed, ours included, at the end of the first monitored
+//! scope. Every later test case then finds no stack active and gets Boost's own
+//! SIGSTKSZ-sized install.
+//!
+//! Measured with strace on this suite, counting only installs (ss_flags == 0):
+//!
+//!     flag only          our stack 0   boost 1   <- framework::init, aborts on musl
+//!     pre-install only   our stack 1   boost 6   <- one per test case
+//!     BOTH               our stack 1   boost 0   <- what we want
+//!
+//! So src/test/CMakeLists.txt keeps passing --use_alt_stack=no alongside this
+//! file. The two cover disjoint phases; removing either reopens the failure.
+
+#include <test/alt_signal_stack.h>
+
+#if defined(__linux__)
+
+#include <csignal>
+#include <cstddef>
+#include <vector>
+
+#include <sys/auxv.h>
+
+//! musl exposes getauxval() but does not pull in <linux/auxvec.h>, which is where
+//! AT_MINSIGSTKSZ lives. The value is ABI, not a build-time choice.
+#ifndef AT_MINSIGSTKSZ
+#define AT_MINSIGSTKSZ 51
+#endif
+
+namespace {
+//! Must outlive every signal that could be delivered, i.e. the process. A
+//! function-local static gets that lifetime without depending on the
+//! initialisation order of other translation units.
+std::vector<char>& AltSignalStackStorage()
+{
+    static std::vector<char> storage;
+    return storage;
+}
+
+//! Runs during static initialisation, so before main() and therefore before
+//! Boost's framework::init(). Its value is unused; the side effect is the point.
+AltSignalStackReport& MutableReport()
+{
+    static AltSignalStackReport report;
+    return report;
+}
+
+const bool g_alt_signal_stack_installed = [] {
+    // What the kernel requires on THIS cpu, not what a header hardcodes. Zero
+    // means the kernel did not publish it, in which case the constants below
+    // are all we have.
+    std::size_t wanted = static_cast<std::size_t>(::getauxval(AT_MINSIGSTKSZ));
+
+    if (wanted < static_cast<std::size_t>(SIGSTKSZ)) {
+        wanted = static_cast<std::size_t>(SIGSTKSZ);
+    }
+
+    if (wanted < static_cast<std::size_t>(MINSIGSTKSZ)) {
+        wanted = static_cast<std::size_t>(MINSIGSTKSZ);
+    }
+
+    // Headroom over the bare minimum. The kernel's figure is what it takes to
+    // DELIVER a signal; a handler that does any work of its own needs more, and
+    // Boost's runs a longjmp and formats a message.
+    wanted += 8192;
+
+    AltSignalStackStorage().resize(wanted);
+
+    stack_t alt_stack{};
+    alt_stack.ss_sp = AltSignalStackStorage().data();
+    alt_stack.ss_size = AltSignalStackStorage().size();
+    alt_stack.ss_flags = 0;
+
+    // Deliberately not fatal. If this fails the suite is no worse off than
+    // before -- Boost will try its own and either succeed or produce the setup
+    // error this exists to prevent. Aborting here would turn a recoverable
+    // situation into an unconditional one.
+    const bool ok = ::sigaltstack(&alt_stack, nullptr) == 0;
+
+    AltSignalStackReport& report = MutableReport();
+    report.attempted = true;
+    report.installed = ok;
+    report.requested = wanted;
+    report.kernel_minimum = static_cast<std::size_t>(::getauxval(AT_MINSIGSTKSZ));
+
+    return ok;
+}();
+} // namespace
+
+const AltSignalStackReport& GetAltSignalStackReport()
+{
+    return MutableReport();
+}
+
+#else // !__linux__
+
+const AltSignalStackReport& GetAltSignalStackReport()
+{
+    static const AltSignalStackReport report;
+    return report;
+}
+
+#endif // __linux__

--- a/src/test/alt_signal_stack.h
+++ b/src/test/alt_signal_stack.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_TEST_ALT_SIGNAL_STACK_H
+#define GRIDCOIN_TEST_ALT_SIGNAL_STACK_H
+
+#include <cstddef>
+
+//! What the pre-main alternate-signal-stack installation actually did.
+//!
+//! Recorded at static initialisation because it cannot be observed later: Boost's
+//! signal_handler destructor disables the alternate stack at the end of every
+//! monitored scope, so by the time a test case runs, sigaltstack(2) reports no
+//! stack at all regardless of what we installed. See alt_signal_stack.cpp.
+struct AltSignalStackReport
+{
+    bool attempted = false;      //!< false on platforms where we do not install one
+    bool installed = false;      //!< sigaltstack(2) returned success
+    std::size_t requested = 0;   //!< bytes we asked for
+    std::size_t kernel_minimum = 0;  //!< AT_MINSIGSTKSZ, 0 if unpublished
+};
+
+const AltSignalStackReport& GetAltSignalStackReport();
+
+#endif // GRIDCOIN_TEST_ALT_SIGNAL_STACK_H

--- a/src/test/alt_signal_stack.h
+++ b/src/test/alt_signal_stack.h
@@ -19,6 +19,7 @@ struct AltSignalStackReport
     bool installed = false;      //!< sigaltstack(2) returned success
     std::size_t requested = 0;   //!< bytes we asked for
     std::size_t kernel_minimum = 0;  //!< AT_MINSIGSTKSZ, 0 if unpublished
+    bool deferred_to_existing = false;  //!< an adequate stack was already installed; left alone
 };
 
 const AltSignalStackReport& GetAltSignalStackReport();

--- a/src/test/alt_signal_stack_tests.cpp
+++ b/src/test/alt_signal_stack_tests.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <test/alt_signal_stack.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(alt_signal_stack_tests)
+
+//!
+//! The alternate signal stack installed before main() must meet the size the
+//! kernel reports for this CPU.
+//!
+//! This asserts on a RECORD taken at static-initialisation time, not on the live
+//! sigaltstack(2) state, and that distinction is the whole point. Boost's
+//! signal_handler destructor disables the alternate stack at the end of every
+//! monitored scope, so by the time this test case runs there is no stack
+//! installed at all -- querying it here would report zero bytes and prove
+//! nothing about whether the fix worked. An earlier version of this test did
+//! exactly that and failed for that reason.
+//!
+//! What this catches: the pre-install being removed, being sized from SIGSTKSZ
+//! again rather than from AT_MINSIGSTKSZ, or silently failing. What it cannot
+//! catch is the original musl abort -- on a host where that fires, the process
+//! dies during framework::init() and no test case ever runs. That case is
+//! verified with strace instead; see alt_signal_stack.cpp.
+//!
+BOOST_AUTO_TEST_CASE(the_pre_main_alternate_stack_meets_the_kernel_minimum)
+{
+    const AltSignalStackReport& report = GetAltSignalStackReport();
+
+#if !defined(__linux__)
+    BOOST_CHECK(!report.attempted);
+    BOOST_TEST_MESSAGE("not Linux; no alternate stack is installed by us");
+    return;
+#else
+    BOOST_REQUIRE_MESSAGE(report.attempted,
+                          "the static initialiser in alt_signal_stack.cpp did not run");
+
+    BOOST_CHECK_MESSAGE(report.installed,
+                        "sigaltstack(2) rejected our alternate stack of "
+                        << report.requested << " bytes");
+
+    // Zero means the kernel did not publish AT_MINSIGSTKSZ. Nothing to compare
+    // against, so the size check is skipped rather than failed.
+    if (report.kernel_minimum == 0) {
+        BOOST_TEST_MESSAGE("AT_MINSIGSTKSZ unavailable; size comparison skipped");
+        return;
+    }
+
+    BOOST_CHECK_MESSAGE(report.requested >= report.kernel_minimum,
+                        "requested " << report.requested
+                        << " bytes, below the kernel minimum of "
+                        << report.kernel_minimum);
+#endif
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/alt_signal_stack_tests.cpp
+++ b/src/test/alt_signal_stack_tests.cpp
@@ -38,9 +38,12 @@ BOOST_AUTO_TEST_CASE(the_pre_main_alternate_stack_meets_the_kernel_minimum)
     BOOST_REQUIRE_MESSAGE(report.attempted,
                           "the static initialiser in alt_signal_stack.cpp did not run");
 
-    BOOST_CHECK_MESSAGE(report.installed,
-                        "sigaltstack(2) rejected our alternate stack of "
-                        << report.requested << " bytes");
+    // REQUIRE, not CHECK: if the install failed there is no stack to size-check,
+    // and letting the comparison below run would add a second failure that says
+    // nothing about the cause.
+    BOOST_REQUIRE_MESSAGE(report.installed,
+                          "sigaltstack(2) rejected our alternate stack of "
+                          << report.requested << " bytes");
 
     // Zero means the kernel did not publish AT_MINSIGSTKSZ. Nothing to compare
     // against, so the size check is skipped rather than failed.


### PR DESCRIPTION
Fixes the intermittent Alpine failure properly. **#3273's mitigation does not work**, and this PR
explains why with a backtrace rather than a theory.

## The failure

```
2/3 Test #3: gridcoin_tests ...................***Failed    0.01 sec
Test setup error: system_error produced by: exp: Out of memory
```

Both halves of that message mislead. `exp` is a Boost bug — `BOOST_TEST_SYS_ASSERT` stringizes the
literal token `exp` instead of its condition, so all six of its call sites report the same useless
name. And it is `sigaltstack(2)` rejecting an **undersized** buffer, never memory pressure — the
diagnostics from #3273 show `Mem: 14475 available` and `cgroup mem limit: max` on the failing run.

## Why it is musl-only, and why it will get *more* common

Boost sizes its alternate signal stack at `SIGSTKSZ`. glibc 2.34+ made that dynamic; **musl
hardcodes 8192**. The kernel's real requirement comes from the CPU's XSAVE area, published as auxv
`AT_MINSIGSTKSZ`. Measured on two machines here, it tracks XSAVE plus ~940 bytes:

| CPU | XSAVE | `AT_MINSIGSTKSZ` |
|---|---|---|
| Xeon E5-2687W v2 (AVX) | 832 | 1776 |
| Core i9-13900K (AVX2) | 2696 | 3632 |
| CI runner, observed | ≈11016 | **11952** |

~11 KB of XSAVE state is only reached with **AMX** — tile data is 8192 bytes above AVX-512's
~2.7 KB — i.e. Sapphire Rapids and later. This is a **new**-hardware condition, so the failure rate
tracks how much of GitHub's runner fleet has been refreshed. It grows; it does not age out.

## Why `--use_alt_stack=no` cannot work

`p_use_alt_stack` is applied in exactly one place — `unit_test_monitor_t::execute_and_translate` —
which runs test cases and fixtures. The aborting call happens earlier. `strace -k`, **with the
switch set**:

```
sigaltstack({ss_sp=0x…, ss_flags=0, ss_size=14528}, NULL) = 0
  > libboost_unit_test_framework … execution_monitor::catch_signals
  > libboost_unit_test_framework … execution_monitor::vexecute
  > libboost_unit_test_framework … boost::unit_test::framework::init(bool(*)(), int, char**)
  > libboost_unit_test_framework … boost::unit_test::unit_test_main
```

`framework::init()` is *where the command line is parsed*, so its monitor still holds the
constructor default of `true`. The switch is applied strictly after the call it was meant to
prevent. Identical in Boost 1.84 (Alpine's) and 1.86.

**Seven green Alpine runs after #3273 proved nothing** — those runners reported 1776, 1776 and
3376, all under 8192, so the condition could not arise. The fix was reasoned, never measured,
because it cannot be reproduced on a small-XSAVE host — which is every machine we have.

## The fix, and why it keeps the old switch

Boost queries before installing, and installs only when no alternate stack is active:

```cpp
BOOST_TEST_SYS_ASSERT( ::sigaltstack( 0, &sigstk ) != -1 );
if( sigstk.ss_flags & SS_DISABLE ) { …install SIGSTKSZ bytes… }
```

So a correctly sized stack installed during **static initialisation** — before `main()`, therefore
before `framework::init()` — makes Boost skip its own. No Boost recompilation, so it works under
`BOOST_TEST_DYN_LINK` where `-DBOOST_TEST_DISABLE_ALT_STACK` is inert.

**`--use_alt_stack=no` is kept, because neither half is sufficient.** Boost's `signal_handler`
destructor disables the alternate stack *unconditionally*, ours included, so the pre-install covers
only the first monitored scope. Counting installs (`ss_flags == 0`) with `strace`:

| configuration | our install | **Boost installs** |
|---|---|---|
| flag only *(today)* | 0 | 1 — `framework::init`, the abort |
| pre-install only | 1 | 6 — one per test case |
| **both** *(this PR)* | 1 | **0** |

I initially wrote this PR as a *replacement* for the switch. The trace showed that was wrong, in
both directions.

## The test, and what it cannot do

`alt_signal_stack_tests.cpp` asserts on state **recorded at static-initialisation time**, not on a
live `sigaltstack(2)` query — because Boost's teardown means a test case sees no stack at all. An
earlier version queried it directly and failed for exactly that reason.

Verified to fail when the pre-install is neutered.

**It cannot catch the original abort.** On a host where that fires, the process dies during
`framework::init()` and no test case runs. That condition is verified with `strace`, which works on
any hardware. **A green Alpine board is not proof** — that is precisely the error #3273 made.

## Verification

- Build clean, GUI off + tests: 0 errors, 0 warnings.
- `ctest`: 2/2 passed.
- `lint-all.sh`: exit 0 with `COMMIT_RANGE` set.
- `strace` install counts, per the table above.
- Regression test verified to fail against a neutered install.

## Upstream

Four Boost defects were found and confirmed present on `develop`, none previously reported
(`is:issue sigaltstack OR SIGSTKSZ` returned nothing): the alternate signal stack sized from
`SIGSTKSZ` rather than the kernel minimum; the `signal_handler` destructor disabling the alternate
stack unconditionally instead of restoring the caller's; `p_use_alt_stack` documented as defaulting
to `false` while the constructor sets `true`; and the `BOOST_STRINGIZE( exp )` typo that makes all
six `BOOST_TEST_SYS_ASSERT` sites report the same useless name.

These were reported upstream and the fix has been **accepted by Boost**:

- **[boostorg/test#495](https://github.com/boostorg/test/issues/495)** - issue, closed.
- **[boostorg/test#496](https://github.com/boostorg/test/pull/496)** - *"Size the alternate signal
  stack from the kernel minimum, and stop discarding the caller's"* - **merged to `develop`
  2026-08-26 as `0040e366`**.

Once that reaches a Boost release and Alpine picks it up, Boost will size the stack correctly on its
own and the `--use_alt_stack=no` half of this change becomes unnecessary. Until then both halves are
required against Boost 1.84/1.86, per the strace table above.
