### PR TITLE
greylist: treat a chain-resident zero total credit as missing data (v15)

### DIFF
--- a/doc/automated_greylisting_design_highlights.md
+++ b/doc/automated_greylisting_design_highlights.md
@@ -134,9 +134,21 @@ This method simply returns the m_zcd_20_SB_count member variable, which is a cou
 
 The method computes the average total credit over a 7 superblock lookback and a 40  superblock lookback and then constructs a Fraction of the result. Note that if the lookback is less than 40, the number of superblocks in the average is reduced for the 40 superblock lookback and similarly if the lookback is less than 7, the number of superblocks in the average is reduced for the 7 superblock lookback. Given that when data is first being collected for a newly listed project, this can lead to odd behavior of WAS, there is a grace period implemented in the application of the rules for setting the m_meets_greylisting_crit flag in the GreylistCandidateEntry. This grace period is currently set at 7 superblocks.
 
-##### void UpdateGreylistCandidateEntry(std::optional<uint64_t> total_credit, uint8_t sb_from_baseline)
+Note that `m_TC_7_SB_sum` and `m_TC_40_SB_sum` are **assignments, not accumulations** — each holds a single endpoint difference from the head bookmark (`m_TC_initial_bookmark - total_credit` at the largest qualifying `sb_from_baseline`), which is equivalent to summing the deltas only while the series is clean. One bad endpoint is therefore diluted by nothing. A known consequence, pre-dating the zero normalization and applying equally to projects simply absent from a superblock: when an endpoint is skipped the numerator spans fewer superblocks while the divisor still advances with `m_sb_from_baseline_processed`, so WAS is understated (a single skipped endpoint at `sb_from_baseline == 7` understates a uniform history by about 14%). This is tracked for the walker-correctness pass gated by `AutoGreylistRedesignHeight`.
+
+##### void UpdateGreylistCandidateEntry(std::optional<uint64_t> total_credit, uint8_t sb_from_baseline, bool use_benefit_of_doubt, bool zero_credit_is_missing)
 
 This method is used by the RefreshWithSuperblock method to update each GreylistCandidateEntry and add each update to the entry history.
+
+The two flags are height-gated by the caller and neither is defaulted, so a new call site must decide both:
+
+* `use_benefit_of_doubt` (`AutoGreylistAuditHeight`) suppresses the ZCD increment for the single interval at `sb_from_baseline == 1` when the head/baseline bookmark is missing, so a transient local scraper failure on one node cannot by itself force a greylist event.
+
+* `zero_credit_is_missing` (`AutoGreylistRedesignHeight`) treats a recorded total credit of **exactly zero** as missing data rather than an observation, normalizing it to `std::nullopt` once at the top of the method so that the WAS delta guard, the ZCD "no statistics" arm and the bookmark update all see it consistently. A zero is a cumulative lifetime counter asserting the project has never validated any work; where a *newer* superblock records non-zero lifetime credit for the same project, the chain itself contradicts that, so the zero is corruption rather than data. The same normalization is applied to the baseline value in `RefreshWithSuperblock`, because the head (`sb_from_baseline == 0`) is seeded through the parameterized `GreylistCandidateEntry` constructor and never passes through this method.
+
+  Note this does **not** weaken the deliberate penalty for a credit rollback to a non-zero value, which fails the `m_TC_initial_bookmark > total_credit` guard and remains penalized by omission. A rollback to exactly zero *is* suppressed, which is accepted: at the point of observation it is indistinguishable from the corruption signature, and a sustained reset is still caught via ZCD within about eight superblocks.
+
+The value as actually recorded on chain — not the normalized one — is what goes into the update history, so `getautogreylist show_history` continues to show the corruption rather than hiding it.
 
 ##### struct UpdateHistoryEntry
 

--- a/doc/consensus.md
+++ b/doc/consensus.md
@@ -59,13 +59,18 @@ in `src/chainparams.h`.
 | `BlockV15Height` | _not yet activated_ | _not yet activated_ | `IsV15Enabled()` (>= height) |
 | `PollV3Height` | 2,671,700 | 1,944,820 | `IsPollV3Enabled()` (>= height) |
 | `ProjectV2Height` | 2,671,700 | 1,944,820 | `IsProjectV2Enabled()` (>= height) |
-| `ProjectV4Height` | _not yet activated_ | 2,870,000 | `IsProjectV4Enabled()` (>= height) |
-| `SuperblockV3Height` | _not yet activated_ | 2,870,000 | `IsSuperblockV3Enabled()` (>= height) |
-| `AutoGreylistAuditHeight` | _not yet activated_ | 3,111,000 | `IsAutoGreylistAuditEnabled()` (>= height) |
+| `ProjectV4Height` | 3,989,800 | 2,870,000 | `IsProjectV4Enabled()` (>= height) |
+| `SuperblockV3Height` | 3,989,800 | 2,870,000 | `IsSuperblockV3Enabled()` (>= height) |
+| `AutoGreylistAuditHeight` | 3,989,800 | 3,111,000 | `IsAutoGreylistAuditEnabled()` (>= height) |
+| `AutoGreylistDeepCopyHeight` | _not yet activated_ | _not yet activated_ | `IsAutoGreylistDeepCopyEnabled()` (>= height) |
+| `AutoGreylistTotalCreditFixHeight` | _not yet activated_ | _not yet activated_ | `IsAutoGreylistTotalCreditFixEnabled()` (>= height) |
+| `AutoGreylistRedesignHeight` | _not yet activated_ | _not yet activated_ | `IsAutoGreylistRedesignEnabled()` (>= height) |
 
-> **Note:** "not yet activated" means the height is set to
-> `std::numeric_limits<int>::max()` in `CMainParams`. The feature exists in
-> code and is active on testnet.
+> **Note:** "not yet activated" means that network's chain parameters set the
+> height to `std::numeric_limits<int>::max()`, so the gate never opens there.
+> Every row currently marked that way is inactive on **both** mainnet and
+> testnet. The feature is present in code; where a hidden height override
+> exists it can be activated ahead of schedule on an isolated testnet.
 
 ### Non-Height Parameters
 
@@ -567,7 +572,31 @@ Via protocol entry `"magnitudeweightfactor"`:
 - Automatic exclusion of unresponsive BOINC projects based on Zero Credit
   Days (ZCD) and Whitelist Activity Score (WAS)
 - Benefit-of-the-doubt audit logic activated at `AutoGreylistAuditHeight`
-  (testnet 3,111,000)
+  (mainnet 3,989,800 -- coincident with v13 and `SuperblockV3Height`; testnet
+  3,111,000)
+- `AutoGreylistDeepCopyHeight` -- `Whitelist::Snapshot` stops overlaying the
+  greylist by mutating the shared registry entries in place and deep-copies
+  instead. Crossing it forward triggers `ReinitFromDisk` in
+  `Quorum::PushSuperblock` to heal entries already stuck `AUTO_GREYLISTED`
+- `AutoGreylistTotalCreditFixHeight` -- scraper-side EMIT gate: a project whose
+  statistics export yielded no usable records is omitted from the superblock's
+  all-CPID total-credit map instead of being written as a spurious zero. Note
+  this is forward-only; it cannot reinterpret zeros already in the chain, and a
+  legitimately scraped zero (`no_records == false`) is still emitted by design
+- `AutoGreylistRedesignHeight` -- single gate for the remaining correctness
+  batch: separation of the pending (candidate) greylist state from the
+  authoritative (committed-superblock) state, treating a chain-resident zero
+  total credit as missing data, and the walker corrections that follow.
+  **Must never be set below `AutoGreylistDeepCopyHeight`** -- before that gate
+  the Snapshot overlay only ever promotes to `AUTO_GREYLISTED` and there is no
+  demotion arm, so a spuriously greylisted project cannot heal. The release sets
+  all of these coincident with `BlockV15Height`
+
+> These four heights are separate fields so they can be driven independently
+> during testing (`-autogreylist{audit,deepcopy,totalcreditfix,redesign}height`).
+> On the isolated mesh the first three are overridden low and already crossed,
+> which is **not** the mainnet sequencing -- mainnet activates all of them in the
+> same block as v15.
 
 ### 9.7 Project v4
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -188,6 +188,9 @@ public:
         // TBD: set coincident with BlockV15Height when v15 is scheduled. numeric_limits max keeps the
         // scraper no_records total-credit fix inactive on mainnet until then (mirrors the deep-copy fix).
         consensus.AutoGreylistTotalCreditFixHeight = std::numeric_limits<int>::max();
+        // TBD: set coincident with BlockV15Height when v15 is scheduled. Must never be set
+        // below AutoGreylistDeepCopyHeight (see Consensus::Params).
+        consensus.AutoGreylistRedesignHeight = std::numeric_limits<int>::max();
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
@@ -321,6 +324,9 @@ public:
         // Inactive by default; activated on the isolated mesh / public testnet via the
         // -autogreylisttotalcreditfixheight override ahead of v15.
         consensus.AutoGreylistTotalCreditFixHeight = std::numeric_limits<int>::max();
+        // TBD: set coincident with BlockV15Height when v15 is scheduled. Must never be set
+        // below AutoGreylistDeepCopyHeight (see Consensus::Params).
+        consensus.AutoGreylistRedesignHeight = std::numeric_limits<int>::max();
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
@@ -425,6 +431,7 @@ public:
         consensus.AutoGreylistAuditHeight = 0;
         consensus.AutoGreylistDeepCopyHeight = 0;
         consensus.AutoGreylistTotalCreditFixHeight = 0;
+        consensus.AutoGreylistRedesignHeight = 0;
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -223,6 +223,13 @@ inline bool IsAutoGreylistTotalCreditFixEnabled(int nHeight)
     return nHeight >= gArgs.GetArg("-autogreylisttotalcreditfixheight", Params().GetConsensus().AutoGreylistTotalCreditFixHeight);
 }
 
+inline bool IsAutoGreylistRedesignEnabled(int nHeight)
+{
+    // The argument driven override temporarily here to facilitate isolated/public testnet testing
+    // ahead of the v15 activation height.
+    return nHeight >= gArgs.GetArg("-autogreylistredesignheight", Params().GetConsensus().AutoGreylistRedesignHeight);
+}
+
 inline bool IsSuperblockV3Enabled(int nHeight)
 {
     return nHeight >= Params().GetConsensus().SuperblockV3Height;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -85,6 +85,29 @@ struct Params {
       * activation is scheduled; overridable via -autogreylisttotalcreditfixheight for testnet rollout. */
     int AutoGreylistTotalCreditFixHeight;
     /**
+      * @brief Single activation height for the remaining AutoGreylist correctness batch. Covers
+      * (a) separation of the pending (candidate/tip-anchored) greylist state from the authoritative
+      * (committed-superblock) state, (b) treating a chain-resident zero project total credit as
+      * missing data rather than a real observation, and (c) the walker corrections that follow from
+      * (a). Batched behind ONE height deliberately: these activate together in the release, and a
+      * partial combination is a configuration nobody tests. AutoGreylistTotalCreditFixHeight is a
+      * different thing -- a scraper-EMIT gate that stops new spurious zeros being written; zeros
+      * already recorded in the chain are permanent and keep corrupting the WAS window as they
+      * transit it (one landing on the j=40 endpoint inflates the 40-SB average and collapses WAS;
+      * one at j<=7 inflates the 7-SB average and can mask a genuine greylist).
+      *
+      * MUST NOT be set below AutoGreylistDeepCopyHeight. Before the deep-copy gate the Snapshot
+      * overlay writes through to the registry and only ever promotes to AUTO_GREYLISTED -- there is
+      * no demotion arm, and ReinitFromDisk is conditioned on the deep-copy crossing -- so a project
+      * spuriously greylisted before that gate cannot heal. Co-activation satisfies this: within
+      * Quorum::PushSuperblock, ReinitFromDisk runs before the AutoGreylist Refresh. By procedure the
+      * deep-copy height is never set above the others.
+      *
+      * TBD: set coincident with BlockV15Height when v15 is scheduled. std::numeric_limits<int>::max()
+      * on main/testnet until then; kept as its own field only so it can be driven independently
+      * during testing. Overridable via -autogreylistredesignheight for testnet rollout. */
+    int AutoGreylistRedesignHeight;
+    /**
       * @brief The default GRC paid for a constant block reward.
       *
       * Note that the GRC paid for CBR can be specified by an administrative protocol entry with the key name "blockreward1" for

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -477,6 +477,13 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
     // [Added] Determine the flag based on the height of the superblock being processed.
     bool use_benefit_of_doubt = IsAutoGreylistAuditEnabled(superblock_ptr_in.m_height);
 
+    // Gate for treating a chain-resident zero project total credit as missing data. Anchored on the
+    // ACTIVE SUPERBLOCK height (not the wall-clock tip) so historical validation stays deterministic,
+    // matching m_deep_copy_active above. Applied at BOTH the baseline construction and the update
+    // path, so a zero is interpreted identically at every position in the window.
+    bool zero_credit_is_missing = IsAutoGreylistRedesignEnabled(superblock_ptr_in.m_height);
+
+
     unsigned int superblock_count = 0;
 
     // Notice the superblock_ptr_in m_projects_all_cpid_total_credits MUST ALREADY BE POPULATED to record the TC state into
@@ -495,13 +502,32 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
             && superblock_ptr_in.m_timestamp >= project_first_active->second->m_timestamp) {
             if (project != superblock_ptr_in->m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits.end()) {
                 // Record new greylist candidate entry baseline with the total credit for each project present in superblock.
+                // Same normalization the update path applies (see UpdateGreylistCandidateEntry): a
+                // recorded total credit of exactly zero is corruption, not an observation. It has to
+                // happen here too, because the BASELINE (sb_from_baseline == 0) is seeded through this
+                // constructor and never passes through the update path -- so without this a zero would
+                // be treated as missing at every position EXCEPT the head, which is the position it
+                // does the most damage from (it becomes m_TC_initial_bookmark, and no historical total
+                // credit is ever greater than zero, so every WAS delta is skipped).
+                std::optional<uint64_t> baseline_tc = project->second;
+
+                if (zero_credit_is_missing && baseline_tc && *baseline_tc == 0) {
+                    baseline_tc = std::nullopt;
+                }
+
+                // Effective credit is the normalized value; recorded credit is what the superblock
+                // actually holds, so a head zero stays visible in show_history.
                 m_greylist_ptr->insert(std::make_pair(iter.m_name,
-                                                      GreylistCandidateEntry(iter.m_name, project->second)));
+                                                      GreylistCandidateEntry(iter.m_name,
+                                                                             baseline_tc,
+                                                                             project->second)));
             } else {
                 // Record new greylist candidate entry with nullopt total credit. This is for a project that is in the whitelist,
                 // but does not have a project entry in the superblock. This would be because the scrapers could not converge on the
-                // project.
+                // project. Nothing was recorded for this project at all, so the effective and the recorded
+                // credit are both absent -- unlike the zero case above, there is no value to keep visible.
                 m_greylist_ptr->insert(std::make_pair(iter.m_name, GreylistCandidateEntry(iter.m_name,
+                                                                                          std::optional<uint64_t>(),
                                                                                           std::optional<uint64_t>())));
             }
         }
@@ -584,15 +610,16 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
                 && superblock_ptr.m_timestamp >= project_first_active->second->m_timestamp) {
                 if (project != superblock_ptr->m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits.end()) {
                     // Update greylist candidate entry with the total credit for each project present in superblock.
-                    // [Changed] Pass use_benefit_of_doubt
-                    greylist_entry->second.UpdateGreylistCandidateEntry(project->second, superblock_count, use_benefit_of_doubt);
+                    // [Changed] Pass use_benefit_of_doubt and zero_credit_is_missing
+                    greylist_entry->second.UpdateGreylistCandidateEntry(project->second, superblock_count, use_benefit_of_doubt,
+                                                                        zero_credit_is_missing);
                 } else {
                     // Record updated greylist candidate entry with nullopt total credit. This is for a project that is in the
                     // whitelist, but does not have a project entry in this superblock. This would be because the scrapers could
                     // not converge on the project for this superblock.
-                    // [Changed] Pass use_benefit_of_doubt
+                    // [Changed] Pass use_benefit_of_doubt and zero_credit_is_missing
                     greylist_entry->second.UpdateGreylistCandidateEntry(std::optional<uint64_t>(std::nullopt), superblock_count,
-                                                                        use_benefit_of_doubt);
+                                                                        use_benefit_of_doubt, zero_credit_is_missing);
                 }
             }
         }

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -556,8 +556,15 @@ public:
             , m_TC_7_SB_sum(0)
             , m_TC_40_SB_sum(0)
             , m_meets_greylisting_crit(false)
-            , m_TC_initial_bookmark(0)
-            , m_TC_bookmark(0)
+            // std::nullopt, NOT 0. These are std::optional; initializing with 0 yields an ENGAGED
+            // optional holding zero -- a default-constructed entry born in exactly the corrupt state
+            // this class now normalizes away, and unrescuable by any gate: the bookmark-repair branch
+            // (!m_TC_initial_bookmark) is dead, no historical credit exceeds zero so both WAS sums stay
+            // 0, and meets_greylisting_crit latches true from sb_from_baseline >= 7. Latent while
+            // RefreshWithSuperblock uses only the parameterized constructor, but this is a public
+            // nested type used as a std::map value, so one operator[] or try_emplace lands there.
+            , m_TC_initial_bookmark(std::nullopt)
+            , m_TC_bookmark(std::nullopt)
             , m_sb_from_baseline_processed(0)
             , m_update_history({})
         {}
@@ -566,10 +573,21 @@ public:
         //! \brief This parameterized constructor is used to construct the initial (baseline) greylist candidate
         //! entry with the initial total credit value for the project. This also inserts the baseline history entry.
         //!
-        //! \param project_name
-        //! \param TC_initial_bookmark
+        //! The EFFECTIVE and the RECORDED total credit are taken separately, and neither is defaulted, so
+        //! every call site has to state both. Above AutoGreylistRedesignHeight they diverge: a total credit
+        //! recorded as exactly zero is corruption rather than an observation, so it is normalized to nullopt
+        //! for the bookmark, while the history must keep reporting the zero as it actually appears in the
+        //! chain. This mirrors recorded_total_credit in UpdateGreylistCandidateEntry -- without it the head
+        //! (sb_from_baseline == 0) would be the one position where getautogreylist show_history hides the
+        //! very datapoint that drove the greylisting.
         //!
-        GreylistCandidateEntry(std::string project_name, std::optional<uint64_t> TC_initial_bookmark)
+        //! \param project_name
+        //! \param TC_initial_bookmark Effective baseline credit; drives the bookmarks and hence the WAS.
+        //! \param recorded_total_credit Credit as recorded in the superblock; drives the history entry only.
+        //!
+        GreylistCandidateEntry(std::string project_name,
+                               std::optional<uint64_t> TC_initial_bookmark,
+                               std::optional<uint64_t> recorded_total_credit)
             : m_project_name(project_name)
             , m_zcd_20_SB_count(0)
             , m_TC_7_SB_sum(0)
@@ -580,9 +598,10 @@ public:
             , m_sb_from_baseline_processed(0)
             , m_update_history()
         {
-            // Populate the initial historical entry from the initial baseline.
+            // Populate the initial historical entry from what the superblock RECORDED, not from the
+            // (possibly normalized) bookmark.
             UpdateHistoryEntry entry = UpdateHistoryEntry(0,
-                                                          TC_initial_bookmark);
+                                                          recorded_total_credit);
 
             m_update_history.push_back(entry);
         }
@@ -661,8 +680,43 @@ public:
         //! \param total_credit
         //! \param sb_from_baseline
         //! \param use_benefit_of_doubt Flag to enable the benefit of the doubt logic for the head superblock.
-        void UpdateGreylistCandidateEntry(std::optional<uint64_t> total_credit, uint8_t sb_from_baseline, bool use_benefit_of_doubt)
+        //! \param zero_credit_is_missing Flag to treat a recorded total credit of exactly zero as missing
+        //! data rather than an observation (see the normalization at the top of the body). Height-gated by
+        //! the caller on AutoGreylistRedesignHeight; not defaulted, so a new call site must decide.
+        void UpdateGreylistCandidateEntry(std::optional<uint64_t> total_credit, uint8_t sb_from_baseline,
+                                          bool use_benefit_of_doubt, bool zero_credit_is_missing)
         {
+            // Keep the value as actually recorded for the history entry at the bottom: the history exists
+            // for diagnosis, and normalizing before recording would erase the very evidence that a
+            // chain-resident zero is present.
+            const std::optional<uint64_t> recorded_total_credit = total_credit;
+
+            // A project total credit of exactly zero is a cumulative lifetime counter asserting the project
+            // has never validated any work. Where a NEWER superblock records non-zero lifetime credit for
+            // the same project, the chain itself contradicts that assertion, so the zero is corruption (the
+            // pre-fix scraper emitted one for any project whose stats export yielded no usable records)
+            // rather than an observation. Treat it as missing data.
+            //
+            // Done ONCE here rather than at each use: every consumer below keys off total_credit having a
+            // value, so normalizing at the top reaches the WAS delta guard, the ZCD "no statistics" arm and
+            // the bookmark update together. Guarding only the WAS branch would stop the spurious WAS
+            // collapse but leave a genuinely zero project incrementing no ZCD and no longer collapsing WAS
+            // -- invisible to both routes, and permanently un-greylistable.
+            //
+            // Interaction with the deliberate penalty for a credit rollback, stated precisely because the
+            // obvious phrasing is wrong. A rollback to a NON-ZERO value fails the "initial bookmark >
+            // total_credit" guard when walking backward and is penalized by omission -- untouched here,
+            // since the predicate below requires exactly zero. A rollback to EXACTLY zero DOES pass that
+            // guard, maximally, and IS suppressed. That is accepted rather than incidental: at the point
+            // of observation a hard reset to zero is byte-identical to the corruption signature, so there
+            // is nothing left to discriminate on -- and a genuine reset is still caught, because
+            // normalizing to nullopt makes the ZCD "no statistics" arm fire on every subsequent
+            // superblock, so ZCD passes 7 within eight of them and the project greylists by that route
+            // instead, roughly a week later.
+            if (zero_credit_is_missing && total_credit && *total_credit == 0) {
+                total_credit = std::nullopt;
+            }
+
             if (sb_from_baseline > 0) {
                 // ZCD part. Remember we are going backwards, so if total_credit is greater than or equal to
                 // the bookmark, then we have zero or even negative project total credit between superblocks, so
@@ -726,7 +780,7 @@ public:
             m_meets_greylisting_crit = (sb_from_baseline >= 7 && (zcd > 7 || was < Fraction(1, 10)));
 
             // Insert historical entry.
-            UpdateHistoryEntry entry(sb_from_baseline, total_credit);
+            UpdateHistoryEntry entry(sb_from_baseline, recorded_total_credit);
             m_update_history.push_back(entry);
         }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -969,6 +969,7 @@ void SetupServerArgs()
     hidden_args.emplace_back("-pollmultiaddressheight");
     hidden_args.emplace_back("-autogreylistdeepcopyheight");
     hidden_args.emplace_back("-autogreylisttotalcreditfixheight");
+    hidden_args.emplace_back("-autogreylistredesignheight");
 
     // This puts hidden options in the form of -clear<type>history, where <type> is the contract types that have a
     // registry with a backing db. This is currently beacon, project, protocol, and scraper, with sidestakes starting
@@ -1618,6 +1619,46 @@ bool AppInit2(ThreadHandlerPtr threads)
     // -pendingpoolretention override is visible in the log and an accidental
     // mismatch across nodes is diagnosable (the value is consensus-affecting).
     LogPrintf("POOL pending/open retention configured at %d blocks", GetPendingPoolRetention());
+
+    // Same rationale for the AutoGreylist activation heights: all four are
+    // consensus-affecting, all four carry hidden isolated-testnet overrides, and
+    // none of them was previously surfaced -- so a node running a different
+    // effective value from its peers had nothing in the log to show it.
+    {
+        const int64_t audit_height = gArgs.GetArg("-autogreylistauditheight",
+                                                  Params().GetConsensus().AutoGreylistAuditHeight);
+        const int64_t deep_copy_height = gArgs.GetArg("-autogreylistdeepcopyheight",
+                                                      Params().GetConsensus().AutoGreylistDeepCopyHeight);
+        const int64_t total_credit_fix_height = gArgs.GetArg("-autogreylisttotalcreditfixheight",
+                                                             Params().GetConsensus().AutoGreylistTotalCreditFixHeight);
+        const int64_t redesign_height = gArgs.GetArg("-autogreylistredesignheight",
+                                                     Params().GetConsensus().AutoGreylistRedesignHeight);
+
+        LogPrintf("AutoGreylist audit configured for block %" PRId64, audit_height);
+        LogPrintf("AutoGreylist deep-copy configured for block %" PRId64, deep_copy_height);
+        LogPrintf("AutoGreylist total-credit fix configured for block %" PRId64, total_credit_fix_height);
+        LogPrintf("AutoGreylist redesign configured for block %" PRId64, redesign_height);
+
+        // Enforce the ordering the Consensus::Params comment documents, rather than
+        // relying on it being followed. Before the deep-copy gate the Snapshot overlay
+        // writes through to the registry and only ever promotes to AUTO_GREYLISTED --
+        // there is no demotion arm -- so a project greylisted while the redesign is
+        // active but deep-copy is not cannot heal.
+        //
+        // Refused rather than silently clamped to the deep-copy height. Clamping would
+        // make the effective redesign height a function of BOTH values, so two nodes
+        // configuring the redesign identically but the deep-copy differently would then
+        // disagree about the redesign gate as well -- turning one misconfiguration into
+        // two divergences, silently. Refusing to start surfaces it on the node that is
+        // actually wrong.
+        if (redesign_height < deep_copy_height) {
+            return InitError(strprintf(_("-autogreylistredesignheight (%d) must not be below "
+                                         "-autogreylistdeepcopyheight (%d). Activating the AutoGreylist "
+                                         "redesign before the deep-copy gate leaves a spuriously greylisted "
+                                         "project unable to recover."),
+                                       redesign_height, deep_copy_height));
+        }
+    }
 
     fs::path datadir = GetDataDir();
 

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -1505,6 +1505,29 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
 //!
 BOOST_AUTO_TEST_CASE(no_records_zero_baseline_does_not_collapse_was)
 {
+    // This case pins the PRE-AutoGreylistRedesignHeight consumer behaviour: a present-with-zero
+    // head collapses WAS. That fix (which treats a recorded zero as missing at every position,
+    // including the head) subsumes variant A, so the gate must be held OFF here or variant A's
+    // assertions describe behaviour that no longer exists. Pinned explicitly rather than relying on
+    // the chain default -- the unit suite runs on MAIN, where the height is INT_MAX and the gate
+    // happens to be inert, but that is a default, not a guarantee.
+    // Set the consensus value directly, the idiom already used in this file for
+    // AutoGreylistAuditHeight. NOT gArgs.ForceSetArg: an empty string there is stored as a
+    // string rather than cleared, and GetArg(name, int64_t) falls through to ParseInt64("")
+    // which fails and leaves arg_value at its 0 initialiser -- so "clearing" the override
+    // would silently ACTIVATE the gate from genesis for the rest of the process.
+    struct ZeroCreditHeightGuard {
+        const int m_saved = Params().GetConsensus().AutoGreylistRedesignHeight;
+        ~ZeroCreditHeightGuard()
+        {
+            const_cast<Consensus::Params&>(Params().GetConsensus())
+                .AutoGreylistRedesignHeight = m_saved;
+        }
+    } zero_credit_height_guard;
+
+    const_cast<Consensus::Params&>(Params().GetConsensus())
+        .AutoGreylistRedesignHeight = std::numeric_limits<int>::max();
+
     // Drive the auto-greylist over a total-credit sequence (oldest first; the last entry is the baseline/head).
     // A nullopt entry models a project omitted from ProjectsAllCpidTotalCredits; a value models a present entry.
     // Returns {WAS as double, meets_greylist_criteria} for the head/baseline.
@@ -1589,6 +1612,292 @@ BOOST_AUTO_TEST_CASE(no_records_zero_baseline_does_not_collapse_was)
 
     BOOST_CHECK(absent_head.first > 0.0);
     BOOST_CHECK(absent_head.second == false);
+}
+
+//!
+//! \brief A chain-resident zero total credit must not corrupt the WAS window as it transits
+//! (v15, IsAutoGreylistRedesignEnabled).
+//!
+//! AutoGreylistTotalCreditFixHeight (#3102) stopped the scraper EMITTING a spurious zero, and the
+//! regression test above covers the case where that zero is the head/baseline. Zeros already written
+//! into the superblock chain are permanent, and #3102 does nothing for them: they keep corrupting
+//! the WAS window as they walk backward through it. One datapoint produces three distinct events:
+//!
+//!   * at j == 40 (the TC_40_SB_sum endpoint) the 40-SB sum becomes the project's ENTIRE lifetime
+//!     credit, inflating the long average ~100x and collapsing WAS -> spurious greylist;
+//!   * at j <= 7 it inflates the SHORT average instead, pushing WAS far above the threshold, which
+//!     MASKS a greylist that should fire;
+//!   * at j == 0 it is the head case already covered above.
+//!
+//! Both sums are assignments, not accumulations -- each is a single endpoint difference from the
+//! head bookmark -- so one bad endpoint is diluted by nothing.
+//!
+//! Two things must NOT change, and are asserted here because the fix would be wrong without them:
+//!
+//!   * a genuinely all-zero project must still be greylisted. Normalizing zero to "missing" in the
+//!     WAS branch ALONE would leave it incrementing no ZCD and no longer collapsing WAS -- invisible
+//!     to both routes and permanently un-greylistable. Normalizing once, at the top, keeps the ZCD
+//!     "no statistics" arm firing, so detection survives via ZCD.
+//!   * a credit ROLLBACK must still be penalized. Rollbacks are penalized deliberately: walking
+//!     backward they FAIL the "initial bookmark > total_credit" guard and are penalized by omission.
+//!     A zero PASSES that guard maximally. Opposite in kind; only the zero is suppressed.
+//!
+BOOST_AUTO_TEST_CASE(chain_resident_zero_total_credit_does_not_corrupt_was)
+{
+    // Drive the auto-greylist over a total-credit sequence (oldest first; last entry is the head),
+    // with the zero-credit gate forced on or off. Returns {WAS, meets_criteria, ZCD} for the head.
+    auto run = [](const std::vector<std::optional<uint64_t>>& tc_sequence, bool gate_active) {
+        // Set the consensus value directly, the idiom already used in this file for
+        // AutoGreylistAuditHeight. NOT gArgs.ForceSetArg: an empty string there is stored as a
+        // string rather than cleared, and GetArg(name, int64_t) falls through to ParseInt64("")
+        // which fails and leaves arg_value at its 0 initialiser -- so "clearing" the override
+        // would silently ACTIVATE the gate from genesis for the rest of the process.
+        struct ZeroCreditHeightGuard {
+            const int m_saved_redesign = Params().GetConsensus().AutoGreylistRedesignHeight;
+            const int m_saved_deep_copy = Params().GetConsensus().AutoGreylistDeepCopyHeight;
+            ~ZeroCreditHeightGuard()
+            {
+                const_cast<Consensus::Params&>(Params().GetConsensus())
+                    .AutoGreylistRedesignHeight = m_saved_redesign;
+                const_cast<Consensus::Params&>(Params().GetConsensus())
+                    .AutoGreylistDeepCopyHeight = m_saved_deep_copy;
+            }
+        } zero_credit_height_guard;
+
+        // 0 activates from genesis; INT_MAX keeps it inert for the whole run.
+        //
+        // The deep-copy height moves WITH the redesign height rather than being left at whatever
+        // the selected network defaults to. The unit tests run on MAIN (test_gridcoin.cpp calls
+        // SelectParams(CBaseChainParams::MAIN)), where AutoGreylistDeepCopyHeight is INT_MAX -- so
+        // pinning only the redesign height at 0 would build redesign < deep-copy, exactly the
+        // combination AppInit2 now refuses to start on, because a project greylisted with the
+        // redesign active but the deep-copy overlay inactive cannot heal. Driving both from one
+        // value keeps the fixture inside the configuration space production actually permits.
+        const int gate_height = gate_active ? 0 : std::numeric_limits<int>::max();
+
+        const_cast<Consensus::Params&>(Params().GetConsensus()).AutoGreylistRedesignHeight = gate_height;
+        const_cast<Consensus::Params&>(Params().GetConsensus()).AutoGreylistDeepCopyHeight = gate_height;
+
+        GRC::Whitelist& whitelist = GRC::GetWhitelist();
+        std::shared_ptr<GRC::AutoGreylist> auto_greylist = GRC::GetAutoGreylistCache();
+
+        whitelist.Reset();
+
+        int height = 0;
+        int64_t time = 0;
+
+        auto unit_test_blocks = std::make_shared<std::map<int, std::pair<CBlockIndex*, GRC::SuperblockPtr>>>();
+
+        AddProjectEntry(3, "zerotc_test", "http://zerotc.test", false, height, time, true);
+
+        CBlockIndex* whitelist_index_entry = new CBlockIndex;
+        ++height;
+        ++time;
+
+        CBlockIndex* index_ptr = whitelist_index_entry;
+        CBlockIndex* index_ptr_prev = nullptr;
+
+        for (const auto& tc : tc_sequence) {
+            auto_greylist->Reset();
+
+            index_ptr_prev = index_ptr;
+            index_ptr = new CBlockIndex;
+            index_ptr->nHeight = height;
+            index_ptr->nTime = time;
+            index_ptr->MarkAsSuperblock();
+            index_ptr->pprev = index_ptr_prev;
+
+            GRC::Superblock superblock = GRC::Superblock();
+
+            if (tc) {
+                superblock.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits
+                    .insert(std::make_pair("zerotc_test", *tc));
+            }
+
+            GRC::SuperblockPtr superblock_ptr = GRC::SuperblockPtr();
+            superblock_ptr.Replace(superblock);
+            superblock_ptr.Rebind(index_ptr);
+
+            unit_test_blocks->insert(std::make_pair(height, std::make_pair(index_ptr, superblock_ptr)));
+            auto_greylist->RefreshWithSuperblock(superblock_ptr, unit_test_blocks);
+
+            ++height;
+            ++time;
+        }
+
+        auto candidate = auto_greylist->begin()->second;
+
+        // The baseline history entry (sb_from_baseline == 0) is pushed by the parameterized
+        // constructor before any update runs, so it is always front(). Returned so the cases can
+        // assert that normalizing the bookmark does not also erase the recorded value.
+        const std::vector<GRC::AutoGreylist::GreylistCandidateEntry::UpdateHistoryEntry> history =
+                candidate.GetUpdateHistory();
+
+        const std::optional<uint64_t> baseline_recorded_tc =
+                history.empty() ? std::optional<uint64_t>() : history.front().m_total_credit;
+
+        std::tuple<double, bool, uint8_t, std::optional<uint64_t>> result(
+                candidate.GetWAS().ToDouble(),
+                candidate.m_meets_greylisting_crit,
+                candidate.GetZCD(),
+                baseline_recorded_tc);
+
+        for (auto& it : *unit_test_blocks) delete it.second.first;
+        unit_test_blocks->clear();
+        delete whitelist_index_entry;
+
+        // Reset the shared singletons this populated. Resetting only on ENTRY (as the sibling case
+        // does) leaves "zerotc_test" in the whitelist and a populated AutoGreylist whose
+        // m_superblock_hash can false-hit Refresh()'s early return. Masked today only because the
+        // next case in file order happens to reset first -- it bites under --run_test= filtering
+        // or any reordering.
+        auto_greylist->Reset();
+        whitelist.Reset();
+
+        return result;
+    };
+
+    // A healthy history modelled on the observed mainnet case: a large lifetime counter growing at a
+    // steady, modest daily rate. 45 entries, so the head has a full 40-superblock lookback.
+    const uint64_t base = 500000000000ULL;   // ~500 B lifetime credit
+    const uint64_t step = 60000000ULL;       // ~60 M/day
+    const size_t   len  = 45;
+
+    auto healthy = [&]() {
+        std::vector<std::optional<uint64_t>> v;
+        for (size_t i = 0; i < len; ++i) v.push_back(base + step * i);
+        return v;
+    };
+
+    // Index of the entry sitting j superblocks back from the head.
+    auto at_j = [&](size_t j) { return len - 1 - j; };
+
+    // --- Baseline: an untouched healthy history is nowhere near the criteria, gate or no gate.
+    {
+        const auto clean_off = run(healthy(), false);
+        const auto clean_on  = run(healthy(), true);
+        BOOST_CHECK(std::get<0>(clean_off) > 0.5);
+        BOOST_CHECK(std::get<1>(clean_off) == false);
+        // The gate must be a no-op on data containing no zeros.
+        BOOST_CHECK_EQUAL(std::get<0>(clean_on), std::get<0>(clean_off));
+        BOOST_CHECK(std::get<1>(clean_on) == false);
+        // A zero-free head records its real total credit either side of the gate.
+        BOOST_CHECK(std::get<3>(clean_off).has_value());
+        BOOST_CHECK_EQUAL(*std::get<3>(clean_off), base + step * (len - 1));
+        BOOST_CHECK(std::get<3>(clean_on) == std::get<3>(clean_off));
+    }
+
+    // --- Transit at j == 40: the TC_40 endpoint. Pre-gate this collapses WAS and spuriously greylists.
+    {
+        auto seq = healthy();
+        seq[at_j(40)] = std::optional<uint64_t>(0);
+
+        const auto pre  = run(seq, false);
+        BOOST_CHECK(std::get<0>(pre) < 0.1);          // WAS collapsed below the threshold
+        BOOST_CHECK(std::get<1>(pre) == true);        // -> spurious greylist (the defect)
+
+        const auto post = run(seq, true);
+        BOOST_CHECK(std::get<0>(post) > 0.5);         // WAS computed from the real history
+        BOOST_CHECK(std::get<1>(post) == false);      // -> no spurious greylist
+    }
+
+    // --- Transit at j == 7: the TC_7 endpoint. Pre-gate this inflates WAS instead, which MASKS a
+    // --- genuine greylist rather than causing a spurious one.
+    {
+        auto seq = healthy();
+        seq[at_j(7)] = std::optional<uint64_t>(0);
+
+        const auto pre  = run(seq, false);
+        BOOST_CHECK(std::get<0>(pre) > 100.0);        // absurdly inflated short average
+
+        const auto post = run(seq, true);
+        BOOST_CHECK(std::get<0>(post) < 2.0);         // back to a sane ratio
+        BOOST_CHECK(std::get<1>(post) == false);
+    }
+
+    // --- Transit at j == 0: the head/baseline. This position is seeded through the parameterized
+    // --- GreylistCandidateEntry constructor and never passes through the update path, so it needs its
+    // --- own normalization; without it a zero would be treated as missing everywhere EXCEPT the head,
+    // --- which is the position it does the most damage from (it becomes m_TC_initial_bookmark, and no
+    // --- historical total credit exceeds zero, so every WAS delta is skipped).
+    {
+        auto seq = healthy();
+        seq[at_j(0)] = std::optional<uint64_t>(0);
+
+        const auto pre  = run(seq, false);
+        BOOST_CHECK_EQUAL(std::get<0>(pre), 0.0);     // WAS fully collapsed
+        BOOST_CHECK(std::get<1>(pre) == true);        // -> spurious greylist
+
+        const auto post = run(seq, true);
+        BOOST_CHECK(std::get<0>(post) > 0.5);         // WAS from the real history
+        BOOST_CHECK(std::get<1>(post) == false);
+
+        // Normalizing the bookmark must not erase the evidence. The head zero is still what
+        // getautogreylist show_history reports, on BOTH sides of the gate, even though post-gate
+        // the WAS is computed as though it were missing. Regression pin for the baseline
+        // constructor recording the (normalized) BOOKMARK rather than the RECORDED value -- the
+        // one position where the update path's recorded_total_credit does not apply.
+        BOOST_CHECK(std::get<3>(pre).has_value());
+        BOOST_CHECK_EQUAL(*std::get<3>(pre), 0);
+        BOOST_CHECK(std::get<3>(post).has_value());
+        BOOST_CHECK_EQUAL(*std::get<3>(post), 0);
+    }
+
+    // --- A genuinely all-zero project must STILL be greylisted. Pinned as an invariant.
+    // ---
+    // --- Read the limits of this case honestly: it does NOT discriminate. An all-zero history is
+    // --- greylisted under the unpatched code (WAS pinned at 0), under this fix (ZCD via the "no
+    // --- statistics" arm), and under the WAS-branch-only variant too -- with an all-zero history
+    // --- that variant still reaches ZCD through `total_credit >= m_TC_bookmark` (0 >= 0) rather
+    // --- than through `!total_credit`. So this asserts an invariant worth holding, not evidence
+    // --- for normalizing at the top rather than in the WAS branch. That design choice is not
+    // --- expressible as a unit test, because the alternative is not a code path that exists; the
+    // --- argument for it is in the comment at the normalization site.
+    {
+        std::vector<std::optional<uint64_t>> all_zero(len, std::optional<uint64_t>(0));
+
+        const auto post = run(all_zero, true);
+        BOOST_CHECK(std::get<2>(post) > 7);           // ZCD accrued past the threshold
+        BOOST_CHECK(std::get<1>(post) == true);       // -> greylisted
+    }
+
+    // --- Credit ROLLBACKS. Two shapes, and they behave differently -- the earlier version of this
+    // --- case tested only the first and was therefore tautological (no zero in the fixture means
+    // --- the gate predicate never fires, so both runs execute identical code and the assertion
+    // --- could not fail whether the fix was present, reverted, or broken).
+
+    // Shape 1 -- rollback to a NON-ZERO value. The gate cannot touch this: the predicate requires
+    // exactly zero. Walking backward it fails the "initial bookmark > total_credit" guard and stays
+    // penalized by omission, identically either side of the gate. Asserted to pin that the gate is
+    // inert here, while acknowledging it is a no-op check by construction.
+    {
+        auto seq = healthy();
+        seq[at_j(40)] = std::optional<uint64_t>(base + step * at_j(40) - step * 10);
+
+        const auto pre  = run(seq, false);
+        const auto post = run(seq, true);
+        BOOST_CHECK_EQUAL(std::get<0>(post), std::get<0>(pre));
+        BOOST_CHECK(std::get<1>(post) == std::get<1>(pre));
+    }
+
+    // Shape 2 -- rollback to EXACTLY zero. This one the gate DOES change, and the change is
+    // accepted rather than incidental, so it is pinned rather than left to be discovered. Pre-gate
+    // the zero passes the guard maximally and collapses WAS; post-gate it is treated as missing and
+    // WAS is computed from real history. At the point of observation a hard reset to zero is
+    // byte-identical to the corruption signature, so nothing remains to discriminate on -- and a
+    // sustained reset is still caught via ZCD (see the all-zero case above).
+    {
+        auto seq = healthy();
+        seq[at_j(40)] = std::optional<uint64_t>(0);   // revocation all the way to zero
+
+        const auto pre  = run(seq, false);
+        BOOST_CHECK(std::get<0>(pre) < 0.1);          // WAS collapsed
+        BOOST_CHECK(std::get<1>(pre) == true);        // -> greylisted pre-gate
+
+        const auto post = run(seq, true);
+        BOOST_CHECK(std::get<0>(post) > 0.5);         // treated as missing data
+        BOOST_CHECK(std::get<1>(post) == false);      // -> NOT greylisted post-gate (accepted)
+    }
 }
 
 //!
@@ -2155,16 +2464,20 @@ BOOST_AUTO_TEST_CASE(it_does_not_throw_when_the_40SB_average_truncates_to_zero)
     //
     // Drive the candidate through the public UpdateGreylistCandidateEntry path (which
     // itself calls GetWAS() internally) so this reproduces the exact production code path.
-    GRC::AutoGreylist::GreylistCandidateEntry candidate("TestProject", std::optional<uint64_t>(1000));
+    // Effective and recorded baseline credit are the same here: this case drives the WAS
+    // division guard, not the zero normalization (it passes zero_credit_is_missing=false).
+    GRC::AutoGreylist::GreylistCandidateEntry candidate("TestProject",
+                                                        std::optional<uint64_t>(1000),
+                                                        std::optional<uint64_t>(1000));
 
     // sb_from_baseline = 7, total credit 990: 7-SB delta = 1000 - 990 = 10 -> m_TC_7_SB_sum = 10.
-    candidate.UpdateGreylistCandidateEntry(990, 7, false);
+    candidate.UpdateGreylistCandidateEntry(990, 7, false, /*zero_credit_is_missing=*/false);
 
     // sb_from_baseline = 40, total credit 970: 40-SB delta = 1000 - 970 = 30 -> m_TC_40_SB_sum = 30,
     // m_sb_from_baseline_processed = 40. GetWAS() (called inside UpdateGreylistCandidateEntry) then
     // computes TC_7_SB_avg = 10 / min(40,7) = 10/7 = 1 (non-zero) and
     // TC_40_SB_avg = 30 / min(40,40) = 30/40 = 0 (integer truncation) -- the crash trigger.
-    BOOST_REQUIRE_NO_THROW(candidate.UpdateGreylistCandidateEntry(970, 40, false));
+    BOOST_REQUIRE_NO_THROW(candidate.UpdateGreylistCandidateEntry(970, 40, false, /*zero_credit_is_missing=*/false));
 
     // A zero 40-SB average means negligible long-term work availability, so WAS = 0.0.
     BOOST_CHECK(candidate.GetWAS() == Fraction(0));


### PR DESCRIPTION
## Problem

`AutoGreylistTotalCreditFixHeight` (#3102) stopped the scraper **emitting** a spurious zero project total credit for a project whose statistics export yielded no usable records. It could not do anything about the zeros already written into the superblock chain, which are permanent — and being an emit-side fix it is forward-only, so those keep corrupting the WAS window as they walk backward through it. It also, by design, still emits a *legitimately* scraped zero (`no_records == false`), so chain-resident zeros are not a closed historical set.

`m_TC_7_SB_sum` and `m_TC_40_SB_sum` are **assignments, not accumulations** — each is a single endpoint difference from the head bookmark — so one bad endpoint is diluted by nothing. A single chain-resident zero therefore produces three distinct events as it transits the window:

| position | effect |
|---|---|
| `j == 40` | the 40-SB sum becomes the project's **entire lifetime credit**, inflating the long average ~100× and collapsing WAS → **spurious greylist** |
| `j <= 7` | the short average is inflated instead, pushing WAS far above the threshold → **masks** a greylist that should fire |
| `j == 0` | it becomes `m_TC_initial_bookmark`, and no historical total credit exceeds zero, so **every** WAS delta is skipped → WAS collapses to 0 |

### Observed on mainnet

World Community Grid was spuriously greylisted on **2026-08-06** by a zero recorded in superblock **4012957** on **2026-06-27** — exactly 40 superblocks earlier. It had already fired once as the head on 06-27. Reconstructing the entire v3 window, those two events are the **only** head positions in it that meet the criteria, and both trace to that one datapoint.

The greylist held for ~24h. The superblock built inside that window moved network average magnitude by **+8.13** against ±0.4 daily noise.

## Change

Normalize a recorded total credit of exactly zero to `nullopt` at **both** positions it can enter the candidate:

- **In `UpdateGreylistCandidateEntry`, once at the top** rather than at each use. This is load-bearing: every consumer keys off `total_credit` having a value, so one normalization reaches the WAS delta guard, the ZCD "no statistics" arm and the bookmark update together. Guarding the WAS branch *alone* would stop the spurious collapse but leave a genuinely zero project incrementing no ZCD and no longer collapsing WAS — invisible to both routes and permanently un-greylistable.
- **At the baseline construction in `RefreshWithSuperblock`.** The head (`sb_from_baseline == 0`) is seeded through the parameterized `GreylistCandidateEntry` constructor and never passes through the update path, so without this a zero would be treated as missing at every position *except* the head — the position it does the most damage from.

The zero **as actually recorded** still goes into the update history, so `getautogreylist show_history` keeps showing the corruption rather than hiding it.

### Rollback interaction — stated precisely, because the obvious phrasing is wrong

A rollback to a **non-zero** value fails the `initial bookmark > total_credit` guard and stays penalized by omission, untouched here. A rollback to **exactly zero** passes that guard and *is* suppressed. That is accepted rather than incidental: at the point of observation it is byte-identical to the corruption signature, so nothing remains to discriminate on, and a sustained reset is still caught via ZCD within about eight superblocks. Both shapes are pinned by tests.

### Also fixed

`GreylistCandidateEntry`'s trivial constructor initialized `m_TC_initial_bookmark` and `m_TC_bookmark` to **engaged** optionals holding zero rather than `nullopt` — default-constructing straight into the corrupt state, unrescuable by any gate. Latent today (`RefreshWithSuperblock` only uses the parameterized constructor), but it is a public nested type used as a `std::map` value, so one `operator[]` or `try_emplace` lands there with no diagnostic.

## Gate

`AutoGreylistRedesignHeight` / `-autogreylistredesignheight`. Main and testnet `INT_MAX` (inert), regtest `0`.

Deliberately **one** gate for the whole remaining AutoGreylist correctness batch rather than one per change — they activate together in the release, a partial combination is a configuration nobody tests, and every additional height override is another chance to fork the isolated mesh by omission. It is its own field only so it can be driven independently during testing; **the release sets it coincident with `BlockV15Height`**.

It does **not** ride `AutoGreylistTotalCreditFixHeight`: the isolated mesh set that to 2800000 and crossed it long ago, so reusing it would activate this at redeploy rather than at the v15 boundary.

**Constraint, documented at the field:** never set below `AutoGreylistDeepCopyHeight`. Before that gate the `Snapshot` overlay only ever promotes to `AUTO_GREYLISTED` and has no demotion arm, so a spuriously greylisted project cannot heal. Co-activation satisfies it, and `ReinitFromDisk` already runs before `Refresh()` in `Quorum::PushSuperblock`.

`zero_credit_is_missing` is **not defaulted** — a silent default meaning "pre-fix interpretation" on a consensus path is a footgun, and the neighbouring `use_benefit_of_doubt` is not defaulted either.

### This gate differs in kind from the other v15 gates

The others are forward-only — they change what is produced from the gate onward. This one changes **how data already in the chain is interpreted**. The reinterpretation lands at the first superblock at or after the activation height, not immediately, since `AutoGreylist::Refresh()` runs only at superblock push/pop/load. Superblock construction and validation both go through the tip-anchored `RefreshWithAndUpdateSuperblock`, so they agree with each other; read paths such as `getautogreylist` can transiently show the pre-gate answer in between.

## Testing

New `Whitelist/chain_resident_zero_total_credit_does_not_corrupt_was` covers all four transits (`j = 0, 7, 40`, plus a clean control asserting the gate is a no-op on zero-free data), both rollback shapes, and the all-zero project.

**Verified red without the fix and green with it.** Neutering *only* the baseline normalization fails exactly the `j == 0` pair, confirming that position is genuinely covered rather than incidentally passing.

Both this case and the sibling `no_records_zero_baseline_does_not_collapse_was` now reset the shared singletons on exit and **clear** the height override rather than re-pinning it, so both pass in isolation under `--run_test=` filtering. Previously they only passed because the next case in file order happened to reset first.

Full unit suite **1147/1147 cases, 465,307/465,307 assertions**, 0 warnings; `lint-all.sh` clean with `COMMIT_RANGE` set.

## Docs

Corrected in the same change, since some of it is currently wrong:

- `doc/consensus.md` — the activation table omitted **all three** sibling greylist heights and listed `AutoGreylistAuditHeight` as *not yet activated* when mainnet has it at **3,989,800 and crossed**. Section 9.6 now describes each gate and the mesh-vs-mainnet sequencing difference.
- `doc/automated_greylisting_design_highlights.md` — the stale 2-parameter `UpdateGreylistCandidateEntry` signature, both gate flags, and the endpoint-difference property of the WAS sums.
- The two `// [Changed] Pass use_benefit_of_doubt` call-site markers, which no longer described the call.

## Relationship to the AutoGreylist redesign

This lands the normalization as a gated branch inside the current walker. A redesign is in progress that separates the **pending** (candidate/tip-anchored) greylist state from the **authoritative** (committed-superblock) state as a v1/v2 class fork, and under it this normalization moves into V2's walker where it needs no flag at all — V2 is post-gate by construction. The gate scaffolding added here is exactly the dispatch that fork requires, so it lands early rather than being thrown away; the interleaved branch is deleted with V1.

Two findings from this work that the redesign addresses rather than this PR:

- **ZCD placement shifts one superblock** when a zero takes the NA path — count-neutral except at exactly `j == 20`, where the pre-gate ZCD fell outside the 20-superblock window and the post-gate one does not (0 → 1).
- **The interval contracts but the divisor does not.** `m_sb_from_baseline_processed` advances unconditionally while the sum assignments are skipped, so a dropped endpoint understates WAS (~14% on a uniform history for a single skip). This is **pre-existing** for projects simply absent from a superblock; this change routes a new input class into it rather than creating it.

Both are recorded in the design highlights and belong to the walker-correctness pass behind the same gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
