### PR TITLE
ci: set an explicit build type for the ARM64 and ARMhf cross jobs

### DIFF
--- a/.github/workflows/cmake_compatibility.yml
+++ b/.github/workflows/cmake_compatibility.yml
@@ -157,6 +157,10 @@ jobs:
 
       - name: Configure CMake (Cross)
         run: |
+          # Set an explicit build type. With none, CMake emits no -O flag and
+          # the tree is compiled unoptimised; every other job in CI sets one.
+          # The cost lands hardest here because ctest runs under emulation, so
+          # the unoptimised code is also the slowest code to execute.
           cmake -B build_arm64 -GNinja \
             -DCMAKE_SYSTEM_NAME=Linux \
             -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
@@ -168,6 +172,7 @@ jobs:
             -DUSE_QT6=ON \
             -DQt6_DIR=/usr/lib/aarch64-linux-gnu/cmake/Qt6 \
             -DENABLE_TESTS=ON \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
             -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/qemu-aarch64-static \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -243,6 +248,10 @@ jobs:
 
       - name: Configure CMake (Cross)
         run: |
+          # Set an explicit build type. With none, CMake emits no -O flag and
+          # the tree is compiled unoptimised; every other job in CI sets one.
+          # The cost lands hardest here because ctest runs under emulation, so
+          # the unoptimised code is also the slowest code to execute.
           cmake -B build_armhf -GNinja \
             -DCMAKE_SYSTEM_NAME=Linux \
             -DCMAKE_SYSTEM_PROCESSOR=arm \
@@ -252,6 +261,7 @@ jobs:
             -DCMAKE_SYSROOT=/ \
             -DQt6_DIR=/usr/lib/arm-linux-gnueabihf/cmake/Qt6 \
             -DENABLE_TESTS=ON \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
             -DENABLE_GUI=ON \
             -DUSE_QT6=ON \
             -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/qemu-arm-static \


### PR DESCRIPTION
## Problem

The two cross-compile jobs in `cmake_compatibility.yml` configure without `CMAKE_BUILD_TYPE`. CMake then emits no `-O` flag, so both trees are built **unoptimised**.

Nothing else in CI is in that state:

| configure | build type |
|---|---|
| `cmake_compatibility.yml` native job | `-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}` |
| `cmake_compatibility.yml` **ARM64 cross** | **none** |
| `cmake_compatibility.yml` **ARMhf cross** | **none** |
| `cmake_production.yml` ARM64 cross | `-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}` |
| all `cmake_multiprocess.yml` jobs | `BUILD_TYPE=${{ env.BUILD_TYPE }}` to `build_targets.sh` |

The workflow already declares `BUILD_TYPE: RelWithDebInfo` and the native job in the same file already consumes it — the two cross blocks simply never referenced it.

These are also the only configures in the repo combining an absent build type with `ENABLE_TESTS=ON` **and** execution under a QEMU emulator, so the unoptimised code is also the slowest code to execute. `cmake_production.yml`'s cross block sets `ENABLE_TESTS=OFF`, so it never paid the cost, which is why this stayed invisible.

## Impact

On ARM64 this dominates the job — `gridcoin_tests` alone accounts for 15281s of its ~5h wall clock (run `32867524403`).

Measured by running the job locally through `contrib/devtools/run-local-ci.sh` with the build type applied:

```
gridcoin_tests, ARM64, -O0, GitHub runner        15281.43s
gridcoin_tests, ARM64, RelWithDebInfo, local       136.96s
```

The suite is registered `RUN_SERIAL` and is effectively single-threaded, so the local machine's core count does not enter into it — only single-thread performance differs, and that is well within 2x. The ~112x gap is far too large to attribute to hardware.

ARMhf carries the same defect and is fixed the same way, though its absolute cost is smaller (665s for `gridcoin_tests` on the same run).

## Change

Pass the workflow's existing `BUILD_TYPE` in both cross blocks, matching the native job. The explanatory comment is placed *before* the `cmake` invocation deliberately: inside a backslash line-continuation a `#` line would swallow the continuation.

## Notes for review

- **Asserts are unaffected.** `CMakeLists.txt` adds `-UNDEBUG` unconditionally for non-MSVC compilers, so `RelWithDebInfo` does not define `NDEBUG` and the suite keeps the assertions it has today. The local run passed 2/2 with the build type applied.
- **`_FORTIFY_SOURCE` becomes active** for these two jobs. The hardening block deliberately skips it when no build type is set, precisely because it "warns on every translation unit while checking nothing" at `-O0`. Supplying a build type puts these jobs on the same footing as the rest of CI rather than changing the intended policy.
- **First run rebuilds cold**, as the changed flags invalidate the ccache entries. Optimisation did not measurably slow the compile: 518/518 objects in about four minutes locally.

## Not addressed here

The cross builds skip `functional_tests` entirely — `CMakeLists.txt` guards registration on `if(NOT CMAKE_CROSSCOMPILING)`. So there is currently no functional-test coverage on any non-x86-64 architecture or on 32-bit. That is a separate question, but it was never going to be affordable on top of a job in this state.
