### PR TITLE
test: make the -devsyntheticcoins group addresses distinct

### DIFF
--- a/src/interfaces/wallet_coin_source.h
+++ b/src/interfaces/wallet_coin_source.h
@@ -171,10 +171,13 @@ std::shared_ptr<WalletCoinSource> MakeWalletCoinSource(CWallet* wallet);
 //! scan is replaced by the synthetic seed), every windowing, epoch/floor and
 //! selection-mirror semantic the production dialog exercises is exercised
 //! here too, at whatever scale the argument requests -- on both axes: the
-//! group addresses are distinct for every <groups>, so a large group count
-//! produces a correspondingly large directory. Group 0 receives the bulk of
-//! the coins (the pathological single-address case); the remaining groups
-//! get up to 1000 each, falling to an even split as <groups> grows.
+//! group addresses are distinct for every <groups>, AND <groups> is clamped
+//! to <total_coins>, so the directory holds exactly <groups> rows. Both are
+//! needed: injective addresses alone do not give a row to a group that seeded
+//! no records, which is what a group count above the coin count would ask
+//! for. Group 0 receives the bulk of the coins (the pathological
+//! single-address case); the remaining groups get up to 1000 each, falling to
+//! an even split as <groups> grows, and to 1 apiece at the clamp.
 //!
 //! Limits vs production: the summary labels read 0 (computeCoinControlSummary
 //! resolves outpoints against the real wallet), and there is no live mutation

--- a/src/interfaces/wallet_coin_source.h
+++ b/src/interfaces/wallet_coin_source.h
@@ -170,9 +170,11 @@ std::shared_ptr<WalletCoinSource> MakeWalletCoinSource(CWallet* wallet);
 //! Because the REAL store, views and queue are underneath (only the wallet
 //! scan is replaced by the synthetic seed), every windowing, epoch/floor and
 //! selection-mirror semantic the production dialog exercises is exercised
-//! here too, at whatever scale the argument requests. Group 0 receives the
-//! bulk of the coins (the pathological single-address case); the remaining
-//! groups get 1000 each.
+//! here too, at whatever scale the argument requests -- on both axes: the
+//! group addresses are distinct for every <groups>, so a large group count
+//! produces a correspondingly large directory. Group 0 receives the bulk of
+//! the coins (the pathological single-address case); the remaining groups
+//! get up to 1000 each, falling to an even split as <groups> grows.
 //!
 //! Limits vs production: the summary labels read 0 (computeCoinControlSummary
 //! resolves outpoints against the real wallet), and there is no live mutation

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -185,7 +185,8 @@ static void SetupUIArgs(ArgsManager& argsman)
                    ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-devsyntheticcoins=<n>[:<groups>]",
                    "DEV ONLY: substitute a synthetic coin-control source with <n> coins over "
-                   "<groups> address groups (default groups: 3) for windowed-model testing",
+                   "<groups> address groups (<groups> is clamped to <n>; default groups: 3) "
+                   "for windowed-model testing",
                    ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-showorphans", "Include stale (orphaned) coinstake transactions in the transaction list",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/test/qt_walletcoinstore_tests.cpp
+++ b/src/test/qt_walletcoinstore_tests.cpp
@@ -14,6 +14,8 @@
 #include <wallet/walletcoinstore.h>
 #include <wallet/wallet_event_queue.h>
 
+#include <interfaces/wallet_coin_source.h>
+
 #include <arith_uint256.h>
 #include <uint256.h>
 
@@ -21,6 +23,7 @@
 
 #include <chrono>
 #include <climits>
+#include <set>
 #include <string>
 #include <thread>
 #include <vector>
@@ -461,6 +464,35 @@ BOOST_AUTO_TEST_CASE(cleanShutdownWithPendingIntake)
         h.store.enqueueUpsert(h1, {makeCoin(h1, 0, 300, "A")}, false);
     }
     // ~Harness runs ~WalletCoinStore with a possibly non-empty intake.
+}
+
+BOOST_AUTO_TEST_CASE(syntheticHarnessGroupsAreDistinctPerRequestedGroup)
+{
+    // -devsyntheticcoins=<n>:<groups> advertises n coins "spread over <groups>
+    // addresses" (interfaces/wallet_coin_source.h). That contract is only met
+    // if the generated group addresses are injective: WalletCoinStore groups
+    // by group_address, so any aliasing silently folds the directory down and
+    // caps the many-groups axis the harness exists to exercise. A single
+    // letter mod 26 used to cap it at 27 groups no matter what was asked for,
+    // which is why both scales below straddle that boundary.
+    for (const int groups : {30, 500}) {
+        const int total = 5000;
+        auto source = interfaces::MakeSyntheticCoinSource(total, groups);
+        BOOST_REQUIRE(source != nullptr);
+
+        const std::vector<GRC::CoinGroupInfo> dir = source->getGroupDirectory();
+        BOOST_CHECK_EQUAL(static_cast<int>(dir.size()), groups);
+
+        // Injective, and the seeded coins are all still accounted for.
+        std::set<std::string> addresses;
+        int counted = 0;
+        for (const GRC::CoinGroupInfo& g : dir) {
+            addresses.insert(g.address);
+            counted += g.output_count;
+        }
+        BOOST_CHECK_EQUAL(static_cast<int>(addresses.size()), groups);
+        BOOST_CHECK_EQUAL(counted, total);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_walletcoinstore_tests.cpp
+++ b/src/test/qt_walletcoinstore_tests.cpp
@@ -475,7 +475,11 @@ BOOST_AUTO_TEST_CASE(syntheticHarnessGroupsAreDistinctPerRequestedGroup)
     // caps the many-groups axis the harness exists to exercise. A single
     // letter mod 26 used to cap it at 27 groups no matter what was asked for,
     // which is why both scales below straddle that boundary.
-    for (const int groups : {30, 500}) {
+    // 5000 is not shortfall coverage -- at groups == total the directory
+    // already reaches <groups> rows without the clamp. It is an off-by-one
+    // guard on the clamp BOUND: it is the only input here that fails against a
+    // mutated std::min(groups, total_coins - 1).
+    for (const int groups : {30, 500, 5000}) {
         const int total = 5000;
         auto source = interfaces::MakeSyntheticCoinSource(total, groups);
         BOOST_REQUIRE(source != nullptr);
@@ -493,6 +497,38 @@ BOOST_AUTO_TEST_CASE(syntheticHarnessGroupsAreDistinctPerRequestedGroup)
         BOOST_CHECK_EQUAL(static_cast<int>(addresses.size()), groups);
         BOOST_CHECK_EQUAL(counted, total);
     }
+}
+
+BOOST_AUTO_TEST_CASE(syntheticHarnessClampsGroupsToTheCoinCount)
+{
+    // Distinct addresses are not enough on their own. small_group is
+    // total_coins / groups, an integer division, so a group count above the
+    // coin count used to leave every non-whale group with zero records --
+    // and a group with no records never becomes a directory row, however
+    // unique its address is. -devsyntheticcoins=5000:6000 built a one-row
+    // directory and logged 6000 groups: the same silent shortfall the
+    // aliasing case above is about, one regime over.
+    //
+    // Asserted against `total`, deliberately NOT against `groups`: the
+    // contract post-clamp is a group per coin, which is the most that can be
+    // seeded. Checking dir.size() == groups here would fail by construction.
+    const int total = 5000;
+    const int groups = 6000;
+
+    auto source = interfaces::MakeSyntheticCoinSource(total, groups);
+    BOOST_REQUIRE(source != nullptr);
+
+    const std::vector<GRC::CoinGroupInfo> dir = source->getGroupDirectory();
+    BOOST_CHECK_EQUAL(static_cast<int>(dir.size()), total);
+
+    std::set<std::string> addresses;
+    int counted = 0;
+    for (const GRC::CoinGroupInfo& g : dir) {
+        addresses.insert(g.address);
+        counted += g.output_count;
+    }
+    BOOST_CHECK_EQUAL(static_cast<int>(addresses.size()), total);
+    BOOST_CHECK_EQUAL(counted, total);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/synthetic_coin_source.cpp
+++ b/src/wallet/synthetic_coin_source.cpp
@@ -138,9 +138,25 @@ SyntheticCoinSourceImpl::SyntheticCoinSourceImpl(int total_coins, int groups)
     total_coins = std::max(total_coins, 1);
     groups = std::max(groups, 1);
 
+    // CLAMP to <total_coins>. Injective addresses are necessary for the
+    // directory to reach <groups> rows, but not sufficient: small_group is an
+    // integer division, so once <groups> exceeds <total_coins> it is 0, every
+    // non-whale group seeds no records, and buildGroups() -- which only ever
+    // sees records -- never gives them a row. -devsyntheticcoins=100:500 built
+    // a ONE-row directory and reported 500.
+    //
+    // That is the same silent shortfall as the aliasing bug below, one regime
+    // over, so it is fixed the same way: by making the advertised contract
+    // true rather than by reporting its violation. A group count above the
+    // coin count has no meaning here -- there are not enough coins to put one
+    // in each group -- so clamping loses nothing.
+    const int requested_groups = groups;
+    groups = std::min(groups, total_coins);
+
     // Group 0 is the pathological single-address case; the rest get up to
     // 1000 coins each, falling to an even split once <groups> is large
-    // relative to <total_coins> (and to 1 apiece when they are equal).
+    // relative to <total_coins> (and to 1 apiece when they are equal, which
+    // post-clamp is the floor: small_group is now always >= 1).
     const int small_group = std::min(1000, total_coins / std::max(groups, 1));
     const int whale = total_coins - (groups - 1) * small_group;
 
@@ -179,6 +195,14 @@ SyntheticCoinSourceImpl::SyntheticCoinSourceImpl(int total_coins, int groups)
 
     m_store.seedSynthetic(std::move(records), /*tip_height=*/300000);
 
+    if (requested_groups != groups) {
+        LogPrintf("SyntheticCoinSource: clamped %d requested groups to %d, the coin count "
+                  "(a group per coin is the most that can be seeded)",
+                  requested_groups, groups);
+    }
+
+    // Reports the shape actually seeded: <groups> is the clamped value, so
+    // this line can no longer advertise a directory the store does not hold.
     LogPrintf("SyntheticCoinSource: seeded %d coins over %d groups (whale group: %d)",
               total_coins, groups, whale);
 }

--- a/src/wallet/synthetic_coin_source.cpp
+++ b/src/wallet/synthetic_coin_source.cpp
@@ -7,6 +7,7 @@
 #include "amount.h"
 #include "arith_uint256.h"
 #include "logging.h"
+#include "tinyformat.h"
 #include "wallet/wallet_event_queue.h"
 #include "wallet/walletcoinstore.h"
 
@@ -137,8 +138,9 @@ SyntheticCoinSourceImpl::SyntheticCoinSourceImpl(int total_coins, int groups)
     total_coins = std::max(total_coins, 1);
     groups = std::max(groups, 1);
 
-    // Group 0 is the pathological single-address case; the rest get 1000
-    // coins each (or an even split when the total is small).
+    // Group 0 is the pathological single-address case; the rest get up to
+    // 1000 coins each, falling to an even split once <groups> is large
+    // relative to <total_coins> (and to 1 apiece when they are equal).
     const int small_group = std::min(1000, total_coins / std::max(groups, 1));
     const int whale = total_coins - (groups - 1) * small_group;
 
@@ -147,10 +149,16 @@ SyntheticCoinSourceImpl::SyntheticCoinSourceImpl(int total_coins, int groups)
 
     int seed = 0;
     for (int g = 0; g < groups; ++g) {
+        // The group index is rendered in full, zero-padded to the same
+        // 34-character width as the whale address. It has to stay
+        // injective: an aliasing scheme (a single letter mod 26, say)
+        // collapses the directory onto 26 addresses no matter what
+        // <groups> asks for, because buildGroups() keys on group_address
+        // -- which silently caps the many-groups axis this harness exists
+        // to exercise.
         const std::string address = (g == 0)
             ? std::string("SynthWhale000000000000000000000000")
-            : std::string("SynthGroup") + std::string(1, static_cast<char>('A' + (g - 1) % 26))
-                  + "00000000000000000000000";
+            : strprintf("SynthGroup%024d", g);
         const int count = (g == 0) ? whale : small_group;
         for (int i = 0; i < count; ++i, ++seed) {
             GRC::CoinRecord r;


### PR DESCRIPTION
The `-devsyntheticcoins=<n>[:<groups>]` dev harness advertises `<n>` coins "spread over `<groups>` addresses" — `interfaces/wallet_coin_source.h:166-168`, and the arg help at `bitcoin.cpp:186-189`. It could not deliver that: each group address was derived as

```cpp
std::string("SynthGroup") + std::string(1, static_cast<char>('A' + (g - 1) % 26)) + "000...";
```

so every `g >= 27` aliased back onto `'A'`. `r.group_address = address` (`synthetic_coin_source.cpp:163`) and `buildGroups` keys `m_groups[r.group_address]` (`coinviews.cpp:176`), so the store saw **at most 27 groups** no matter what was requested.

Nothing clamps in between — `ParseInt32` (`bitcoin.cpp:1440-1445`) is unbounded and `seedSynthetic` moves the records in verbatim — so the shortfall was silent, and the log line at `:174-175` reported the requested count regardless. `-devsyntheticcoins=50000:20000` seeded a whale of 10002 plus 26 groups of ~1538 and logged "seeded 50000 coins over 20000 groups".

The consequence is that the many-groups axis the #3183 acceptance harness documents has never been exercisable. It surfaced while measuring #3228 item 2, which names exactly that shape as its first step.

## Change

Render the group index in full, zero-padded to the same 34-character width as the whale address, so the mapping is injective. `git grep SynthGroup` has one hit, so nothing depended on the letter shape.

Also corrects two stale statements that the old behaviour made wrong: the header contract, and the "the remaining groups get 1000 each" comment (`small_group` is `min(1000, total/groups)`, so it falls to an even split as `<groups>` grows, and to 1 apiece when they are equal).

## Test

New case in `qt_walletcoinstore_tests` pins the directory size and address injectivity at 30 and 500 groups — both across the old 27 ceiling — and checks the seeded coins are all still accounted for. Against the previous code it reports:

```
check static_cast<int>(dir.size()) == groups has failed [27 != 30]
check static_cast<int>(dir.size()) == groups has failed [27 != 500]
```

https://claude.ai/code/session_01Q5mqyoeyLygRtQTmUqPTTg
