### PR TITLE
miner: restore the -mintxfee floor and stop aborting block assembly on one transaction

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1617,6 +1617,12 @@ bool AppInit2(ThreadHandlerPtr threads)
         // option managed to be ignored for years.
         CAmount fee_rate = 0;
 
+        // The fee_rate < 0 arm is defensive depth, not a reachable branch:
+        // ParseMoney stops at the first non-digit (util.cpp), so a leading '-'
+        // fails the parse outright and it cannot return true with a negative.
+        // It is kept so the guard stays correct if ParseMoney ever learns to
+        // accept a sign -- but the negative case in mining_fee_policy.py is
+        // pinning the PARSE failure, not this check.
         if (!ParseMoney(gArgs.GetArg("-mintxfee", ""), fee_rate) || fee_rate < 0) {
             return InitError(strprintf(_("Invalid amount for -mintxfee=<amount>: '%s'"),
                                        gArgs.GetArg("-mintxfee", "")));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -653,7 +653,7 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-paytxfee=<amt>", "Fee per KB to add to transactions you send",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-mintxfee=<amt>", "Minimum transaction fee for transactions you send or process (default: 0.001 GRC)",
+    argsman.AddArg("-mintxfee=<amt>", "Minimum fee rate, per KB, a transaction must pay to be included in a block this node stakes (default: 0.001 GRC). Does not affect transactions you send; use -paytxfee for that.",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-mininput=<amt>", "When creating transactions, ignore inputs with value less than this (default: 0.01)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1609,6 +1609,27 @@ bool AppInit2(ThreadHandlerPtr threads)
             InitWarning(_("Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction."));
     }
 
+    if (gArgs.IsArgSet("-mintxfee"))
+    {
+        // Parse into a local: ParseMoney leaves its out-param untouched on
+        // failure, so parsing straight into nMinerMinTxFee would silently keep
+        // the "unset" sentinel and fall back to the default -- which is how this
+        // option managed to be ignored for years.
+        CAmount fee_rate = 0;
+
+        if (!ParseMoney(gArgs.GetArg("-mintxfee", ""), fee_rate) || fee_rate < 0) {
+            return InitError(strprintf(_("Invalid amount for -mintxfee=<amount>: '%s'"),
+                                       gArgs.GetArg("-mintxfee", "")));
+        }
+
+        nMinerMinTxFee = fee_rate;
+
+        if (nMinerMinTxFee > 0.25 * COIN) {
+            InitWarning(_("Warning: -mintxfee is set very high! Transactions paying less than "
+                          "this per KB will be left out of blocks this node stakes."));
+        }
+    }
+
     fConfChange = gArgs.GetBoolArg("-confchange", false);
     fEnforceCanonical = gArgs.GetBoolArg("-enforcecanonical", true);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -553,7 +553,7 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
         }
 
         int nBlockSigOps = 100;
-    unsigned int nMinTxFeeRejected = 0;
+        unsigned int nMinTxFeeRejected = 0;
 
         std::make_heap(vecPriority.begin(), vecPriority.end());
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -45,6 +45,7 @@ using namespace std;
 //
 
 unsigned int nMinerSleep;
+CAmount nMinerMinTxFee = -1;  // -1: -mintxfee unset, use GetBaseFee
 
 // Development-build staking cripple; see miner.h. Extracted from the former
 // util.h global. Set from init (AppInit2 devbuild/testnet gating).
@@ -387,9 +388,15 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
     // a transaction spammer can cheaply fill blocks using
     // 0-satoshi-fee transactions. It should be set above the real
     // cost to you of processing a transaction.
-    int64_t nMinTxFee = GetBaseFee(CTransaction(mtxCoinbase));
-    if (gArgs.IsArgSet("-mintxfee"))
-        ParseMoney(gArgs.GetArg("-mintxfee", "dummy"), nMinTxFee);
+    //
+    // When -mintxfee is unset the floor is GetBaseFee of the COINBASE, not of
+    // each candidate. That is only equivalent because AcceptToMemoryPool
+    // rejects nVersion < 2, so every mempool transaction carries the same x10
+    // multiplier the default-constructed coinbase does. If that ever stops
+    // holding, take the base fee per candidate instead.
+    int64_t nMinTxFee = nMinerMinTxFee >= 0
+            ? nMinerMinTxFee
+            : GetBaseFee(CTransaction(mtxCoinbase));
 
     // Collect memory pool transactions into the block
     int64_t nFees = 0;
@@ -546,6 +553,7 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
         }
 
         int nBlockSigOps = 100;
+    unsigned int nMinTxFeeRejected = 0;
 
         std::make_heap(vecPriority.begin(), vecPriority.end());
 
@@ -593,6 +601,8 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
             // what -mintxfee's documented meaning describes.
             if (dFeePerKb < nMinTxFee)
             {
+                ++nMinTxFeeRejected;
+
                 LogPrint(BCLog::LogFlags::NOISY,
                          "Not including tx %s: fee rate %.0f below -mintxfee %" PRId64,
                          tx.GetHash().GetHex(), dFeePerKb, nMinTxFee);
@@ -768,6 +778,11 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
                     }
                 }
             }
+        }
+
+        if (nMinTxFeeRejected > 0) {
+            LogPrintf("CreateNewBlock(): -mintxfee (%s/KB) excluded %u mempool transaction(s)",
+                      FormatMoney(nMinTxFee), nMinTxFeeRejected);
         }
 
         if (LogInstance().WillLogCategory(BCLog::LogFlags::NOISY) || gArgs.GetBoolArg("-printpriority"))

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -568,6 +568,37 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
                 continue;
             }
 
+            // Fee-rate floor from -mintxfee. Both sides are satoshi per 1000
+            // bytes -- see the "Fee-per-kilobyte amount considered the same as
+            // free" comment where nMinTxFee is set -- not absolute amounts.
+            //
+            // Restored here: 1421209a0 removed the free-transaction path and
+            // with it the only read of nMinTxFee, so the option went on being
+            // parsed from -mintxfee while nothing consumed it.
+            //
+            // At the default (GetBaseFee, 100000 sat/KB) this rejects nothing.
+            // Relay already requires (1 + bytes/1000) * MIN_TX_FEE * 10, and
+            // over every size AcceptToMemoryPool admits -- 1 to
+            // MAX_STANDARD_TX_SIZE-1, IsStandardTx being unconditional on that
+            // path -- the resulting rate stays above the floor. The margin is
+            // thinnest at the top: 100001 sat/KB at 99999 bytes, i.e. 1 sat/KB.
+            // dFeePerKb is a double, but its error here is ~1e-11 sat/KB, ten
+            // orders of magnitude inside that margin, so the comparison is not
+            // at risk. The floor bites only when an operator raises the option.
+            //
+            // Note this is stricter than the pre-1421209a0 check, which also
+            // required (nBlockSize + nTxSize >= nBlockMinSize) and so left a
+            // free area at the front of the block. nBlockMinSize went with the
+            // free-transaction path; the floor is unconditional now, which is
+            // what -mintxfee's documented meaning describes.
+            if (dFeePerKb < nMinTxFee)
+            {
+                LogPrint(BCLog::LogFlags::NOISY,
+                         "Not including tx %s: fee rate %.0f below -mintxfee %" PRId64,
+                         tx.GetHash().GetHex(), dFeePerKb, nMinTxFee);
+                continue;
+            }
+
             // Legacy limits on sigOps:
             unsigned int nTxSigOps = GetLegacySigOpCount(tx);
             if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
@@ -603,9 +634,21 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
                          "Not including tx %s  due to TxFees of %" PRId64 ", bare min fee is %" PRId64,
                          tx.GetHash().GetHex(), nTxFees, nMinFee);
 
-                // Since transactions are sorted by fee, the fee of rest must also be lower
-                // than required.
-                break;
+                // continue, not break. This compares an ABSOLUTE fee against
+                // an absolute threshold while the heap is ordered by fee RATE
+                // (dFeePerKb), and the two orders are not the same: a larger
+                // transaction popped later, at a lower rate, can pay more in
+                // total than this one and clear a threshold this one missed.
+                //
+                // The heap is not globally descending either. An orphan is
+                // pushed onto it mid-loop when its parent is included (see
+                // mapDependers below), so a transaction entering after this
+                // point can outrank everything already popped.
+                //
+                // The "sorted by fee" justification for breaking belonged to
+                // the fee-RATE check that 1421209a0 deleted, not to this one;
+                // it came along with the edit and has been wrong since.
+                continue;
             }
 
             nTxSigOps += GetP2SHSigOpCount(tx, mapInputs);

--- a/src/miner.h
+++ b/src/miner.h
@@ -19,6 +19,15 @@ typedef std::vector<GRC::SideStake_ptr> SideStakeAlloc;
 
 extern unsigned int nMinerSleep;
 
+//! \brief -mintxfee: the fee-rate floor, in satoshi per 1000 bytes, a
+//! transaction must clear to be selected into a block this node stakes.
+//!
+//! Negative means the option was not set; CreateRestOfTheBlock then falls back
+//! to GetBaseFee. Parsed and validated once at startup (init.cpp), beside
+//! -paytxfee, rather than re-parsed for every block template -- and so that a
+//! malformed value is a startup error instead of a silent fallback.
+extern CAmount nMinerMinTxFee;
+
 //! Extra data appended to the coinbase scriptSig of blocks we create.
 //! Defined in miner.cpp (moved from main.{h,cpp}, issue #3125 C9).
 extern CScript COINBASE_FLAGS;

--- a/test/functional/mining_fee_policy.py
+++ b/test/functional/mining_fee_policy.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""Miner fee policy: inclusion ordering and the -mintxfee floor.
+
+CreateRestOfTheBlock packs a block from a max-heap keyed on effective fee RATE
+(dFeePerKb), and applies -mintxfee as a floor on that same rate. This covers
+both, reading inclusion order from the block itself: block.vtx is filled by
+push_back as transactions are selected, so vtx[2:] IS the selection order
+(vtx[0] is the coinbase and vtx[1] the coinstake).
+
+  1. ordering is by fee RATE, not absolute fee -- pinned with a large
+     transaction that pays the highest absolute fee in the block and must still
+     sort below smaller transactions paying a higher rate;
+  2. the DEFAULT -mintxfee rejects nothing, for a multi-kilobyte transaction
+     paying exactly the relay minimum -- the shape whose effective rate comes
+     closest to the floor in ordinary use;
+  3. a raised -mintxfee excludes a below-floor transaction from the block while
+     leaving it in the mempool, and still includes one above the floor.
+
+One node per case. Nodes 0 and 1 run the default -mintxfee (cases 1 and 2),
+node 2 a raised one (case 3). They are separate nodes rather than one node
+restarted because restart_node rebuilds the ephemeral regtest wallet with a
+fresh seed, and deliberately unconnected, so each mines its own chain.
+
+One case per node is a robustness requirement, not tidiness. Each case spends
+about half its node's UTXO universe into the mempool and then mines, and
+CWallet marks a parent spent on TxStateInMempool as well as TxStateConfirmed,
+so those outputs leave AvailableCoinsForStaking. Running two cases on one node
+drained it far enough that CreateCoinStake failed with "no stake found (need a
+mature UTXO with sufficient weight)" in ~5% of runs. Retrying does not help --
+a retry advances the mock clock by one 16 s slot, which adds no meaningful
+weight -- so the supply has to be there in the first place.
+
+Background: Gridcoin's schedule is (1 + bytes/1000) * 0.001 GRC, so the
+effective rate FALLS with size -- ~0.0051 GRC/KB for a 196-byte transaction
+against ~0.0010 GRC/KB for a 3 KB one. That is why case 2 exists, and why
+ordering by rate is not the same as ordering by absolute fee.
+
+NOT covered here: the `nTxFees < nMinFee` handler in CreateRestOfTheBlock. At
+the default -blockmaxsize that branch is unreachable -- AcceptToMemoryPool
+already requires at least the flat fee the miner recomputes -- so no functional
+test can reach it. Covering it needs a unit-test chain fixture with spendable
+coins, which the tree does not have (issue #3290).
+
+This test is in EXTENDED_SCRIPTS, not the default suite: it asserts on the
+contents of a staked block, which makes it subject to the regtest stake-supply
+hazard documented in test_runner.py.
+"""
+from decimal import Decimal
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+SAT = Decimal("0.00000001")
+
+# -mintxfee for node 1, in GRC per KB. Sits between the two probe transactions
+# in case 3 (~0.0051 and ~0.0102 GRC/KB).
+RAISED_MIN_TX_FEE = Decimal("0.008")
+
+# Inputs in the "bulk" transaction. ~148 bytes per P2PKH input puts it near
+# 3 KB, far enough from a 1000-byte boundary to be stable run to run.
+BULK_INPUTS = 20
+
+
+class MiningFeePolicyTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        common = ["-staking=0", "-connect=0", "-listen=0", "-devbuild=override"]
+        self.extra_args = [
+            common,                                              # case 1
+            common,                                              # case 2
+            common + ["-mintxfee=%s" % RAISED_MIN_TX_FEE],       # case 3
+        ]
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+        # Deliberately not connected: each node mines its own chain.
+
+    # ------------------------------------------------------------- helpers
+
+    @staticmethod
+    def rate(fee, nbytes):
+        """Effective fee rate in GRC per 1000 bytes."""
+        return (fee * Decimal(1000) / Decimal(nbytes)).quantize(Decimal("0.0000001"))
+
+    def build(self, node, utxos, fee):
+        """Spend `utxos` into one output, paying `fee` in total."""
+        ins = [{"txid": u["txid"], "vout": u["vout"]} for u in utxos]
+        total = sum((u["amount"] for u in utxos), Decimal(0))
+        value = (total - fee).quantize(SAT)
+        assert value > 0, "fee exceeds input value"
+        signed = node.signrawtransactionwithwallet(
+            node.createrawtransaction(ins, {node.getnewaddress(): value}))
+        assert signed.get("complete"), signed
+        return signed["hex"]
+
+    def schedule_fee(self, nbytes):
+        """The relay minimum: (1 + bytes/1000) * 0.001 GRC."""
+        return (Decimal(1) + Decimal(nbytes // 1000)) * Decimal("0.001")
+
+    def build_at_schedule_minimum(self, node, utxos, attempts=4):
+        """Build once to learn the size, again to pay exactly the minimum.
+
+        Signature (DER) lengths vary between signings, so the second build can
+        differ in size from the probe. If that straddles a 1000-byte bucket the
+        fee derived from the probe is below what relay requires and
+        sendrawtransaction throws "insufficient-fee". Re-derive until the fee
+        matches the transaction actually built.
+        """
+        probe = self.build(node, utxos, Decimal("0.05"))
+        fee = self.schedule_fee(len(probe) // 2)
+        for _ in range(attempts):
+            final = self.build(node, utxos, fee)
+            size = len(final) // 2
+            if self.schedule_fee(size) == fee:
+                return final, size, fee
+            fee = self.schedule_fee(size)
+        raise AssertionError(
+            "transaction size did not settle on a fee bucket in %d builds" % attempts)
+
+    def fund(self, node, spends):
+        """Fund `node` with roughly twice the UTXOs its case will spend.
+
+        The headroom is what keeps staking alive. Every spend this case makes
+        parks an output in the mempool, and CWallet marks a parent spent on
+        TxStateInMempool as well as TxStateConfirmed, so it leaves
+        AvailableCoinsForStaking before the case mines. Sizing the universe to
+        the exact number spent leaves nothing to stake on: at 24 of 28 outputs
+        consumed, CreateCoinStake failed with "no stake found (need a mature
+        UTXO with sufficient weight)" in ~2% of runs.
+        """
+        count = spends * 2 + 8
+        node.generatetoaddress(12, node.getnewaddress())
+        self.grow_utxo_universe(node, count=count)
+        pool = [u for u in node.listunspent(1)
+                if u["amount"] > Decimal("1.0") and u.get("spendable", True)]
+        assert len(pool) >= spends, "need %d UTXOs, have %d" % (spends, len(pool))
+        return pool
+
+    def mine_one(self, node, attempts=4):
+        """Mine one block, retrying the regtest stake-supply race.
+
+        Each case locks most of the UTXO universe into mempool spends
+        immediately before mining, and CWallet marks a parent spent on
+        TxStateInMempool as well as TxStateConfirmed (wallet.cpp), so
+        AvailableCoinsForStaking can momentarily find no eligible kernel and
+        CreateCoinStake fails. nStakeMinAge is 0 on regtest, so the universe
+        outputs really are kernel candidates and really do leave the set.
+
+        This is a property of the setup, not of the transactions under test:
+        grow_utxo_universe guards its own mine the same way. Without the retry
+        this test flakes at roughly 4% -- measured at 11 failures in 263 runs.
+        """
+        last = None
+        for _ in range(attempts):
+            self.advance_to_next_stake_slot()
+            try:
+                node.generatetoaddress(1, node.getnewaddress())
+                return
+            except JSONRPCException as e:
+                # Only the stake-supply race is retried; anything else is a
+                # real failure and must not be masked.
+                if "no stake found" not in str(e):
+                    raise
+                last = e
+        raise AssertionError(
+            "no block mined in %d attempts; last error: %s" % (attempts, last))
+
+    def mine_and_read_order(self, node, submitted):
+        """Mine one block; return the submitted names in selection order."""
+        self.mine_one(node)
+        tip = node.getblock(node.getbestblockhash(), True)
+        mined = [t["txid"] if isinstance(t, dict) else t for t in tip["tx"]]
+        return [submitted[t] for t in mined if t in submitted]
+
+    # --------------------------------------------------------------- cases
+
+    def test_rate_ordering(self, node, pool):
+        """Selection order is descending effective fee rate, not absolute fee."""
+        self.log.info("case 1: inclusion order follows fee RATE")
+
+        specs = []
+        cursor = 0
+
+        # One bulk transaction paying the LARGEST absolute fee in the block.
+        # If selection went by absolute fee it would come first; by rate it
+        # belongs in the middle.
+        bulk_hex = self.build(node, pool[cursor:cursor + BULK_INPUTS],
+                              Decimal("0.035"))
+        cursor += BULK_INPUTS
+        specs.append(("bulk", bulk_hex, len(bulk_hex) // 2, Decimal("0.035")))
+
+        # Small transactions straddling it in rate.
+        for fee in (Decimal("0.001"), Decimal("0.002"), Decimal("0.004"),
+                    Decimal("0.006")):
+            h = self.build(node, pool[cursor:cursor + 1], fee)
+            cursor += 1
+            specs.append(("small-%s" % fee, h, len(h) // 2, fee))
+
+        submitted = {}
+        for name, h, nbytes, fee in specs:
+            submitted[node.sendrawtransaction(h)] = name
+            self.log.info("  %-12s %5d bytes  fee %-7s -> %s GRC/KB",
+                          name, nbytes, fee, self.rate(fee, nbytes))
+
+        expected = [name for name, _, nbytes, fee in
+                    sorted(specs, key=lambda s: self.rate(s[3], s[2]),
+                           reverse=True)]
+        observed = self.mine_and_read_order(node, submitted)
+
+        self.log.info("  expected: %s", expected)
+        self.log.info("  observed: %s", observed)
+        assert_equal(observed, expected)
+
+        # The discriminating assertion: highest absolute fee, not selected first.
+        biggest_fee = max(specs, key=lambda s: s[3])[0]
+        assert_equal(biggest_fee, "bulk")
+        assert observed[0] != "bulk", (
+            "the transaction paying the largest absolute fee was selected "
+            "first -- selection is ordering by fee, not by fee rate")
+
+    def test_default_mintxfee_rejects_nothing(self, node, pool):
+        """The default floor must not reject honest minimum-fee traffic.
+
+        A ~3 KB transaction paying exactly the relay minimum. Its effective rate
+        is a little over 0.001 GRC/KB against a 0.001 GRC/KB floor -- not the
+        theoretical worst case, which is 100001 sat/KB at 99999 bytes (a margin
+        of 1 sat/KB), but that needs ~675 inputs to construct. This asserts the
+        margin is positive rather than pinning its size.
+        """
+        self.log.info("case 2: the default -mintxfee rejects nothing")
+
+        hexstr, nbytes, fee = self.build_at_schedule_minimum(
+            node, pool[:BULK_INPUTS])
+        rate = self.rate(fee, nbytes)
+        self.log.info("  %d bytes at the schedule minimum %s GRC -> %s GRC/KB "
+                      "(default floor is 0.001)", nbytes, fee, rate)
+        assert rate > Decimal("0.001"), (
+            "test is not exercising what it claims: this transaction is below "
+            "the default floor, so relay should not have accepted it either")
+
+        submitted = {node.sendrawtransaction(hexstr): "schedule-minimum"}
+        observed = self.mine_and_read_order(node, submitted)
+        assert_equal(observed, ["schedule-minimum"])
+
+    def test_raised_mintxfee_excludes_below_floor(self, node, pool):
+        """A raised floor skips below-floor transactions, keeping them pooled."""
+        self.log.info("case 3: -mintxfee=%s excludes below-floor transactions",
+                      RAISED_MIN_TX_FEE)
+
+        low_hex = self.build(node, pool[0:1], Decimal("0.001"))
+        high_hex = self.build(node, pool[1:2], Decimal("0.002"))
+        low_rate = self.rate(Decimal("0.001"), len(low_hex) // 2)
+        high_rate = self.rate(Decimal("0.002"), len(high_hex) // 2)
+
+        self.log.info("  low  %d bytes -> %s GRC/KB (below floor)",
+                      len(low_hex) // 2, low_rate)
+        self.log.info("  high %d bytes -> %s GRC/KB (above floor)",
+                      len(high_hex) // 2, high_rate)
+        assert low_rate < RAISED_MIN_TX_FEE < high_rate, (
+            "the floor no longer straddles the two transactions")
+
+        low_txid = node.sendrawtransaction(low_hex)
+        high_txid = node.sendrawtransaction(high_hex)
+
+        # -mintxfee is miner policy, not relay policy: both are accepted.
+        assert_equal(sorted(node.getrawmempool()), sorted([low_txid, high_txid]))
+
+        submitted = {low_txid: "low", high_txid: "high"}
+        observed = self.mine_and_read_order(node, submitted)
+        self.log.info("  mined: %s", observed)
+        assert_equal(observed, ["high"])
+
+        # Skipped by the miner, not dropped: it is still available to a later
+        # block (or to a node running a lower floor).
+        assert low_txid in node.getrawmempool(), (
+            "the below-floor transaction left the mempool; -mintxfee must skip "
+            "it during selection, not evict it")
+
+    def run_test(self):
+        node0, node1, node2 = self.nodes
+
+        # fund() is told what each case SPENDS; it provisions the headroom.
+        self.test_rate_ordering(node0, self.fund(node0, spends=BULK_INPUTS + 4))
+        self.test_default_mintxfee_rejects_nothing(
+            node1, self.fund(node1, spends=BULK_INPUTS))
+        self.test_raised_mintxfee_excludes_below_floor(
+            node2, self.fund(node2, spends=2))
+
+
+if __name__ == "__main__":
+    MiningFeePolicyTest().main()

--- a/test/functional/mining_fee_policy.py
+++ b/test/functional/mining_fee_policy.py
@@ -17,7 +17,10 @@ push_back as transactions are selected, so vtx[2:] IS the selection order
      paying exactly the relay minimum -- the shape whose effective rate comes
      closest to the floor in ordinary use;
   3. a raised -mintxfee excludes a below-floor transaction from the block while
-     leaving it in the mempool, and still includes one above the floor.
+     leaving it in the mempool, and still includes one above the floor;
+  4. an unparseable -mintxfee is rejected at startup rather than silently
+     falling back to the default -- the failure path that keeps the option from
+     being ignored, which is what it did for years.
 
 One node per case. Nodes 0 and 1 run the default -mintxfee (cases 1 and 2),
 node 2 a raised one (case 3). They are separate nodes rather than one node
@@ -52,6 +55,7 @@ from decimal import Decimal
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import GridcoinTestFramework
+from test_framework.test_node import ErrorMatch
 from test_framework.util import assert_equal
 
 SAT = Decimal("0.00000001")
@@ -64,17 +68,22 @@ RAISED_MIN_TX_FEE = Decimal("0.008")
 # 3 KB, far enough from a 1000-byte boundary to be stable run to run.
 BULK_INPUTS = 20
 
+# Hoisted out of set_test_params because case 4 restarts a node itself, and
+# TestNode.start REPLACES extra_args rather than appending to it -- a restart
+# that passes only "-mintxfee=..." would drop -devbuild=override and fail for
+# an unrelated reason.
+COMMON_ARGS = ["-staking=0", "-connect=0", "-listen=0", "-devbuild=override"]
+
 
 class MiningFeePolicyTest(GridcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.chain = "regtest"
         self.setup_clean_chain = True
-        common = ["-staking=0", "-connect=0", "-listen=0", "-devbuild=override"]
         self.extra_args = [
-            common,                                              # case 1
-            common,                                              # case 2
-            common + ["-mintxfee=%s" % RAISED_MIN_TX_FEE],       # case 3
+            COMMON_ARGS,                                              # case 1
+            COMMON_ARGS,                                              # case 2
+            COMMON_ARGS + ["-mintxfee=%s" % RAISED_MIN_TX_FEE],       # case 3
         ]
 
     def setup_network(self):
@@ -292,6 +301,42 @@ class MiningFeePolicyTest(GridcoinTestFramework):
             node1, self.fund(node1, spends=BULK_INPUTS))
         self.test_raised_mintxfee_excludes_below_floor(
             node2, self.fund(node2, spends=2))
+
+        # Last, because it leaves node2 stopped.
+        self.test_bad_mintxfee_refuses_to_start(2)
+
+    def test_bad_mintxfee_refuses_to_start(self, n):
+        """Case 4: an unparseable -mintxfee is rejected at startup.
+
+        The point is the REJECTION, not the arithmetic. Parsing into a local and
+        failing loudly is what stops the option silently falling back to its
+        default, which is how -mintxfee came to be ignored for years -- so the
+        failure path is the load-bearing half of that commit and nothing else
+        exercises it.
+
+        All three inputs fail inside ParseMoney rather than at the fee_rate < 0
+        range check, which is unreachable: ParseMoney stops at the first
+        non-digit, so "-1" fails as a parse and never reaches the comparison.
+        The empty value is a real case and not a curiosity -- "-mintxfee=" is a
+        SET argument whose value is "", ParseMoney accumulates no digits and
+        ParseInt64 rejects the empty string, so the node refuses to start.
+        """
+        self.log.info("case 4: -mintxfee that cannot be parsed refuses to start")
+        self.stop_node(n)
+
+        for value in ("abc", "-1", ""):
+            # Full args, not just the one under test: TestNode.start replaces
+            # extra_args wholesale. PARTIAL_REGEX because the default
+            # FULL_TEXT compares the entire stderr for equality.
+            self.nodes[n].assert_start_raises_init_error(
+                COMMON_ARGS + ["-mintxfee=%s" % value],
+                "Invalid amount for -mintxfee=",
+                match=ErrorMatch.PARTIAL_REGEX)
+
+        # A valid value still starts, so the guard rejects bad input rather
+        # than the option as such.
+        self.start_node(n, COMMON_ARGS + ["-mintxfee=0.01"])
+        self.stop_node(n)
 
 
 if __name__ == "__main__":

--- a/test/functional/mining_fee_policy.py
+++ b/test/functional/mining_fee_policy.py
@@ -60,8 +60,8 @@ from test_framework.util import assert_equal
 
 SAT = Decimal("0.00000001")
 
-# -mintxfee for node 1, in GRC per KB. Sits between the two probe transactions
-# in case 3 (~0.0051 and ~0.0102 GRC/KB).
+# -mintxfee for node 2 (the third node, which runs case 3), in GRC per KB. Sits
+# between the two probe transactions in case 3 (~0.0051 and ~0.0102 GRC/KB).
 RAISED_MIN_TX_FEE = Decimal("0.008")
 
 # Inputs in the "bulk" transaction. ~148 bytes per P2PKH input puts it near

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -91,6 +91,18 @@ EXTENDED_SCRIPTS = [
     # so it takes tens of seconds and is opt-in rather than in the default suite.
     'feature_stakelimit.py',
     #
+    # mining_fee_policy.py asserts on the contents of a staked block, so it has
+    # to spend most of its wallet's UTXOs and then stake. CWallet marks a parent
+    # spent on TxStateInMempool as well as TxStateConfirmed, so those outputs
+    # leave AvailableCoinsForStaking and CreateCoinStake can fail with "no stake
+    # found (need a mature UTXO with sufficient weight)". Same shared-premine
+    # hazard as feature_reorg.py below. One case per node and a 2x UTXO universe
+    # took it from ~4.5% to ~1.3% (2 failures in 150 runs) but did not remove it,
+    # and a bounded mine retry does not help -- a retry advances the mock clock
+    # one 16 s slot, which adds no stake weight. Unit-testing this needs a chain
+    # fixture with spendable coins, which the tree does not have (issue #3290).
+    'mining_fee_policy.py',
+    #
     # feature_reorg.py exercises a competing-proof-of-stake reorg between two
     # nodes. It is intermittently flaky on the current regtest stack and is NOT
     # in the default CI suite: both nodes share the same deterministic, stakeable


### PR DESCRIPTION
Two defects in `CreateRestOfTheBlock`'s mempool selection loop, both dating from `1421209a0`
("mempool, miner, gui: remove tx prioritisation and free txs", 2022-02-18), plus the startup
validation that the first of them makes load-bearing.

Found while working through #2025. Neither is exploitable and neither changes behaviour at the
default settings — see the no-op arguments below — but the option they concern is still
advertised in `-help` and has not done anything for four years.

### 1. `-mintxfee` has been parsed and ignored since 2022

`1421209a0` removed the free-transaction gate, which was the only reader of `nMinTxFee`:

```cpp
if (fSortedByFee && (dFeePerKb < nMinTxFee) && (nBlockSize + nTxSize >= nBlockMinSize))
    continue;
```

That left the option parsed into a variable nothing consumed, while `init.cpp` went on
advertising it. This restores the floor against `dFeePerKb`; both sides are satoshi per 1000
bytes, per the "Fee-per-kilobyte amount considered the same as free" comment where `nMinTxFee`
is set.

**At the default it rejects nothing.** Relay requires `(1 + bytes/1000) * MIN_TX_FEE * 10`,
whose rate stays above the 100000 sat/KB floor over every size `AcceptToMemoryPool` admits —
`IsStandardTx` is unconditional there, so 1..`MAX_STANDARD_TX_SIZE`-1 — with a worst case of
100001 sat/KB at 99999 bytes. It bites only when an operator raises the option.

Note the restored check is unconditional, unlike the pre-2022 one, which also required
`nBlockSize + nTxSize >= nBlockMinSize`; `nBlockMinSize` went with the free-transaction path.

The `-mintxfee` help text is also corrected. It claimed the option affects transactions you
send; it never has — the wallet prices from `nTransactionFee` (`-paytxfee`) and `GetMinFee`.

### 2. `break` → `continue` on the underpaying-transaction handler

The same commit changed the `nTxFees < nMinFee` handler from `continue` to `break`, adding the
comment "Since transactions are sorted by fee, the fee of rest must also be lower than
required". This reverts that.

The justification does not hold. The heap is ordered by fee **rate** (`dFeePerKb`) while the
check compares **absolute** fees, so a larger transaction popped later at a lower rate can pay
more in total. And the heap is not globally descending anyway, because an orphan is pushed onto
it mid-loop when its parent is included. That justification belonged to the fee-rate check the
same commit deleted.

**At the default `-blockmaxsize` this is a no-op**: `nMinFee` is a flat `GetBaseFee` (the
escalator needs a block past `MAX_BLOCK_SIZE_GEN/2`, which is also the default block-size cap),
relay already enforces at least that much, and `ConnectInputs` — called with `fBlock=false` a
few lines below — would skip the same transaction anyway. It matters only under a raised
`-blockmaxsize`, where the old `break` truncated the block at the first underpaying transaction
instead of skipping it.

### 3. Validate `-mintxfee` at startup instead of discarding the parse

`CreateRestOfTheBlock` re-parsed `-mintxfee` for every block template and threw away
`ParseMoney`'s return value:

```cpp
int64_t nMinTxFee = GetBaseFee(CTransaction(mtxCoinbase));
if (gArgs.IsArgSet("-mintxfee"))
    ParseMoney(gArgs.GetArg("-mintxfee", "dummy"), nMinTxFee);
```

`ParseMoney` leaves its out-param untouched on failure, so `-mintxfee=abc`, a negative value
(the leading `-` is not a digit) or an over-long whole part all fell back to the default
silently. Harmless while nothing read the variable; with the floor enforced it would silently
ignore an operator's setting.

Parsing and validation move to startup beside `-paytxfee`, which this follows exactly:
`InitError` on a malformed value, `InitWarning` above 0.25 GRC. The floor's effect is also
reported once per template at `LogPrintf` when it actually excluded something — per-transaction
rejections stay at `NOISY` so a high floor and a large mempool cannot spam the log, but an
operator who has priced themselves out of their own blocks can see it without turning on a debug
category. The adjacent size rejection is already unconditional.

One thing worth flagging at the site and here: the fallback base fee is `GetBaseFee` of the
**coinbase**, not of each candidate. That is only equivalent because `AcceptToMemoryPool` rejects
`nVersion < 2`, so every mempool transaction carries the same multiplier.

### Upgrade note

A stale `-mintxfee` sitting in an existing `gridcoinresearch.conf` starts taking effect on
upgrade, having been ignored since 2022. A value below the relay minimum still changes nothing.
A value set high enough will now exclude transactions from blocks this node stakes — which is
what the option says it does, but it has been inert long enough that someone may have forgotten
it is set. A malformed value that used to be swallowed silently is now a startup error.

### Test coverage

`test/functional/mining_fee_policy.py` reads selection order from `block.vtx` (filled by
`push_back` as transactions are selected) rather than from log output:

1. selection order is descending effective fee **rate**, pinned with a transaction that pays the
   largest absolute fee in the block and must still sort third — so an absolute-fee sort fails
   the test;
2. the default `-mintxfee` rejects a multi-kilobyte transaction paying exactly the relay minimum;
3. a raised `-mintxfee` excludes a below-floor transaction from the block while leaving it in the
   mempool — miner policy, not eviction.

Both assertions have a negative control: removing the `-mintxfee` floor fails case 3, and sorting
by absolute fee instead of rate fails case 1.

It is in `EXTENDED_SCRIPTS`, not the default suite. The test asserts on the contents of a staked
block, so it must spend most of its wallet's UTXOs and then stake, and `CWallet` marks a parent
spent on `TxStateInMempool` as well as `TxStateConfirmed` — those outputs leave
`AvailableCoinsForStaking` and `CreateCoinStake` fails with "no stake found (need a mature UTXO
with sufficient weight)". Same shared-premine hazard that keeps `feature_reorg.py` out of the
default suite. One case per node plus a 2x UTXO universe took it from ~4.5% to ~1.3% (2 failures
in 150 runs); a bounded mine retry does not help, since a retry advances the mock clock one 16 s
slot and adds no stake weight.

**Item 2 above is deliberately not covered.** At the default `-blockmaxsize` that branch is
unreachable, so no functional test can reach it. Covering it needs a unit-test chain fixture with
spendable coins, which the tree does not have — opened as #3290.

### Testing

- Full unit suite: `No errors detected`.
- Full default functional suite: 29/29. Run against `development` at `2d9ec8e1b`.
- `mining_fee_policy.py` run standalone, and repeated for determinism as described above.
- Build clean, zero warnings.
- `-mintxfee` validation checked by hand: `-mintxfee=abc` errors, `-mintxfee=5` warns and starts,
  `-mintxfee=0.005` starts clean.
