### PR TITLE
wallet: make AddCScript idempotent

### DIFF
--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -765,6 +765,51 @@ BOOST_AUTO_TEST_CASE(wallet_update_spent_does_not_notify_the_transaction_itself)
     pwalletMain->EraseFromWallet(hash);
 }
 
+//!
+//! \brief CWallet::AddCScript must be idempotent.
+//!
+//! Regression for the non-idempotency shared by addmultisigaddress, addredeemscript and
+//! createhtlc. CCryptoKeyStore::AddCScript assigns into mapScripts unconditionally, so a
+//! repeat add always succeeds in memory; the failure came from CWalletDB::WriteCScript
+//! writing with fOverwrite=false, which makes BDB return DB_KEYEXIST on the duplicate key.
+//! AddCScript then returned false and the RPCs threw "AddCScript() failed" -- even though
+//! the wallet held the script and could sign with it.
+//!
+//! This exercises the real path: the fixture's wallet is file-backed (CWallet("wallet.dat")
+//! over bitdb.MakeMock()), so WriteCScript is actually reached. A wallet with
+//! fFileBacked == false would return true early and the test would pass vacuously.
+//!
+BOOST_AUTO_TEST_CASE(addcscript_is_idempotent)
+{
+    BOOST_REQUIRE(pwalletMain != nullptr);
+
+    // A distinctive, valid redeem script. Content does not matter, only that it is stable
+    // so every add hashes to the same key.
+    CScript redeem_script = CScript() << OP_1 << OP_DROP << OP_TRUE;
+    const CScriptID script_id{redeem_script};
+
+    // Deliberately NOT asserting initial absence. pwalletMain is a shared
+    // BOOST_GLOBAL_FIXTURE, so asserting the script is missing would make this case
+    // order-dependent if any other test ever adds the same script id. It would also add
+    // no coverage: if the script were already present, every add below is a duplicate
+    // add, which is precisely the path under test. Seed it, then repeat.
+    BOOST_CHECK(pwalletMain->AddCScript(redeem_script));
+    BOOST_CHECK(pwalletMain->HaveCScript(script_id));
+
+    // Second add of the IDENTICAL script must also succeed. This is the regression: it
+    // previously returned false because the duplicate BDB write was rejected.
+    BOOST_CHECK(pwalletMain->AddCScript(redeem_script));
+
+    // ...and a third, to show it is not a one-shot tolerance.
+    BOOST_CHECK(pwalletMain->AddCScript(redeem_script));
+
+    // The script is still retrievable and unchanged after the repeat adds.
+    BOOST_CHECK(pwalletMain->HaveCScript(script_id));
+    CScript fetched;
+    BOOST_CHECK(pwalletMain->GetCScript(script_id, fetched));
+    BOOST_CHECK(fetched == redeem_script);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(wallet_integration_tests)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -209,7 +209,24 @@ public:
     bool WriteCScript(const uint160& hash, const CScript& redeemScript)
     {
         nWalletDBUpdated++;
-        return Write(std::make_pair(std::string("cscript"), hash), redeemScript, false);
+        //! fOverwrite is TRUE, deliberately. The key is Hash160 of the value, so a
+        //! duplicate key means the identical script is already stored and rewriting it
+        //! leaves the record's contents unchanged. That is a SEMANTIC no-op, not an
+        //! operational one -- BDB still performs the put, wallet.dat is still written,
+        //! and nWalletDBUpdated is still bumped. The cost does not matter here: the
+        //! callers are RPC-driven and rare.
+        //!
+        //! With fOverwrite=false BDB returns DB_KEYEXIST on a repeat add,
+        //! CWallet::AddCScript returns false, and the caller reports failure even though
+        //! the wallet holds the script and can sign with it -- the in-memory
+        //! CCryptoKeyStore::AddCScript assignment is unconditional. That made
+        //! addmultisigaddress, addredeemscript and createhtlc non-idempotent: asking for
+        //! the same script twice threw "AddCScript() failed".
+        //!
+        //! Overwriting (rather than returning early on HaveCScript) is the safer repair:
+        //! it also heals a wallet whose in-memory map holds a script that never reached
+        //! disk, which an early return would mask permanently.
+        return Write(std::make_pair(std::string("cscript"), hash), redeemScript, true);
     }
 
     bool WriteOrderPosNext(int64_t nOrderPosNext)


### PR DESCRIPTION
## Problem

`CWallet::AddCScript` is not idempotent, so re-adding a script the wallet already holds fails. Three RPCs inherit it:

| site | RPC |
|---|---|
| `src/wallet/rpcwallet.cpp:1899` | `addmultisigaddress` |
| `src/wallet/rpcwallet.cpp:1935` | `addredeemscript` |
| `src/rpc/htlc.cpp:97` | `createhtlc` |

All three treat the `false` return as fatal and throw, so none of them relies on it meaning "already exists".

## Mechanism

```cpp
// src/wallet/wallet.cpp:444
bool CWallet::AddCScript(const CScript& redeemScript)
{
    if (!CCryptoKeyStore::AddCScript(redeemScript))   // in-memory: ALWAYS succeeds
        return false;
    if (!fFileBacked)
        return true;
    return CWalletDB(strWalletFile).WriteCScript(Hash160(redeemScript), redeemScript);  // fails on duplicate
}
```

`CBasicKeyStore::AddCScript` assigns into `mapScripts` unconditionally (`keystore.cpp:36`), so the in-memory add always succeeds. The failure came from `WriteCScript` writing with `fOverwrite=false`: BDB returns `DB_KEYEXIST` for the duplicate key, `AddCScript` returns false, and the caller reports failure **even though the wallet holds the script and can sign with it**. The boolean conflated *"already present"* with *"failed"*.

The key is `Hash160` of the value, so a duplicate key means the identical script is already stored and rewriting it is a no-op. `WriteCScript` has a single caller, so the change is contained.

**Why overwrite rather than an early return on `HaveCScript`:** an early return would also skip the write for a wallet whose in-memory map holds a script that never reached disk (in-memory add succeeded, write failed for some other reason), masking that permanently. Overwriting heals that case. A genuine write failure — disk full, corruption — still returns false and still surfaces to the caller.

## Not consensus-relevant; no activation height

- `validation.cpp` and `main.cpp` reference the script store **zero** times.
- Every consumer is signing- or display-side: `script/sign.cpp`, `script/standard.cpp` (`IsMine`/solver), `psgt.cpp`, `rpc/psgt.cpp`, `rpc/rawtransaction.cpp`, `rpc/htlc.cpp`, `interfaces.cpp`.
- The record is persisted only to the local wallet BDB (`("cscript", hash)`).
- No serialization or wallet-format change — the same bytes are written; only the duplicate-key disposition differs.

Two nodes on either side of this change cannot disagree about the chain. **Demonstrated empirically, not just argued** — see below.

## Testing

### Unit test, verified to discriminate

`wallet_tests/addcscript_is_idempotent`. It exercises the real path: the fixture's wallet is file-backed (`CWallet("wallet.dat")` over `bitdb.MakeMock()`), so `WriteCScript` is actually reached — with `fFileBacked == false` `AddCScript` returns true early and the test would pass vacuously.

Confirmed to fail **before** the fix and pass **after**, on this branch's development base:

```
without the fix:
  wallet_tests.cpp(800): check pwalletMain->AddCScript(redeem_script) has failed   <- 2nd add
  wallet_tests.cpp(803): check pwalletMain->AddCScript(redeem_script) has failed   <- 3rd add
  *** 2 failures
with the fix:
  *** No errors detected
```

Only the repeat adds fail; the first add and both `HaveCScript` assertions pass, so the test isolates the duplicate-write path exactly.

Full `test_gridcoin` suite passes (`walletdb.h` is widely included, so the whole suite was run, not just the wallet suites). `lint-all.sh` exit 0 with `COMMIT_RANGE` set.

### Live validation on the isolated 4-node testnet

Built and deployed to two of four mesh nodes, leaving the other two unpatched as controls, all running under v15:

```
inst 8   UNPATCHED   v5.5.1.8-cbb5cbd00d08
inst 9   patched     v5.5.1.8-6c2f2fb999b3
inst 10  patched     v5.5.1.8-6c2f2fb999b3
inst 11  UNPATCHED   v5.5.1.8-cbb5cbd00d08   (ASan)
```

**A/B on the identical script** — both nodes derive the same address on the first call, so they are handling the same script; the only variable is the patch:

```
PATCHED   (inst 9)   call 1: 2MtymscC8AqsJZkDUicei5MsD4zLRErtmr6
                     call 2: 2MtymscC8AqsJZkDUicei5MsD4zLRErtmr6
                     call 3: 2MtymscC8AqsJZkDUicei5MsD4zLRErtmr6
UNPATCHED (inst 8)   call 1: 2MtymscC8AqsJZkDUicei5MsD4zLRErtmr6
                     call 2: error: {"code":-1,"message":"AddCScript() failed"}
```

**The unpatched node is not impaired.** After its error, `validateaddress` on the multisig returns `ismine=true`, `isscript=true`, identical redeem-script hex, `sigsrequired=2` — the wallet has the script, because the error only fires *because* it is already stored.

**Full multisig transaction with an unpatched co-signer.** A 2-of-3 PSGT was created and submitted on a patched node (inst 9) and co-signed by the **unpatched** node (inst 8, the one that threw the error). It completed, broadcast, and confirmed:

```
inst 8   UNPATCHED   conf=1  block=55d3a280a30846cf   (co-signer)
inst 9   patched     conf=1  block=55d3a280a30846cf   (initiator/signer)
inst 10  patched     conf=1  block=55d3a280a30846cf   (non-signing observer)
inst 11  UNPATCHED   conf=1  block=55d3a280a30846cf   (non-signing observer)
```

All four accepted it into the same block — patched and unpatched, signing and non-signing alike. A mixed-binary mesh staying in consensus is the practical demonstration that this cannot split the network.

## Impact

Quality-of-life and diagnosability, not capability. Nobody is excluded from multisig by not upgrading. The harm is that the RPC lies about state: a setup script or operator that treats the error as fatal aborts a flow that actually succeeded. The `createhtlc` variant is the nastier one — it adds the script and *then* funds, so if funding fails (locked wallet) the retry dies on the script add rather than on the thing that actually failed, hiding the real cause. The known workaround was to perturb an input so `Hash160` differs, which works around the tool rather than the user's intent.
