### PR TITLE
net, rpc: four small robustness fixes

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1435,6 +1435,22 @@ static bool ProcessMessages(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(pfrom->cs_vRe
                 // Allow exceptions from over-long size
                 LogPrintf("ProcessMessages(%s, %u bytes) : Exception '%s' caught", strCommand, nMessageSize, e.what());
             }
+            else if (strstr(e.what(), "Vector length limit exceeded"))
+            {
+                // Allow exceptions from a vector whose element count exceeds the
+                // limit declared for it (LimitedVector in serialize.h, applied to
+                // the block locator at MAX_LOCATOR_SZ). This is an ordinary
+                // malformed-message rejection and belongs with the two above.
+                //
+                // Without this arm the message matches neither filter and falls
+                // through to PrintExceptionContinue(), which assigns
+                // strMiscWarning; GetWarnings() returns that at priority 1000, so
+                // it surfaces in getinfo, getstakinginfo, getnetworkinfo,
+                // getblockchaininfo and the GUI status bar. That let any peer set
+                // the node's user-visible warning string on demand, unthrottled
+                // and with no misbehavior score, by sending one oversized locator.
+                LogPrintf("ProcessMessages(%s, %u bytes) : Exception '%s' caught", strCommand, nMessageSize, e.what());
+            }
             else
             {
                 PrintExceptionContinue(&e, "ProcessMessages()");

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -4,6 +4,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include <limits>
+#include <type_traits>
 #include "netbase.h"
 #include "util.h"
 #include "sync.h"
@@ -337,6 +338,11 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
     static_assert(sizeof(pchRet3) > std::numeric_limits<uint8_t>::max(),
                   "the domain-name length is read from a single byte, so the buffer "
                   "must be larger than any value that byte can hold");
+    static_assert(std::is_unsigned_v<std::remove_reference_t<decltype(pchRet3[0])>>,
+                  "the length byte is read out of this buffer into an int, so a signed "
+                  "element type sign-extends any value above 0x7f into a negative nRecv "
+                  "-- CVE-2017-18350. The size assert above does not cover this: "
+                  "char pchRet3[256] satisfies it and reintroduces the bug");
 
     switch (pchRet2[3])
     {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1162,7 +1162,19 @@ void StartRPCThreads()
         return;
     }
 
-    const int nRPCThreads = gArgs.GetArg("-rpcthreads", 4);
+    // Clamp to at least one worker. These threads are the only ones that run
+    // ioContext::run(), so -rpcthreads=0 installs the acceptors with nothing to
+    // service them: the port listens, no request is ever dispatched, and that
+    // includes the "stop" call an operator would use to recover -- the node has
+    // to be killed. -rpcthreads is registered ALLOW_ANY, so nothing else
+    // rejects the value.
+    const int nRPCThreadsArg = gArgs.GetArg("-rpcthreads", 4);
+    const int nRPCThreads = std::max(1, nRPCThreadsArg);
+
+    if (nRPCThreads != nRPCThreadsArg) {
+        LogPrintf("WARNING: StartRPCThreads: -rpcthreads=%d is below the minimum of 1; using %d.\n",
+                  nRPCThreadsArg, nRPCThreads);
+    }
 
     rpc_worker_group = new boost::thread_group();
     for (int i = 0; i < nRPCThreads; i++)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1354,7 +1354,14 @@ void ServiceConnection(AcceptedConnection *conn)
             /* Deter brute-forcing short passwords.
                If this results in a DOS the user really
                shouldn't have their RPC port exposed.*/
-            if (gArgs.GetArgs("-rpcpassword").size() < 20)
+            // GetArg, not GetArgs: the intent is the length of the configured
+            // password, but GetArgs returns one element per occurrence of the
+            // option, so .size() was the number of times -rpcpassword appeared.
+            // That is 0 or 1 in every real configuration, so the test was always
+            // true and the sleep always ran -- burning one of only nRPCThreads
+            // workers on each failed attempt, which is the denial of service the
+            // comment above is willing to accept only for short passwords.
+            if (gArgs.GetArg("-rpcpassword", "").size() < 20)
                 UninterruptibleSleep(std::chrono::milliseconds{250});
 
             conn->stream() << HTTPReply(HTTP_UNAUTHORIZED, "", false) << std::flush;


### PR DESCRIPTION

Four independent one- to few-line fixes found by inspection while comparing this tree against
upstream Bitcoin Core. None of them changes a consensus rule or a wire format, and each is
self-contained, so they can be split if that reads better.

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`; every line number below is on
that commit.

### 1. `net_processing.cpp` — an oversized block locator lets a peer set the node's warning string

`ProcessMessages()` filters two expected `ios_base::failure` messages out of its catch — `"end of
data"` and `"size too large"` — and logs them as ordinary malformed-message rejections. Anything
else falls through to `PrintExceptionContinue()`, which assigns `strMiscWarning` (`util/system.cpp:757-763`).

`LimitedVector::Unserialize` throws a third message, `"Vector length limit exceeded"`
(`serialize.h:681`), and it matches neither filter. `GetWarnings()` gives `strMiscWarning` priority
1000 (`alert.cpp:301-305`), so it surfaces in `getinfo` (`wallet/rpcwallet.cpp:235`),
`getstakinginfo` (`rpc/mining.cpp:185`, aliased as `getmininginfo`), `getnetworkinfo`
(`rpc/net.cpp:914`), `getblockchaininfo` (`rpc/blockchain.cpp:4810`) and the GUI status bar
(`node/interfaces.cpp:153`). `strMiscWarning` also latches — nothing clears it — so one message
leaves the warning in place until something else overwrites it.

The result is that a peer can set the node's user-visible warning string on demand by sending one
locator with more than `MAX_LOCATOR_SZ` entries — unthrottled, with no misbehavior score, and with
the connection left open. The path predates the locator cap; the cap gave it a cheap deterministic
trigger.

This adds a third filter arm. It deliberately does not score the peer: an over-long locator is a
protocol violation rather than an attack in itself, and I would rather not add a ban path to a
message shape that an older or non-conforming implementation might emit. Happy to add
`Misbehaving()` instead if you prefer that reading.

### 2. `rpc/server.cpp` — `-rpcthreads=0` makes the node unreachable and unstoppable over RPC

`StartRPCThreads()` creates `nRPCThreads` workers, and those workers are the only threads that run
`ioContext::run()`. With `-rpcthreads=0` the acceptors are installed with nothing to service them:
the port listens, no request is ever dispatched, and that includes the `stop` call an operator would
reach for — the process has to be killed. `-rpcthreads` is registered `ALLOW_ANY`, so nothing else
rejects the value.

Clamped to a minimum of 1, with a warning logged when the configured value is raised.

### 3. `rpc/server.cpp` — the `-rpcpassword` length check measures the wrong thing

```cpp
if (gArgs.GetArgs("-rpcpassword").size() < 20)
    UninterruptibleSleep(std::chrono::milliseconds{250});
```

`GetArgs()` returns one element per *occurrence* of the option, so `.size()` is the number of times
`-rpcpassword` was passed — 0 or 1 in every real configuration. The test is therefore always true
and the sleep always runs, where the comment above it intends the delay only for passwords shorter
than 20 characters.

That matters a little more than it looks: the sleep parks one of only `nRPCThreads` workers for
250 ms per failed attempt, so the anti-brute-force measure is itself a small denial-of-service
amplifier, and it is currently unconditional. Changed to `GetArg("-rpcpassword", "")`, which is the
length the comment describes.

### 4. `netbase.cpp` — pin the SOCKS5 buffer's element type, not just its size

The SOCKS5 domain-name path reads a length byte out of `pchRet3` and passes it to
`InterruptibleRecv()` as the read size. The existing `static_assert` pins `sizeof(pchRet3) > 255`,
which is necessary but does not constrain the element *type* — and the type is what the safety
argument actually rests on. `char pchRet3[256]` satisfies the existing assert on every platform,
and on a signed-char platform sign-extends any length above `0x7f` into a negative `nRecv`, which is
CVE-2017-18350.

This adds a second assert on the element type, so the invariant is checked rather than assumed. No
behaviour change; the guarantee is entirely compile-time. The comment block above the buffer already
explains why the type matters — this makes the compiler enforce what the comment claims.

Checked by mutation: with `char pchRet3[256]` the build fails on the new assert alone on signed-`char` platforms (x86/x86-64; on unsigned-`char` targets plain `char` passes it, but there the sign-extension hazard does not exist either) — the existing
size assert stays silent, which is the gap being closed.

### Testing

- `test_gridcoin`: clean (`*** No errors detected`).
- Functional suite: 29/29 passed, 84 s accumulated, against a RelWithDebInfo build of this branch.
- Full CI matrix green on this exact commit: all six workflows (Quality Gate, Production,
  Distribution Native, Compatibility, Multiprocess, Functional Tests) passed.

No test asserts the new behaviour yet — see the note below.

### Behaviour an existing configuration would see on upgrade

- A node running `-rpcthreads=0` currently listens on the RPC port and answers nothing; it will now
  start with one worker and serve requests. Anyone relying on `-rpcthreads=0` as a way to disable
  RPC should use `-server=0` instead — the old behaviour was not a documented off switch.
- With an `-rpcpassword` of 20 characters or more, a failed authentication attempt no longer sleeps
  250 ms. Shorter passwords are unaffected, which is what the existing comment intends.
- Nothing else changes: fix 1 only stops a warning being set, and fix 4 is compile-time.

### Possible follow-ups

Fixes 2 and 3 are reachable from the functional harness if you would like tests for them — a node
started with `-rpcthreads=0` and a request that times out, and an auth-failure timing assertion.
I left them out because the timing test would be inherently flaky; say the word if you want the
first one.

Fix 1 is also testable end to end — `test/functional/test_framework/messages.py` already defines
`CBlockLocator` and `msg_getblocks` — by asserting `getinfo`'s `errors` field stays empty after an
oversized locator. Happy to add that as a follow-up or to this PR.

