### PR TITLE
node: clear g_reorg_in_progress on every SetBestChain exit

### DIFF
--- a/src/gridcoin/voting/poll_result_cache.cpp
+++ b/src/gridcoin/voting/poll_result_cache.cpp
@@ -214,9 +214,12 @@ std::vector<PollResultItem> PollResultCache::BuildPollTable(PollFilterFlag flags
             break;
         }
 
-        // Wait for the reorg to clear before retrying. DetectReorg clears the flag
-        // once ReorganizeChain has finished; a failed reorg leaves it set and the
-        // node will shut down, interrupting the sleep.
+        // Wait for the reorg to clear before retrying. The TraversalScope opened
+        // at the top of this function is still held here, so DetectReorg re-arms
+        // reorg_occurred_during_reg_traversal for as long as g_reorg_in_progress
+        // is set: this loop ends when the reorg finishes, or when the next block
+        // is connected successfully, since SetBestChain clears that flag on every
+        // exit including its failure returns.
         while (registry.reorg_occurred_during_reg_traversal) {
             if (!MilliSleep(1000)) {
                 return items;

--- a/src/gridcoin/voting/poll_result_cache.cpp
+++ b/src/gridcoin/voting/poll_result_cache.cpp
@@ -217,9 +217,9 @@ std::vector<PollResultItem> PollResultCache::BuildPollTable(PollFilterFlag flags
         // Wait for the reorg to clear before retrying. The TraversalScope opened
         // at the top of this function is still held here, so DetectReorg re-arms
         // reorg_occurred_during_reg_traversal for as long as g_reorg_in_progress
-        // is set: this loop ends when the reorg finishes, or when the next block
-        // is connected successfully, since SetBestChain clears that flag on every
-        // exit including its failure returns.
+        // is set: this loop ends when the in-progress reorg exits -- success or
+        // failure alike -- since SetBestChain and ForceReorganizeToHash clear
+        // that flag on every exit. No later block connect is needed to unwedge.
         while (registry.reorg_occurred_during_reg_traversal) {
             if (!MilliSleep(1000)) {
                 return items;

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -690,8 +690,16 @@ bool ForceReorganizeToHash(uint256 NewHash)
         LogPrintf("WARN: %s: Chain trust is now less than before!", __func__);
     }
 
-    // g_reorg_in_progress is set in ReorganizeChain, but cleared by the caller. It is debatable whether this should
-    // be cleared here if g_chain_trust.Best() < previous_chain_trust.
+    // g_reorg_in_progress is set in ReorganizeChain, which is what decides whether the move
+    // was a trivial extension, and cleared by the caller -- so this is the only place that can
+    // clear it on this path.
+    //
+    // Cleared unconditionally, and that is the decision rather than an oversight: once this
+    // function returns, no reorg is in progress, whatever the trust outcome above was. A
+    // regression means the reorganize we forced left the chain worse off, which is what the
+    // warning is for; it does not leave a reorg running. Holding the flag would tell every
+    // later reader -- the GUI and the poll-registry RPCs, which read it without cs_main --
+    // that one still was.
     g_reorg_in_progress = false;
 
     if (!success) {

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -508,11 +508,12 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
 namespace {
 //!
-//! \brief RAII scope that clears g_reorg_in_progress when SetBestChain returns.
+//! \brief RAII scope that clears g_reorg_in_progress when its holder exits --
+//! held by SetBestChain and ForceReorganizeToHash for their full extent.
 //!
 //! ReorganizeChain sets the flag, because only it can distinguish a non-trivial
-//! reorg from a trivial single-block extension, and the caller clears it,
-//! because ReorganizeChain can run twice within one SetBestChain call (the
+//! reorg from a trivial single-block extension, and the calling scope clears
+//! it, because ReorganizeChain can run twice within one SetBestChain call (the
 //! forward reorg and the trust-regression reorg-back).
 //!
 //! Clearing on the success path alone left the flag set on both of the failure

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -520,7 +520,8 @@ namespace {
 //! returns below. A stuck flag wedges PollResultCache::BuildPollTable: its
 //! TraversalScope is open across the whole build, so PollRegistry::DetectReorg
 //! keeps re-arming reorg_occurred_during_reg_traversal, and the retry loop
-//! there waits on that flag at 1 Hz until the next block connects successfully.
+//! there waits on that flag at 1 Hz -- before this guard, with no way out
+//! until some later block connected successfully and cleared it.
 //!
 //! The explicit clear before the post-connect fix-up below is deliberately
 //! kept: it releases consumers at the point it always has. This scope only

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -506,8 +506,41 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     return true;
 }
 
+namespace {
+//!
+//! \brief RAII scope that clears g_reorg_in_progress when SetBestChain returns.
+//!
+//! ReorganizeChain sets the flag, because only it can distinguish a non-trivial
+//! reorg from a trivial single-block extension, and the caller clears it,
+//! because ReorganizeChain can run twice within one SetBestChain call (the
+//! forward reorg and the trust-regression reorg-back).
+//!
+//! Clearing on the success path alone left the flag set on both of the failure
+//! returns below. A stuck flag wedges PollResultCache::BuildPollTable: its
+//! TraversalScope is open across the whole build, so PollRegistry::DetectReorg
+//! keeps re-arming reorg_occurred_during_reg_traversal, and the retry loop
+//! there waits on that flag at 1 Hz until the next block connects successfully.
+//!
+//! The explicit clear before the post-connect fix-up below is deliberately
+//! kept: it releases consumers at the point it always has. This scope only
+//! covers the exits that never reached it.
+//!
+class ReorgInProgressScope
+{
+public:
+    ReorgInProgressScope() = default;
+
+    ~ReorgInProgressScope() { g_reorg_in_progress = false; }
+
+    ReorgInProgressScope(const ReorgInProgressScope&) = delete;
+    ReorgInProgressScope& operator=(const ReorgInProgressScope&) = delete;
+};
+} // anonymous namespace
+
 bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    const ReorgInProgressScope reorg_scope;
+
     unsigned cnt_dis = 0;
     unsigned cnt_con = 0;
     bool success = false;

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -656,6 +656,14 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
 bool ForceReorganizeToHash(uint256 NewHash)
 {
     LOCK(cs_main);
+
+    // Same guard as SetBestChain: the flag clears on EVERY exit -- the two
+    // early failure returns below never set it (ReorganizeChain does), so
+    // clearing false there is a no-op, and the returns after ReorganizeChain
+    // are covered without a manual clear that an exception or a future early
+    // return could bypass.
+    const ReorgInProgressScope reorg_scope;
+
     CTxDB txdb;
 
     auto mapItem = mapBlockIndex.find(NewHash);
@@ -690,18 +698,10 @@ bool ForceReorganizeToHash(uint256 NewHash)
         LogPrintf("WARN: %s: Chain trust is now less than before!", __func__);
     }
 
-    // g_reorg_in_progress is set in ReorganizeChain, which is what decides whether the move
-    // was a trivial extension, and cleared by the caller -- so this is the only place that can
-    // clear it on this path.
-    //
-    // Cleared unconditionally, and that is the decision rather than an oversight: once this
-    // function returns, no reorg is in progress, whatever the trust outcome above was. A
-    // regression means the reorganize we forced left the chain worse off, which is what the
-    // warning is for; it does not leave a reorg running. Holding the flag would tell every
-    // later reader -- the GUI and the poll-registry RPCs, which read it without cs_main --
-    // that one still was.
-    g_reorg_in_progress = false;
-
+    // The flag (set in ReorganizeChain) is cleared by the ReorgInProgressScope
+    // guard at every exit of this function -- unconditionally, and that is the
+    // decision rather than an oversight: once this function returns, no reorg
+    // is in progress, whatever the trust outcome above was.
     if (!success) {
         return error("%s: Fatal Error while setting best chain.", __func__);
     }


### PR DESCRIPTION
`SetBestChain` cleared `g_reorg_in_progress` only on its success path, so both failure returns left
the flag set:

```
src/node/chainman.cpp:538   return error("%s: Fatal Error while reading original best block", __func__);
src/node/chainman.cpp:546   return false;
src/node/chainman.cpp:551   g_reorg_in_progress = false;   <- only reached on success
```

`ForceReorganizeToHash` already gets this right — it clears at `:662`, before its own
`if (!success) return error(...)` at `:664-665`. The asymmetry between the two is what makes this
look like an oversight rather than a design.

Noted in the #3182 description under "Pre-existing issues noticed nearby (out of scope, can file
separately)" and never filed.

## Why it is worth more than a tidy-up

A stuck flag is not merely cosmetic state. `PollRegistry::DetectReorg` re-arms
`reorg_occurred_during_reg_traversal` for as long as `registry_traversal_in_progress` is non-zero
**and** `g_reorg_in_progress` is set (`registry.cpp:1354-1359`), and
`PollResultCache::BuildPollTable` holds a `TraversalScope` across its entire build
(`poll_result_cache.cpp:115`). Its retry loop at `:220-226` therefore waits on that flag at 1 Hz and
cannot exit while the flag is stuck — so a failed reorg wedges the poll table build until a later
block connects successfully and clears the flag at `:551`.

That bound is usually the next accepted block, since every block extending the best chain reaches
`SetBestChain` (`validation.cpp:1385-1386`). It is not bounded at all if whatever caused the failure
recurs — and the `ReadBlockFromDisk` failure at `:537` is a disk-level error, which is exactly the
case likely to repeat.

## The change

An RAII scope in `chainman.cpp` clears the flag when `SetBestChain` returns, on any path. The
explicit clear at `:551` is kept deliberately: it releases consumers before the post-connect fix-up
work, which is where it has always released them, and moving it to scope exit would hold the flag
across the wallet locator write and the `UpdatedBlockTip` emission. The scope only covers the exits
that never reached it.

This mirrors `PollRegistry::TraversalScope` (`registry.h:508-520`), which guards the *other* half of
the same `DetectReorg` condition with the same pattern.

Also corrects the comment on `PollResultCache`'s wait loop, which said:

> a failed reorg leaves it set and the node will shut down, interrupting the sleep

That is true only of the `DisconnectBlocksBatch` `exit(1)` at `chainman.cpp:343`. `SetBestChain`'s
failure returns propagate as a rejected block — `SetBestChain` → `AddToBlockIndex`
(`validation.cpp:1386-1387`) → `AcceptBlock` (`:1814-1815`) — and do not shut down. The comment now
describes what actually ends the loop.

## Scope notes

- The `:546` return is reachable with **no** trust regression at all — a `TxnBegin` failure at
  `chainman.cpp:337` after the flag is set at `:314` reaches it without entering the revert branch.
  So the fix could not be scoped to "the revert failure" as the #3182 note framed it.
- Not touched here: `ForceReorganizeToHash`'s `// It is debatable whether this should be cleared
  here if g_chain_trust.Best() < previous_chain_trust` at `:660`. Raised separately rather than
  resolved by assumption.

## Testing

- Full unit suite passes.
- Full functional suite passes.
- No functional harness reaches the changed paths: the `reorganize` RPC uses
  `ForceReorganizeToHash`, which bypasses `SetBestChain` entirely. That gap is tracked in #3290
  (unit-test chain fixture) and this is a concrete consumer for it — the RAII scope is specifically
  chosen so the invariant holds without a test to pin it.

---

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`; the full six-workflow CI matrix is green on this exact commit.
