### PR TITLE
wallet: drop the redundant scope, dead return and by-value loop in CWalletTx::AcceptWalletTransaction

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5201,21 +5201,17 @@ bool CMerkleTx::AcceptToMemoryPool() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
 bool CWalletTx::AcceptWalletTransaction(CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-
+    // Add previous supporting transactions first
+    for (auto& tx : vtxPrev)
     {
-        // Add previous supporting transactions first
-        for (auto tx : vtxPrev)
+        if (!(tx.IsCoinBase() || tx.IsCoinStake()))
         {
-            if (!(tx.IsCoinBase() || tx.IsCoinStake()))
-            {
-                uint256 hash = tx.GetHash();
-                if (!mempool.exists(hash) && !txdb.ContainsTx(hash))
-                    tx.AcceptToMemoryPool();
-            }
+            uint256 hash = tx.GetHash();
+            if (!mempool.exists(hash) && !txdb.ContainsTx(hash))
+                tx.AcceptToMemoryPool();
         }
-        return AcceptToMemoryPool();
     }
-    return false;
+    return AcceptToMemoryPool();
 }
 
 bool CWalletTx::AcceptWalletTransaction() EXCLUSIVE_LOCKS_REQUIRED(cs_main)


### PR DESCRIPTION
Three pre-existing warts preserved verbatim through #3135's move, and declined on #3136/#3137 to
keep the pure-move guarantee:

```cpp
// src/wallet/wallet.cpp:5202
{
    {                                          // redundant inner scope
        for (auto tx : vtxPrev)                // by value
        ...
        return AcceptToMemoryPool();
    }
    return false;                              // unreachable
}
```

**The by-value loop is behaviour-neutral, not merely "probably" so.** Every `CTransaction` data
member is const (`primitives/transaction.h:247-253`, plus `const uint256 hash` at `:262`) with a
single `mutable` lazy contract-parse cache at `:257`, and `::AcceptToMemoryPool`
(`validation.cpp:2110`) only reads and copies — `CheckTransaction`, `IsStandardTx`, `tx.vin`,
`tx.GetValueOut`, `CTxMemPoolEntry entry(tx, ...)`, `MakeTransactionRef(tx)`. So the copy costs a
deep copy per `vtxPrev` element and changes nothing observable.

That argument holds only because `CMerkleTx::AcceptToMemoryPool` slices to `CTransaction&`
(`wallet.cpp:5197`); `CMerkleTx`'s own members (`hashBlock`, `nIndex`, `vMerkleBranch`) are not
const, and none of them is touched.

Used `auto&` rather than `const auto&`: the latter additionally requires making
`CMerkleTx::AcceptToMemoryPool` const and constifying `::AcceptToMemoryPool`'s `CTransaction&`
parameter, which is a wider change than this cleanup warrants.

---

---

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`; the full six-workflow CI matrix is green on this exact commit.
