### PR TITLE
net: remove dead boost::thread_interrupted handlers from migrated threads

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1891,11 +1891,6 @@ void ThreadStakeMiner(void* parg)
     {
         PrintException(&e, "ThreadStakeMiner()");
     }
-    catch(boost::thread_interrupted&)
-    {
-        LogPrintf("ThreadStakeMiner exited (interrupt)");
-        return;
-    }
     catch (...)
     {
         PrintException(nullptr, "ThreadStakeMiner()");

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -731,11 +731,6 @@ void CConnman::ThreadSocketHandler()
     {
         PrintException(&e, "ThreadSocketHandler()");
     }
-    catch(boost::thread_interrupted&)
-    {
-        LogPrintf("ThreadSocketHandler exited (interrupt)");
-        return;
-    }
     catch (...)
     {
         throw; // support pthread_cancel()
@@ -1314,11 +1309,6 @@ void ThreadDNSAddressSeed(void* parg)
     {
         PrintException(&e, "ThreadDNSAddressSeed()");
     }
-    catch(boost::thread_interrupted&)
-    {
-        LogPrint(BCLog::LogFlags::NET, "ThreadDNSAddressSeed exited (interrupt)");
-        return;
-    }
     catch (...)
     {
         throw; // support pthread_cancel()
@@ -1414,11 +1404,6 @@ void ThreadDumpAddress(void* parg)
     {
         PrintException(&e, "ThreadDumpAddress()");
     }
-    catch(boost::thread_interrupted&)
-    {
-        LogPrintf("ThreadDumpAddress exited (interrupt)");
-        return;
-    }
     catch (...)
     {
         PrintException(nullptr, "ThreadDumpAddress");
@@ -1439,11 +1424,6 @@ void CConnman::ThreadOpenConnections()
     catch (std::exception& e)
     {
         PrintException(&e, "ThreadOpenConnections()");
-    }
-    catch(boost::thread_interrupted&)
-    {
-        LogPrintf("ThreadOpenConnections exited (interrupt)");
-        return;
     }
     catch (...)
     {
@@ -1620,11 +1600,6 @@ void CConnman::ThreadOpenAddedConnections()
     {
         PrintException(&e, "ThreadOpenAddedConnections()");
     }
-    catch(boost::thread_interrupted&)
-    {
-        LogPrintf("ThreadOpenAddedConnections exited (interrupt)");
-        return;
-    }
     catch (...)
     {
         PrintException(nullptr, "ThreadOpenAddedConnections()");
@@ -1741,11 +1716,6 @@ void CConnman::ThreadMessageHandler()
     catch (std::exception& e)
     {
         PrintException(&e, "ThreadMessageHandler()");
-    }
-    catch(boost::thread_interrupted&)
-    {
-        LogPrintf("ThreadMessageHandler exited (interrupt)");
-        return;
     }
     catch (...)
     {


### PR DESCRIPTION
#3033 left these as "a trivial follow-up (harmless dead code on a `std::thread`)". Seven handlers
sit on threads that are `std::thread` now, which never throws `boost::thread_interrupted`:

```
src/net.cpp     ThreadSocketHandler · ThreadDNSAddressSeed · ThreadDumpAddress
                ThreadOpenConnections · ThreadOpenAddedConnections · ThreadMessageHandler
src/miner.cpp   ThreadStakeMiner
```

All seven are launched into `std::vector<std::thread> m_net_threads` (`net.h:782`, from
`net.cpp:2244-2264`), except `ThreadStakeMiner`, which is `init.cpp:2338`
`g_stake_miner_thread = std::thread(ThreadStakeMiner, pwalletMain)`.

**Not removed**, because they are still boost threads on `ThreadHandler`'s
`boost::thread_group` (`util.h:844`):

```
src/net.cpp:1152                     ThreadMapPort    -> net.cpp:1279  netThreads->createThread
src/gridcoin/gridcoin.cpp:330, :359  scraper threads  -> gridcoin.cpp:423/430  threads->createThread
```

Also left alone, out of scope but named so a later sweep does not catch them by surprise:
`src/util.h:863` (`TraceThread`, which rethrows) and `src/wallet/walletdb.cpp:669`.

### One observation while auditing this

Of the three handlers kept, only the two scraper ones can actually fire. `interrupt_all()` reaches a
thread group solely through `ThreadHandler::interruptAll` (`util.cpp:535`), and its only two callers
are `gridcoinresearchd.cpp:399` and `qt/bitcoin.cpp:1667`, both `threads->interruptAll()`. Nothing
ever calls `netThreads->interruptAll()` — `netThreads` is only ever `removeAll()`'d
(`net.cpp:2290`), and `removeAll` does `threadGroup.join_all()` with no interrupt (`util.cpp:546`).

So `ThreadMapPort`'s handler is unreachable too, for a different reason. I have kept it: it is
type-correct for the thread it is on, and the shutdown wiring could reasonably change. Flagging it
rather than acting on it.

---

---

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`; the full six-workflow CI matrix is green on this exact commit.
