### PR TITLE
txmempool: pass MemPoolRemovalReason::CONFLICT from removeConflicts

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -172,7 +172,7 @@ bool CTxMemPool::removeConflicts(const CTransaction &tx)
         if (it != mapNextTx.end()) {
             const CTransaction &txConflict = *it->second.ptx;
             if (txConflict != tx)
-                remove(txConflict, true);
+                remove(txConflict, true, MemPoolRemovalReason::CONFLICT);
         }
     }
     return true;


### PR DESCRIPTION
```
src/txmempool.cpp:176   remove(txConflict, true);
src/txmempool.h:199-200 bool remove(const CTransaction &tx, bool fRecursive = false,
                                   MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
```

`removeConflicts` is the one caller that does not pass a reason, so conflict removals thread through
as `UNKNOWN`. The recursive `remove` call inside already forwards `reason` correctly, so this is the
only gap.

It reaches the right handler arm today by accident — `UNKNOWN` happens to fall where `CONFLICT`
would in `CWallet::TransactionRemovedFromMempool`. Worth fixing on its own terms, and it is a
prerequisite for anything that later wants to distinguish removal reasons: the conflict path is the
only mempool removal with a live handler arm that reaches `SyncTransaction`.

Found while checking the register's item on mempool-eviction notifications; that broader item is
**not** proposed here — the note at `txmempool.cpp:132-139` records emitting from `remove()` as a
deliberately rejected design, and I am not reopening it.

---

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`; the full six-workflow CI matrix is green on this exact commit.
