### PR TITLE
test: add newest_coinstake_utxo() and use it for the amount-1 pattern

### DIFF
--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -79,10 +79,7 @@ class MempoolAcceptTest(GridcoinTestFramework):
 
         # stake so we have a mature, tx-indexed coinstake output to spend
         node.generatetoaddress(10, node.getnewaddress())
-        # most-recently-staked output (fewest confirmations) is a coinstake,
-        # never the height-0 premine coinbase.
-        u = min(node.listunspent(0), key=lambda x: x["confirmations"])
-        amt = u["amount"] - 1  # ~1 GRC fee (amounts are Decimal from authproxy)
+        u, amt = self.newest_coinstake_utxo(node)  # ~1 GRC fee
 
         # 1. a valid tx is accepted into the mempool
         first = self._signed_spend(node, u, node.getnewaddress(), amt)

--- a/test/functional/rpc_psgt.py
+++ b/test/functional/rpc_psgt.py
@@ -38,10 +38,10 @@ class RpcPsgtTest(GridcoinTestFramework):
 
         # stake so we have a mature, tx-indexed coinstake output to spend
         node.generatetoaddress(10, node.getnewaddress())
-        utxo = min(node.listunspent(0), key=lambda u: u["confirmations"])
+        utxo, amount = self.newest_coinstake_utxo(node)
         inputs = [{"txid": utxo["txid"], "vout": utxo["vout"]}]
         dest = node.getnewaddress()
-        outputs = {dest: utxo["amount"] - 1}  # amounts are Decimal from authproxy
+        outputs = {dest: amount}
 
         # --- createpsgt + decodepsgt round-trip ---
         psgt = node.createpsgt(inputs, outputs)

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -38,9 +38,8 @@ class RpcRawTransactionTest(GridcoinTestFramework):
 
         # stake so we have a mature, tx-indexed coinstake output to spend
         node.generatetoaddress(10, node.getnewaddress())
-        utxo = min(node.listunspent(0), key=lambda u: u["confirmations"])
+        utxo, amount = self.newest_coinstake_utxo(node)  # ~1 GRC fee
         dest = node.getnewaddress()
-        amount = utxo["amount"] - 1  # ~1 GRC fee (amounts are Decimal from authproxy)
 
         # --- createrawtransaction ---
         raw = node.createrawtransaction(

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -86,10 +86,10 @@ class RpcTxoutProofTest(GridcoinTestFramework):
         # stack generatetoaddress excludes mempool txs, so it stays unconfirmed and
         # has no containing block. (sendtoaddress is avoided: its coin selection can
         # pick the non-tx-indexed premine coinbase, which the wallet then rejects.)
-        cs = min(node.listunspent(0), key=lambda u: u["confirmations"])
+        cs, amount = self.newest_coinstake_utxo(node)
         dest = node.getnewaddress()
         raw = node.createrawtransaction(
-            [{"txid": cs["txid"], "vout": cs["vout"]}], {dest: cs["amount"] - 1})
+            [{"txid": cs["txid"], "vout": cs["vout"]}], {dest: amount})
         signed = node.signrawtransactionwithwallet(raw)
         assert signed.get("complete"), signed
         mempool_txid = node.sendrawtransaction(signed["hex"])

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -832,6 +832,41 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         peer.version_time = node.mock_now()
         return node.add_p2p_connection(peer)
 
+    def newest_coinstake_utxo(self, node, fee=Decimal("1.0")):
+        """Return (utxo, spend_amount) for the most-recently-staked output.
+
+        Several tests independently did:
+
+            u = min(node.listunspent(0), key=lambda x: x["confirmations"])
+            amount = u["amount"] - 1
+
+        The output with the fewest confirmations is a coinstake, which is
+        tx-indexed -- never the height-0 premine coinbase, which the wallet
+        refuses to spend. None of those call sites checked that `amount` stayed
+        positive.
+
+        It is positive today only because sidestaking is off by default. Stake
+        splitting cannot drive it negative: MIN_STAKE_SPLIT_VALUE_GRC
+        (src/amount.h) is a hard 800 GRC clamp applied with max() in
+        src/miner.cpp, so every split output is at least 800 GRC. Sidestake
+        outputs have no such floor -- src/miner.cpp computes `allocation *
+        nReward` with no clamp, and the regtest constant block reward is 10 GRC
+        (src/chainparams.cpp) -- so `-enablesidestaking=1 -sidestake=<addr>,5`
+        puts a 0.5 GRC output at the same confirmation depth and `amount - fee`
+        goes negative.
+
+        Assert rather than silently build a negative-value transaction.
+        """
+        utxo = min(node.listunspent(0), key=lambda u: u["confirmations"])
+        amount = utxo["amount"] - fee
+        assert amount > 0, (
+            f"newest coinstake output {utxo['txid']}:{utxo['vout']} holds "
+            f"{utxo['amount']} GRC, which cannot cover a {fee} GRC fee. "
+            f"If this node runs with -enablesidestaking, a sidestake output "
+            f"shares the coinstake's confirmation count and has no minimum size."
+        )
+        return utxo, amount
+
     def grow_utxo_universe(self, funder, count=48, *, agree_with=None, confirm_on=None):
         """Fan one mature premine UTXO on `funder` into `count` ordinary,
         consensus-agreed outputs so a test's mature-UTXO funding scan never runs

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -54,10 +54,10 @@ class WalletBasicTest(GridcoinTestFramework):
         # --- raw spend of a recent coinstake output is accepted into the mempool ---
         # (Most-recently-staked output = fewest confirmations = a coinstake, which
         # is tx-indexed; never the height-0 premine coinbase.)
-        cs = min(node.listunspent(0), key=lambda u: u["confirmations"])
+        cs, amount = self.newest_coinstake_utxo(node)
         dest = node.getnewaddress()
         raw = node.createrawtransaction(
-            [{"txid": cs["txid"], "vout": cs["vout"]}], {dest: cs["amount"] - 1})
+            [{"txid": cs["txid"], "vout": cs["vout"]}], {dest: amount})
         signed = node.signrawtransactionwithwallet(raw)
         assert signed.get("complete"), signed
         txid = node.sendrawtransaction(signed["hex"])


### PR DESCRIPTION
Five functional tests independently picked the most-recently-staked output and spent `amount - 1`
with no check that the result stayed positive: `mempool_accept.py`, `wallet_basic.py`,
`rpc_rawtransaction.py`, `rpc_psgt.py` and `rpc_txoutproof.py`. Flagged for the record on #3233.

**Correcting the hazard as it was described there:** `-enablestakesplit` cannot drive it negative.
`MIN_STAKE_SPLIT_VALUE_GRC` (`src/amount.h`) is a hard 800 GRC clamp applied with `max()` in
`src/miner.cpp`, with the count rounded down and capped, so every split output is at least 800 GRC
and `amount - 1` is at least 799.

The reachable trigger is the other half of the same function. Sidestake outputs have no floor —
`src/miner.cpp` computes `allocation * nReward` with no clamp — and the regtest constant block
reward is 10 GRC, so enabling sidestaking with a 5% allocation puts a 0.5 GRC output in the same
coinstake transaction, at the same confirmation depth, where `min(listunspent(0),
key=confirmations)` can select it. `feature_sidestake.py` already demonstrates the 50% case at 5 GRC.
No test enables sidestaking today, so this stays latent — one config flag away, which is what the
original note was warning about, via the wrong flag.

The helper asserts instead of silently building a negative-value transaction, and its docstring
records why stake splitting is *not* the trigger so the analysis is not redone. Four call sites
already guarded the same pattern (`grow_utxo_universe`, `p2p_psgt_orphan.py`, `p2p_psgt_relay.py`,
`rpc_psgtpool.py`), which is what the shared helper generalises.

**Testing.** Full functional suite passes.

---

---

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`; the full six-workflow CI matrix is green on this exact commit.
