### PR TITLE
rpc: un-stub generatesuperblock

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1845,6 +1845,13 @@ bool TryMineRegtestBlock(CWallet* pwallet,
         return false;
     }
 
+    // Snapshot any staged regtest superblock before the attach step consumes
+    // it. The two failure exits below (signing, ProcessBlock) return to a
+    // caller that retries with a new stake timestamp; without restoring the
+    // slot, the retry would mine a plain block and silently drop the staged
+    // superblock while the RPC still reported success.
+    std::optional<GRC::Superblock> staged_backup = g_regtest_staged_superblock;
+
     AddSuperblockContractOrVote(mtxCoinbase, StakeBlock.nTime);
 
     // Copy back coinbase AFTER CreateMRCRewards and AddSuperblockContractOrVote
@@ -1878,12 +1885,14 @@ bool TryMineRegtestBlock(CWallet* pwallet,
     StakeBlock.vtx[1] = CTransaction(mtxCoinstake);
 
     if (!SignStakeBlock(StakeBlock, BlockKey, StakeInputs, pwallet)) {
+        g_regtest_staged_superblock = std::move(staged_backup);
         err = "SignStakeBlock failed (check beacon / investor mode)";
         return false;
     }
 
     CValidationState stake_state;
     if (!ProcessBlock(nullptr, &StakeBlock, true, stake_state)) {
+        g_regtest_staged_superblock = std::move(staged_backup);
         err = "ProcessBlock rejected the block: " + stake_state.GetRejectReason();
         return false;
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1359,7 +1359,7 @@ static std::optional<GRC::Superblock> g_regtest_staged_superblock GUARDED_BY(cs_
 
 void StageRegtestSuperblock(GRC::Superblock superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    assert(Params().IsMockableChain());
+    assert(Params().IsMockableChain()); // LINT-OK-ASSERT: regtest-only entry guard, unreachable via the RPC gate; abort beats staging a synthetic superblock on a live chain
     g_regtest_staged_superblock = std::move(superblock);
 }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1353,27 +1353,45 @@ bool SignStakeBlock(CBlock &block, CKey &key,
     return true;
 }
 
+//! Explicit superblock staged by the regtest-only generatesuperblock RPC.
+//! Consumed exactly once by the next AddSuperblockContractOrVote call.
+static std::optional<GRC::Superblock> g_regtest_staged_superblock GUARDED_BY(cs_main);
+
+void StageRegtestSuperblock(GRC::Superblock superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    assert(Params().IsMockableChain());
+    g_regtest_staged_superblock = std::move(superblock);
+}
+
 void AddSuperblockContractOrVote(CMutableTransaction& mtxCoinbase, int64_t nBlockTime) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    GRC::Superblock superblock;
+
     if (Params().IsMockableChain()) {
         // Under -regtest, the only path to a superblock is the explicit
-        // `generatesuperblock` RPC (Phase 2B). Suppress auto-attach so blocks
-        // produced by the deterministic staker stay free of synthetic quorum
-        // payloads driven by absent scrapers.
-        return;
-    }
+        // `generatesuperblock` RPC. Scrapers are disabled, so auto-attach has
+        // nothing to attach: consume a staged superblock if the RPC left one,
+        // and otherwise stay silent exactly as before, so blocks produced by
+        // the deterministic staker carry no synthetic quorum payloads.
+        if (!g_regtest_staged_superblock) {
+            return;
+        }
 
-    if (OutOfSyncByAge()) {
-        LogPrintf("AddSuperblockContractOrVote: Out of sync.");
-        return;
-    }
+        superblock = std::move(*g_regtest_staged_superblock);
+        g_regtest_staged_superblock.reset();
+    } else {
+        if (OutOfSyncByAge()) {
+            LogPrintf("AddSuperblockContractOrVote: Out of sync.");
+            return;
+        }
 
-    if (!GRC::Quorum::SuperblockNeeded(nBlockTime)) {
-        LogPrintf("AddSuperblockContractOrVote: Not needed.");
-        return;
-    }
+        if (!GRC::Quorum::SuperblockNeeded(nBlockTime)) {
+            LogPrintf("AddSuperblockContractOrVote: Not needed.");
+            return;
+        }
 
-    GRC::Superblock superblock = GRC::Quorum::CreateSuperblock();
+        superblock = GRC::Quorum::CreateSuperblock();
+    }
 
     if (!superblock.WellFormed()) {
         LogPrintf("AddSuperblockContractOrVote: Local contract empty.");

--- a/src/miner.h
+++ b/src/miner.h
@@ -50,6 +50,16 @@ extern std::atomic<int> g_stakelimit_height;
 //! hidden `devbuild=override` setting is passed. State lives in miner.cpp;
 //! extracted from the former util.h fDevbuildCripple global so util.h is
 //! stateless. Set from init.
+namespace GRC { class Superblock; }
+
+//! \brief Stage an explicit superblock for the next block the miner assembles.
+//!
+//! Regtest only. Scrapers are disabled under -regtest, so Quorum::CreateSuperblock()
+//! has nothing to build from and AddSuperblockContractOrVote suppresses auto-attach.
+//! The generatesuperblock RPC stages a caller-specified superblock here; the next
+//! call to AddSuperblockContractOrVote consumes it exactly once.
+void StageRegtestSuperblock(GRC::Superblock superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 bool GetDevbuildCripple();
 void SetDevbuildCripple(bool crippled);
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -57,7 +57,10 @@ namespace GRC { class Superblock; }
 //! Regtest only. Scrapers are disabled under -regtest, so Quorum::CreateSuperblock()
 //! has nothing to build from and AddSuperblockContractOrVote suppresses auto-attach.
 //! The generatesuperblock RPC stages a caller-specified superblock here; the next
-//! call to AddSuperblockContractOrVote consumes it exactly once.
+//! call to AddSuperblockContractOrVote consumes it exactly once. If the block
+//! attempt that consumed it fails to sign or be accepted, TryMineRegtestBlock
+//! restores the staged value so the retry attempt carries it. Staging again
+//! before consumption replaces the pending value (last writer wins).
 void StageRegtestSuperblock(GRC::Superblock superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool GetDevbuildCripple();

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -181,6 +181,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "claimhtlc"              , 1 },
     { "createhtlc"             , 3 },
     { "createhtlc"             , 4 },
+    { "generatesuperblock"     , 0 },
+    { "generatesuperblock"     , 1 },
     { "createrawtransaction"   , 0 },
     { "createrawtransaction"   , 1 },
     { "consolidatemsunspent"   , 1 },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1259,6 +1259,11 @@ UniValue generatesuperblock(const UniValue& params)
         }
 
         for (const UniValue& name : names) {
+            if (!name.isStr() || name.get_str().empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                                   "project name must be a non-empty string");
+            }
+
             superblock.m_projects.Add(name.get_str(), stats);
         }
     } else {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1181,7 +1181,10 @@ static const RPCHelpMan generatesuperblock_help{
     "Scrapers are disabled under -regtest, so there is no convergence for\n"
     "Quorum::CreateSuperblock() to build from and the miner suppresses\n"
     "auto-attach. This RPC is the only path: it stages the superblock given\n"
-    "here, and the next block the miner assembles consumes it.",
+    "here, and the next block the miner assembles consumes it. Run the node\n"
+    "with -staking=0 so the background stake miner cannot assemble that block\n"
+    "first; calling this RPC again before a block is mined replaces the\n"
+    "pending superblock (last writer wins).",
     {
         {"magnitudes", RPCArg::Type::OBJ_USER_KEYS, RPCArg::Optional::NO,
             "Magnitudes keyed by CPID. At least one is required: a superblock\n"

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1176,22 +1176,33 @@ UniValue generate(const UniValue& params)
 
 static const RPCHelpMan generatesuperblock_help{
     "generatesuperblock",
-    "Mine one regtest block carrying the current local superblock contract\n"
-    "(built from scraper convergence or, on -regtest where scrapers are\n"
-    "disabled, from any local quorum state). Auto-attach is disabled under\n"
-    "-regtest; this RPC is the only path.\n"
+    "Mine one regtest block carrying an explicit superblock contract.\n"
     "\n"
-    "TODO: accept JSON params to construct a synthetic superblock directly\n"
-    "rather than relying on Quorum::CreateSuperblock() state. For now, this\n"
-    "mines one block and the regtest miner code path skips superblock attach\n"
-    "(Phase 2A gate) -- so this is a stub until the 2B follow-up wires the\n"
-    "explicit-attach path.",
-    {},
+    "Scrapers are disabled under -regtest, so there is no convergence for\n"
+    "Quorum::CreateSuperblock() to build from and the miner suppresses\n"
+    "auto-attach. This RPC is the only path: it stages the superblock given\n"
+    "here, and the next block the miner assembles consumes it.",
+    {
+        {"magnitudes", RPCArg::Type::OBJ_USER_KEYS, RPCArg::Optional::NO,
+            "Magnitudes keyed by CPID. At least one is required: a superblock\n"
+            "with no CPIDs is not well formed and is refused.",
+            {
+                {"cpid", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                    "Magnitude for this CPID."},
+            }},
+        {"projects", RPCArg::Type::ARR, RPCArg::Optional::OMITTED,
+            "Project names to record. Defaults to a single synthetic project.\n"
+            "Statistics are synthetic: regtest has no project data, and the\n"
+            "superblock only needs a non-empty project index to be well formed.",
+            {
+                {"name", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Project name."},
+            }},
+    },
     RPCResult{RPCResult::Type::ARR, "", "Hashes of the blocks generated",
         {{RPCResult::Type::STR_HEX, "", "Block hash."}}},
     RPCExamples{
-        HelpExampleCli("generatesuperblock", "") +
-        HelpExampleRpc("generatesuperblock", "")},
+        HelpExampleCli("generatesuperblock", "\"{\\\"00010203040506070809101112131415\\\":100}\"") +
+        HelpExampleRpc("generatesuperblock", "{\"00010203040506070809101112131415\":100}")},
 };
 const RPCHelpMan& generatesuperblock_helpman() { return generatesuperblock_help; }
 
@@ -1200,10 +1211,55 @@ UniValue generatesuperblock(const UniValue& params)
     if (!Params().IsMockableChain()) {
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "generatesuperblock only available on -regtest");
     }
-    // TODO(2B): Construct a GRC::Superblock from caller-supplied JSON, bypass
-    // the IsMockableChain() short-circuit in AddSuperblockContractOrVote for
-    // this one call, and attach. For now, just mines a plain block so the
-    // RPC surface is reachable.
+
+    GRC::Superblock superblock(GRC::Superblock::CURRENT_VERSION);
+
+    const UniValue& magnitudes = params[0].get_obj();
+    const std::vector<std::string> cpid_keys = magnitudes.getKeys();
+
+    if (cpid_keys.empty()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "at least one CPID magnitude is required");
+    }
+
+    for (const std::string& cpid_hex : cpid_keys) {
+        const GRC::CpidOption cpid = GRC::MiningId::Parse(cpid_hex).TryCpid();
+
+        if (!cpid) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("invalid CPID: %s", cpid_hex));
+        }
+
+        const double magnitude = magnitudes[cpid_hex].get_real();
+
+        if (magnitude < 0) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               strprintf("negative magnitude for CPID %s", cpid_hex));
+        }
+
+        superblock.m_cpids.Add(*cpid, GRC::Magnitude::RoundFrom(magnitude));
+    }
+
+    // Synthetic statistics: regtest has no project data, and the superblock
+    // only needs a non-empty project index to be well formed.
+    const GRC::Superblock::ProjectStats stats(1, 1, 1);
+
+    if (params.size() > 1 && !params[1].isNull()) {
+        for (const UniValue& name : params[1].get_array().getValues()) {
+            superblock.m_projects.Add(name.get_str(), stats);
+        }
+    } else {
+        superblock.m_projects.Add("regtest", stats);
+    }
+
+    if (!superblock.WellFormed()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           "the resulting superblock is not well formed");
+    }
+
+    {
+        LOCK(cs_main);
+        StageRegtestSuperblock(std::move(superblock));
+    }
+
     return MineNBlocks(1, "");
 }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1231,6 +1231,11 @@ UniValue generatesuperblock(const UniValue& params)
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("invalid CPID: %s", cpid_hex));
         }
 
+        if (!magnitudes[cpid_hex].isNum()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               strprintf("magnitude for CPID %s must be a number", cpid_hex));
+        }
+
         const double magnitude = magnitudes[cpid_hex].get_real();
 
         if (magnitude < 0) {
@@ -1246,7 +1251,14 @@ UniValue generatesuperblock(const UniValue& params)
     const GRC::Superblock::ProjectStats stats(1, 1, 1);
 
     if (params.size() > 1 && !params[1].isNull()) {
-        for (const UniValue& name : params[1].get_array().getValues()) {
+        const std::vector<UniValue>& names = params[1].get_array().getValues();
+
+        if (names.empty()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "projects must contain at least one name");
+        }
+
+        for (const UniValue& name : names) {
             superblock.m_projects.Add(name.get_str(), stats);
         }
     } else {

--- a/test/functional/feature_generatesuperblock.py
+++ b/test/functional/feature_generatesuperblock.py
@@ -77,6 +77,8 @@ class GenerateSuperblockTest(GridcoinTestFramework):
             -8, "must be a number", node.generatesuperblock, {CPID_A: "high"})
         assert_raises_rpc_error(
             -8, "at least one name", node.generatesuperblock, {CPID_A: 100}, [])
+        assert_raises_rpc_error(
+            -8, "non-empty string", node.generatesuperblock, {CPID_A: 100}, [1])
 
         # A failed call must not leave anything staged behind it.
         node.generatetoaddress(1, node.getnewaddress())

--- a/test/functional/feature_generatesuperblock.py
+++ b/test/functional/feature_generatesuperblock.py
@@ -73,6 +73,10 @@ class GenerateSuperblockTest(GridcoinTestFramework):
             -8, "invalid CPID", node.generatesuperblock, {"not-a-cpid": 1})
         assert_raises_rpc_error(
             -8, "negative magnitude", node.generatesuperblock, {CPID_A: -1})
+        assert_raises_rpc_error(
+            -8, "must be a number", node.generatesuperblock, {CPID_A: "high"})
+        assert_raises_rpc_error(
+            -8, "at least one name", node.generatesuperblock, {CPID_A: 100}, [])
 
         # A failed call must not leave anything staged behind it.
         node.generatetoaddress(1, node.getnewaddress())

--- a/test/functional/feature_generatesuperblock.py
+++ b/test/functional/feature_generatesuperblock.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""generatesuperblock: explicit superblock attach on regtest.
+
+Scrapers are disabled under -regtest, so Quorum::CreateSuperblock() has nothing
+to build from and the miner suppresses auto-attach. generatesuperblock is the
+only path: it stages a caller-specified superblock and the next block the miner
+assembles consumes it.
+
+The block still goes through the ordinary consensus path.
+Quorum::ValidateSuperblockClaim requires the superblock to be needed, the claim
+quorum hash to match, and Quorum::ValidateSuperblock to not return INVALID --
+which on a node with no local manifest data resolves to UNKNOWN ("waiting for
+manifest data"), i.e. accepted. That is what makes a synthetic superblock
+viable on regtest without a consensus bypass.
+"""
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+CPID_A = "00010203040506070809101112131415"
+CPID_B = "1f1e1d1c1b1a19181716151413121110"
+
+
+class GenerateSuperblockTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        # -staking=0 disables the background ThreadStakeMiner so the chain only
+        # advances via explicit generate calls; -connect=0 / -listen=0 keep the
+        # node isolated.
+        self.extra_args = [["-staking=0", "-connect=0", "-listen=0"]]
+
+    def setup_network(self):
+        # Bypass the base setup_nodes() regtest branch: it calls
+        # import_deterministic_coinbase_privkeys() -> createwallet, which
+        # Gridcoin does not have.
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # A few ordinary blocks first: they must NOT pick up a superblock,
+        # which is the auto-attach suppression this RPC works around.
+        node.generatetoaddress(3, node.getnewaddress())
+        assert_equal(node.superblocks(100), [])
+
+        self.log.info("generatesuperblock attaches a staged superblock")
+        height_before = node.getblockcount()
+        hashes = node.generatesuperblock({CPID_A: 100, CPID_B: 50.25})
+        assert_equal(len(hashes), 1)
+        assert_equal(node.getblockcount(), height_before + 1)
+
+        # The block was accepted onto the chain, carrying the contract.
+        assert_equal(node.getbestblockhash(), hashes[0])
+        landed = node.superblocks(100)
+        assert len(landed) == 1, f"expected exactly one superblock, got {landed}"
+
+        self.log.info("the staged superblock is consumed exactly once")
+        # The next ordinary block must not re-attach it.
+        node.generatetoaddress(1, node.getnewaddress())
+        assert_equal(len(node.superblocks(100)), 1)
+
+        self.log.info("input validation")
+        assert_raises_rpc_error(
+            -8, "at least one CPID magnitude is required",
+            node.generatesuperblock, {})
+        assert_raises_rpc_error(
+            -8, "invalid CPID", node.generatesuperblock, {"not-a-cpid": 1})
+        assert_raises_rpc_error(
+            -8, "negative magnitude", node.generatesuperblock, {CPID_A: -1})
+
+        # A failed call must not leave anything staged behind it.
+        node.generatetoaddress(1, node.getnewaddress())
+        assert_equal(len(node.superblocks(100)), 1)
+
+
+if __name__ == "__main__":
+    GenerateSuperblockTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -177,6 +177,7 @@ BASE_SCRIPTS = [
     'rpc_net.py',
     'rpc_net_connman.py',
     'feature_sidestake.py',
+    'feature_generatesuperblock.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since longer tests benefit from being scheduled


### PR DESCRIPTION
`generatesuperblock` returned `MineNBlocks(1, "")` and nothing else: the miner suppresses superblock
auto-attach under `-regtest`, so the RPC mined an ordinary block and no superblock could ever be
produced on a regtest chain. Its own TODO described the fix. Remaining-work item 2 on #2932.

The miner keeps a single staged superblock, set only by this RPC and consumed exactly once by the
next `AddSuperblockContractOrVote` call. When nothing is staged the regtest path returns exactly as
before, so blocks produced by the deterministic staker still carry no synthetic quorum payloads. The
non-regtest path is unchanged; the function is restructured so both paths converge on the same
attach code rather than duplicating it.

The RPC takes magnitudes keyed by CPID plus an optional list of project names. Project statistics are
synthetic (1, 1, 1): regtest has no project data, and `Superblock::WellFormed()` only requires a
non-empty project index. The argument spec is deliberately **flat** — an object of user keys with
numeric values, and an array of strings — because `RPCArg::ToStringObj()` refuses to render an
object nested inside another object's `m_inner`, so a nested spec would fail help rendering.

**No consensus bypass is needed, which is worth recording because it is not obvious.**
`Quorum::ValidateSuperblockClaim` requires the superblock to be needed (true on a regtest chain with
no current superblock), the claim quorum hash to match (the attach code sets it), and
`Quorum::ValidateSuperblock` to not return `INVALID`. That last one resolves to `UNKNOWN` on a node
with no local manifest data — "we don't have enough context to try to validate a superblock. Skip the
validation and rely on peers" — and `ValidateSuperblock` returns `result != Result::INVALID`. So a
synthetic superblock is accepted on regtest through the ordinary consensus path, unmodified.

**Testing.** New `feature_generatesuperblock.py` (registered in `BASE_SCRIPTS`) covers the attach,
that ordinary blocks around it carry no superblock, that the staged superblock is consumed exactly
once, and the three input-validation errors. It fails without the consumption path. Full unit +
functional suites pass.

This is one of the two blockers on the Phase 4B researcher-flow tests; the regtest RSA trust-anchor
questions on #2932 are the other.

---

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`; the full six-workflow CI matrix is green on this exact commit.
