### PR TITLE
net: move mapAlreadyAskedFor and AskFor into net_processing

### DIFF
--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <stdexcept>
 #include "net.h"
+#include "net_processing.h"
 #include "rpc/server.h"
 #include "rpc/protocol.h"
 #include "rpc/util.h"
@@ -184,10 +185,7 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
 
     auto& ss = vRecv;
     uint256 hash(Hash(ss));
-    {
-        LOCK(cs_mapAlreadyAskedFor);
-        mapAlreadyAskedFor.erase(CInv(MSG_PART, hash));
-    }
+    if (g_peerman) g_peerman->ForgetInventoryRequest(CInv(MSG_PART, hash));
 
     LOCK(cs_mapParts);
 
@@ -369,7 +367,7 @@ void CSplitBlob::UseAsSource(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(CSplitBlob::
             if (!part->present())
             {
                 /*Actually request the part. Inventory system will prevent redundant requests.*/
-                pfrom->AskFor(CInv(MSG_PART, part->hash));
+                if (g_peerman) g_peerman->AskFor(pfrom, CInv(MSG_PART, part->hash));
             }
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -86,15 +86,6 @@ std::atomic<NodeId> CNode::nLastNodeId {-1};
 CCriticalSection cs_vAddedNodes;
 vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
 
-CCriticalSection cs_mapAlreadyAskedFor;
-// Bounded at MAX_INV_SZ, the same ceiling upstream used, and the same number a
-// single peer can announce in one inv message. The map is global, so without a
-// bound one peer announcing inventory it never serves grows state charged to
-// every peer: entries are only removed on receipt. limitedmap evicts the lowest
-// value first, and the value here is the request time, so the oldest unfulfilled
-// request is what goes.
-limitedmap<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor){MAX_INV_SZ};
-
 CCriticalSection cs_vOneShots;
 static deque<string> vOneShots GUARDED_BY(cs_vOneShots);
 

--- a/src/net.h
+++ b/src/net.h
@@ -117,8 +117,6 @@ extern ServiceFlags nLocalServices;
 //! CSplitBlob::RecvPart on the scraper PART path which does NOT hold
 //! cs_main. A dedicated leaf-level mutex avoids hoisting cs_main into
 //! the PART path and keeps the lock as narrow as possible.
-extern CCriticalSection cs_mapAlreadyAskedFor;
-extern limitedmap<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor);
 extern ThreadHandler* netThreads;
 
 
@@ -442,51 +440,6 @@ public:
         }
     }
 
-    void AskFor(const CInv& inv)
-    {
-        // We're using mapAskFor as a priority queue,
-        // the key is the earliest time the request can be sent
-        if (mapAskFor.size() > 50000) return;
-
-        // Snapshot the current request time under the mutex. The
-        // logging / time-formatting / static-counter arithmetic below
-        // does not touch mapAlreadyAskedFor and should not hold the
-        // global mutex.
-        // Absent means never asked, which is a request time of zero. Reading
-        // through find() rather than operator[] also stops the lookup itself
-        // from creating an entry: the write below is what should create it, and
-        // always runs, so the old insert-on-read was redundant as well as
-        // unbounded.
-        int64_t nRequestTime = 0;
-        {
-            LOCK(cs_mapAlreadyAskedFor);
-            const auto it = mapAlreadyAskedFor.find(inv);
-            if (it != mapAlreadyAskedFor.end()) nRequestTime = it->second;
-        }
-
-        LogPrint(BCLog::LogFlags::NET, "askfor %s   %" PRId64 " (%s)", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000));
-
-        // Make sure not to reuse time indexes to keep things in the same order
-        int64_t nNow = (GetAdjustedTime() - 1) * 1000000;
-        static int64_t nLastTime;
-        ++nLastTime;
-        nNow = std::max(nNow, nLastTime);
-        nLastTime = nNow;
-
-        // Each retry is 2 minutes after the last
-        const int64_t nNewRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
-        {
-            LOCK(cs_mapAlreadyAskedFor);
-            const auto it = mapAlreadyAskedFor.find(inv);
-
-            if (it != mapAlreadyAskedFor.end()) {
-                mapAlreadyAskedFor.update(it, nNewRequestTime);
-            } else {
-                mapAlreadyAskedFor.insert(std::make_pair(inv, nNewRequestTime));
-            }
-        }
-        mapAskFor.insert(std::make_pair(nNewRequestTime, inv));
-    }
 
     void BeginMessage(const char* pszCommand) EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)
     {

--- a/src/net.h
+++ b/src/net.h
@@ -111,12 +111,6 @@ enum
 
 extern bool fDiscover;
 extern ServiceFlags nLocalServices;
-//! \brief Guards \ref mapAlreadyAskedFor. Written and read from
-//! ProcessMessage handlers (under cs_main) for the TX / BLOCK paths,
-//! from ProcessBlock, from SendMessages' getdata loop, and from
-//! CSplitBlob::RecvPart on the scraper PART path which does NOT hold
-//! cs_main. A dedicated leaf-level mutex avoids hoisting cs_main into
-//! the PART path and keeps the lock as narrow as possible.
 extern ThreadHandler* netThreads;
 
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -77,6 +77,78 @@ static CCriticalSection cs_mapRelay;
 static map<CInv, CDataStream> mapRelay GUARDED_BY(cs_mapRelay);
 static deque<pair<int64_t, CInv> > vRelayExpiration GUARDED_BY(cs_mapRelay);
 
+// Per-inventory request times, backing the two-minute AskFor backoff. Moved out
+// of net.{h,cpp} together with CNode::AskFor (the #3028 deferral): this is
+// request tracking, which belongs to this layer.
+//
+// A dedicated leaf-level mutex rather than cs_main: the scraper PART path
+// (CSplitBlob::RecvPart) reaches it without holding cs_main, and hoisting
+// cs_main into that path to share a lock would be the wrong trade.
+//
+// Bounded at MAX_INV_SZ, the same ceiling upstream used, and the same number a
+// single peer can announce in one inv message. The map is shared, so without a
+// bound one peer announcing inventory it never serves grows state charged to
+// every peer: entries are only removed on receipt. limitedmap evicts the lowest
+// value first, and the value here is the request time, so the oldest unfulfilled
+// request is what goes.
+static CCriticalSection cs_mapAlreadyAskedFor;
+static limitedmap<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor){MAX_INV_SZ};
+
+size_t InventoryRequestMapCapacity()
+{
+    LOCK(cs_mapAlreadyAskedFor);
+    return mapAlreadyAskedFor.max_size();
+}
+
+//! Verbatim CNode::AskFor, less the CNode qualification. Kept as a file-local
+//! helper so callers in this TU do not pay a virtual dispatch through
+//! PeerManager to reach a map that is right here.
+static void AskForInv(CNode* pnode, const CInv& inv)
+{
+    // We are using mapAskFor as a priority queue,
+    // the key is the earliest time the request can be sent
+    if (pnode->mapAskFor.size() > 50000) return;
+
+    // Snapshot the current request time under the mutex. The
+    // logging / time-formatting / static-counter arithmetic below
+    // does not touch mapAlreadyAskedFor and should not hold the
+    // mutex.
+    // Absent means never asked, which is a request time of zero. Reading
+    // through find() rather than operator[] also stops the lookup itself
+    // from creating an entry: the write below is what should create it, and
+    // always runs, so the old insert-on-read was redundant as well as
+    // unbounded.
+    int64_t nRequestTime = 0;
+    {
+        LOCK(cs_mapAlreadyAskedFor);
+        const auto it = mapAlreadyAskedFor.find(inv);
+        if (it != mapAlreadyAskedFor.end()) nRequestTime = it->second;
+    }
+
+    LogPrint(BCLog::LogFlags::NET, "askfor %s   %" PRId64 " (%s)", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000));
+
+    // Make sure not to reuse time indexes to keep things in the same order
+    int64_t nNow = (GetAdjustedTime() - 1) * 1000000;
+    static int64_t nLastTime;
+    ++nLastTime;
+    nNow = std::max(nNow, nLastTime);
+    nLastTime = nNow;
+
+    // Each retry is 2 minutes after the last
+    const int64_t nNewRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
+    {
+        LOCK(cs_mapAlreadyAskedFor);
+        const auto it = mapAlreadyAskedFor.find(inv);
+
+        if (it != mapAlreadyAskedFor.end()) {
+            mapAlreadyAskedFor.update(it, nNewRequestTime);
+        } else {
+            mapAlreadyAskedFor.insert(std::make_pair(inv, nNewRequestTime));
+        }
+    }
+    pnode->mapAskFor.insert(std::make_pair(nNewRequestTime, inv));
+}
+
 void RelayTransaction(const CTransaction& tx, const uint256& hash)
 {
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
@@ -788,7 +860,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     && (!IsV15Enabled(nBestHeight) || OutOfSyncByAge());
 
                 if (!fAlreadyHave && !skip_psgt)
-                    pfrom->AskFor(inv);
+                    AskForInv(pfrom, inv);
                 else if (inv.type == MSG_BLOCK && g_orphan_blocks.Contains(inv.hash)) {
                     const CBlock* pblock_root = g_orphan_blocks.GetRootBlock(inv.hash);
                     if (pblock_root) {
@@ -1834,6 +1906,30 @@ public:
         }
 
         return nZeroed;
+    }
+
+    void AskFor(CNode* pnode, const CInv& inv) override
+    {
+        AskForInv(pnode, inv);
+    }
+
+    void ForgetInventoryRequest(const CInv& inv) override
+    {
+        LOCK(cs_mapAlreadyAskedFor);
+        mapAlreadyAskedFor.erase(inv);
+    }
+
+    void ResetInventoryRequestBackoff(const CInv& inv) override
+    {
+        LOCK(cs_mapAlreadyAskedFor);
+
+        const auto it = mapAlreadyAskedFor.find(inv);
+
+        if (it != mapAlreadyAskedFor.end()) {
+            mapAlreadyAskedFor.update(it, 0);
+        } else {
+            mapAlreadyAskedFor.insert(std::make_pair(inv, 0));
+        }
     }
 
 private:

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -92,6 +92,11 @@ static deque<pair<int64_t, CInv> > vRelayExpiration GUARDED_BY(cs_mapRelay);
 // value first, and the value here is the request time, so the oldest unfulfilled
 // request is what goes.
 static CCriticalSection cs_mapAlreadyAskedFor;
+//! Monotonic tiebreaker for AskForInv's request-time priority keys. Guarded
+//! by the map mutex: every caller runs on ThreadMessageHandler today, but
+//! AskFor is public PeerManager surface and the counter's monotonicity must
+//! not depend on callers remembering that.
+static int64_t nAskForLastTime GUARDED_BY(cs_mapAlreadyAskedFor) = 0;
 static limitedmap<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor){MAX_INV_SZ};
 
 size_t InventoryRequestMapCapacity()
@@ -109,10 +114,9 @@ static void AskForInv(CNode* pnode, const CInv& inv)
     // the key is the earliest time the request can be sent
     if (pnode->mapAskFor.size() > 50000) return;
 
-    // Snapshot the current request time under the mutex. The
-    // logging / time-formatting / static-counter arithmetic below
-    // does not touch mapAlreadyAskedFor and should not hold the
-    // mutex.
+    // Snapshot the current request time under the mutex; the logging and
+    // time formatting between the two locked blocks touch neither the map
+    // nor the tiebreaker and run unlocked.
     // Absent means never asked, which is a request time of zero. Reading
     // through find() rather than operator[] also stops the lookup itself
     // from creating an entry: the write below is what should create it, and
@@ -127,17 +131,19 @@ static void AskForInv(CNode* pnode, const CInv& inv)
 
     LogPrint(BCLog::LogFlags::NET, "askfor %s   %" PRId64 " (%s)", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000));
 
-    // Make sure not to reuse time indexes to keep things in the same order
     int64_t nNow = (GetAdjustedTime() - 1) * 1000000;
-    static int64_t nLastTime;
-    ++nLastTime;
-    nNow = std::max(nNow, nLastTime);
-    nLastTime = nNow;
-
-    // Each retry is 2 minutes after the last
-    const int64_t nNewRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
+    int64_t nNewRequestTime;
     {
         LOCK(cs_mapAlreadyAskedFor);
+
+        // Make sure not to reuse time indexes to keep things in the same order
+        ++nAskForLastTime;
+        nNow = std::max(nNow, nAskForLastTime);
+        nAskForLastTime = nNow;
+
+        // Each retry is 2 minutes after the last
+        nNewRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
+
         const auto it = mapAlreadyAskedFor.find(inv);
 
         if (it != mapAlreadyAskedFor.end()) {

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -124,6 +124,13 @@ public:
     //! in net_processing (it is request tracking, which is this layer's job, and
     //! net.h must not depend on this header). Applies the two-minute per-item
     //! backoff and pushes onto the peer's own mapAskFor priority queue.
+    //!
+    //! Lifetime contract for the null guards at external call sites
+    //! (scraper_net, chainman): g_peerman outlives every calling thread --
+    //! StopNode() joins the net and scraper threads before init resets the
+    //! pointer -- so `if (g_peerman)` there is defensive, never load-bearing.
+    //! A change to shutdown ordering must revisit those guards: a null here
+    //! silently drops a request rather than failing.
     virtual void AskFor(CNode* pnode, const CInv& inv) = 0;
 
     //! \brief Forget that an inventory item was requested.

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -117,8 +117,38 @@ public:
     //! Clear misbehavior scores for all addresses matching sub_net (registered
     //! as BanMan's clear callback). Returns the number of entries cleared.
     virtual unsigned int ClearMisbehaviorForSubnet(const CSubNet& sub_net) = 0;
+
+    //! \brief Queue an inventory request on this peer.
+    //!
+    //! Was CNode::AskFor. The per-inventory request-time map it consults lives
+    //! in net_processing (it is request tracking, which is this layer's job, and
+    //! net.h must not depend on this header). Applies the two-minute per-item
+    //! backoff and pushes onto the peer's own mapAskFor priority queue.
+    virtual void AskFor(CNode* pnode, const CInv& inv) = 0;
+
+    //! \brief Forget that an inventory item was requested.
+    //!
+    //! Call when the item arrives or the request is abandoned, so it stops being
+    //! re-asked. Absence is meaningful: SendMessages treats a missing entry as a
+    //! satisfied request and will not re-arm it.
+    virtual void ForgetInventoryRequest(const CInv& inv) = 0;
+
+    //! \brief Clear an inventory item's backoff without forgetting it.
+    //!
+    //! Leaves the entry present with a zero request time, so the next AskFor
+    //! sends immediately instead of two minutes out. Distinct from
+    //! ForgetInventoryRequest because presence is load-bearing (see above).
+    virtual void ResetInventoryRequestBackoff(const CInv& inv) = 0;
 };
 
 extern std::unique_ptr<PeerManager> g_peerman;
+
+//! \brief Capacity of the inventory-request map behind PeerManager::AskFor.
+//!
+//! The map itself is private to net_processing.cpp. This exists so the bound is
+//! still assertable: an unbounded map here is the regression that motivated
+//! keeping limitedmap at all (a peer announcing inventory it never serves grows
+//! state charged to every peer, since entries are only removed on receipt).
+size_t InventoryRequestMapCapacity();
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -9,6 +9,7 @@
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "net.h"
+#include "net_processing.h"
 #include "txdb.h"
 #include "node/blockstorage.h"
 #include "node/orphan_blocks.h"
@@ -850,26 +851,17 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me, CValidatio
                 // it never sends the request to download that block. We reset the
                 // request time first to guarantee that the node does not postpone
                 // the message:
-                //
-                {
-                    LOCK(cs_mapAlreadyAskedFor);
-
-                    // Zero is deliberate: AskFor() below takes
-                    // max(nRequestTime + 2 minutes, now), so a stale future
-                    // timestamp here would postpone the request. Note that a
-                    // zero-valued entry is also limitedmap's first eviction
-                    // candidate, which is harmless -- AskFor() raises it
-                    // immediately, and losing it in between simply means AskFor
-                    // inserts it fresh.
-                    const auto it = mapAlreadyAskedFor.find(ancestor_request);
-
-                    if (it != mapAlreadyAskedFor.end()) {
-                        mapAlreadyAskedFor.update(it, 0);
-                    } else {
-                        mapAlreadyAskedFor.insert(std::make_pair(ancestor_request, 0));
-                    }
+                // Zero is deliberate: AskFor() below takes
+                // max(nRequestTime + 2 minutes, now), so a stale future
+                // timestamp here would postpone the request. Note that a
+                // zero-valued entry is also limitedmap's first eviction
+                // candidate, which is harmless -- AskFor() raises it
+                // immediately, and losing it in between simply means AskFor
+                // inserts it fresh.
+                if (g_peerman) {
+                    g_peerman->ResetInventoryRequestBackoff(ancestor_request);
+                    g_peerman->AskFor(pfrom, ancestor_request);
                 }
-                pfrom->AskFor(ancestor_request);
             }
         }
 

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "limitedmap.h"
+#include "net_processing.h"
 
 #include "consensus/consensus.h"
 #include "net.h"
@@ -104,18 +105,20 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
 }
 
 //!
-//! The deployment that motivated keeping this container: mapAlreadyAskedFor is
-//! global, entries are only removed when the object is received, and AskFor()
-//! used to create them through operator[] on a plain std::map. A peer announcing
-//! inventory it never serves therefore grew state charged to every peer. This
-//! asserts the global is constructed bounded, which is the property that was
-//! missing rather than anything about the container itself.
+//! The deployment that motivated keeping this container: the inventory-request
+//! map behind PeerManager::AskFor has entries removed only when the object is
+//! received, and AskFor used to create them through operator[] on a plain
+//! std::map. A peer announcing inventory it never serves therefore grew state
+//! charged to every peer. This asserts the deployed map is constructed bounded,
+//! which is the property that was missing rather than anything about the
+//! container itself.
+//!
+//! The map moved into net_processing.cpp with AskFor and is file-local there,
+//! so this reaches its capacity through the one accessor rather than the map.
 //!
 BOOST_AUTO_TEST_CASE(map_already_asked_for_is_bounded)
 {
-    LOCK(cs_mapAlreadyAskedFor);
-
-    BOOST_CHECK_EQUAL(mapAlreadyAskedFor.max_size(), (size_t)MAX_INV_SZ);
+    BOOST_CHECK_EQUAL(InventoryRequestMapCapacity(), (size_t)MAX_INV_SZ);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
#3028 left the inventory-request map in `net.{h,cpp}` deliberately: moving it then would either
invert the `net.h` → `net_processing` layering or force `AskFor` out of `CNode` prematurely, and it
was to migrate later with `PeerManager`. `PeerManager` exists now; the map did not follow it.

`CNode::AskFor` moves to `PeerManager::AskFor(CNode*, const CInv&)`, and the map and its leaf-level
mutex become file-local to `net_processing.cpp` — the same treatment the relay-message cache above
them already has, and for the same reason: every accessor is now either in that translation unit or
goes through the interface. `net.h` loses both externs and the inline method.

**Two accessors rather than one, because presence in the map is load-bearing:**

| | |
|---|---|
| `ForgetInventoryRequest` | erase; the request is satisfied or abandoned |
| `ResetInventoryRequestBackoff` | set to zero, leaving the entry present |

They are not interchangeable. `SendMessages` re-arms a queued request only if the entry is still
there — "if the entry is gone, the request is satisfied and we should not reinsert it" — so erasing
where the caller means "send this now" would change that path. The two external callers want
different things: `scraper_net` has received the part and is done with it, while `chainman` is
clearing the two-minute backoff so an ancestor block is re-requested immediately, and its entry must
survive to be re-armed.

The four erase sites and the re-arm site inside `net_processing` are unchanged: the file-local names
match the old globals, so only the definition moved.

**One test had to change shape.** `limitedmap_tests` asserted that the deployed map is constructed
bounded — the regression that motivated keeping `limitedmap` at all, since entries are removed only
on receipt and an unbounded map lets one peer grow state charged to every peer. That test named the
global directly, which a file-local map cannot support, so `net_processing` exposes
`InventoryRequestMapCapacity()` and the test asserts through it. The property under test is
unchanged; testing `limitedmap`'s own bounding instead would assert something the container tests
already cover.

**Testing.** Unit + functional suites pass.

---

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`; the full six-workflow CI matrix is green on this exact commit.
