### PR TITLE
qt: stop the coin-control columns overflowing the dialog

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -161,12 +161,28 @@ void CoinControlDialog::setModel(WalletModel *model)
         ui->treeView->setModel(m_selection_model);
         ui->treeView->setAlternatingRowColors(m_selection_model->displayMode() == GRC::CoinViewMode::Flat);
 
-        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_CHECKBOX, 150);
-        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_AMOUNT, 170);
-        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_LABEL, 200);
-        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_ADDRESS, 290);
-        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_DATE, 110);
-        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_CONFIRMATIONS, 100);
+        // These were raw pixels totalling 1020px against the .ui default of
+        // 960px, so the view opened with a horizontal scrollbar. Two changes:
+        //
+        // Trimmed to 910px, leaving room for the frame and a vertical
+        // scrollbar. Scaling alone would not have fixed it -- the dialog is
+        // DPI/font-scaled at construction (the resize() above) and the columns
+        // were not, so an over-wide total stays over-wide once both scale by
+        // the same factor.
+        //
+        // Scaled through the same helper the dialog uses, so the columns track
+        // it. That is also why this was easy to miss: unscaled columns against
+        // a scaled dialog meant the overflow was worst at 100% scaling and
+        // shrank or vanished on a high-DPI display. Verify at 100%.
+        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_CHECKBOX, GRC::ScalePx(this, 140));
+        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_AMOUNT, GRC::ScalePx(this, 160));
+        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_LABEL, GRC::ScalePx(this, 180));
+        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_ADDRESS, GRC::ScalePx(this, 220));
+        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_DATE, GRC::ScalePx(this, 100));
+        // 110, not the previous 100: "Confirmations" is the longest header and
+        // was already clipped at 100. Address gives up the width, so the total
+        // is unchanged.
+        ui->treeView->setColumnWidth(CoinSelectionModel::COLUMN_CONFIRMATIONS, GRC::ScalePx(this, 110));
 
         connect(ui->treeView, &CoinSelectionView::visibleIndexesChanged,
                 m_selection_model, &CoinSelectionModel::onVisibleIndexes);


### PR DESCRIPTION
The six column widths totalled 1020px against the `.ui` default of 960px, so the coin-control view
opened with a horizontal scrollbar and the Confirmations column was pushed off the edge. Noted
during the #3224 interactive verification pass as worth trimming before merge or as a fixup; it
merged without it.

Nothing was overriding them: no `QHeaderView` resize mode is ever set, `coincontroldialog.ui` sets
`headerStretchLastSection` false explicitly, there is no `QSettings` header save/restore, no column
is hidden, and `CoinSelectionModel` has exactly those six columns.

Trimmed to 910px, leaving room for the frame and a vertical scrollbar, and routed through
`GRC::ScalePx` so the columns scale with the dialog.

**Both halves are needed.** The dialog is DPI/font-scaled at construction
(`coincontroldialog.cpp:52`) while the widths were raw pixels, so scaling alone would leave an
over-wide total over-wide once both scale by the same factor. That mismatch is also why this is easy
to miss: the overflow is worst at 100% scaling and shrinks or vanishes on a high-DPI display, where
the dialog scales past 1020px but the columns do not.

`Confirmations` gets 110 rather than its previous 100: it is the longest header and was already
clipped at 100. `Address` gives up the 20px, so the total is unchanged.

**Testing.** Verified in a Qt6 build in the running GUI at 100% scaling: the dialog opens with no
horizontal scrollbar, all six columns visible, and the `Confirmations` header fully rendered.
Reviewers on a scaled display will not reproduce the original overflow — check at 100%.

---

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`; the full six-workflow CI matrix is green on this exact commit.
