### PR TITLE
init: register ten options that are parsed but never reachable

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -576,6 +576,8 @@ void AddLoggingArgs(ArgsManager& argsman)
     argsman.AddArg("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)",
                                                DEFAULT_LOGTIMEMICROS),
                    ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-logips", strprintf("Include IP addresses in debug output (default: %u)", DEFAULT_LOGIPS),
+                   ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-printtoconsole", "Send trace/debug info to console (default: 0) )",
                    ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-printtodebugger", "Send trace/debug info to debugger (default: 0)",
@@ -628,6 +630,8 @@ void SetupServerArgs()
                                             " location. (default: %s)", GRIDCOIN_PID_FILENAME),
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-blocksdir=<dir>", "Specify directory to hold block data (default: <datadir>)",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-nonewprivs", strprintf("On Linux, set NO_NEW_PRIVS and drop the capability bounding set at "
                                             "startup so the daemon and its children can never gain privileges "
                                             "(e.g. via a setuid binary). Best-effort defence-in-depth; ignored on "
@@ -658,6 +662,9 @@ void SetupServerArgs()
     argsman.AddArg("-blocknotify=<cmd>", "Execute command when the best block changes (%s in cmd is replaced by block hash)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-walletnotify=<cmd>", "Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-projectnotify=<cmd>", "Execute command when a project is added to or removed from the whitelist, or "
+                                           "an existing project's status changes",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-pollnotify=<cmd>", "Execute command when a poll is added/deleted/expiring (%s1 in cmd is replaced by poll id,"
                                         "%s2 is replaced by status: added, deleted, expiration warning)",
@@ -717,6 +724,8 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::STAKING);
     argsman.AddArg("-staking", "Allow wallet to stake if conditions to stake are met (default: 1)",
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::STAKING);
+    argsman.AddArg("-minersleep=<n>", "Milliseconds the staking loop sleeps between rounds (default: 8000)",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::STAKING);
     argsman.AddArg("-sidestake=<address,percent>", "Sidestake destination and allocation entry. There can be as many "
                                                    "specified as desired. Only six per stake can be sent. If more than "
                                                    "six are specified. Six are randomly chosen for each stake. Only active "
@@ -841,6 +850,9 @@ void SetupServerArgs()
     argsman.AddArg("-tor=<ip:port>", "Use proxy to reach Tor onion services (default: same as -proxy)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-dns", "Allow DNS lookups for -addnode, -seednode and -connect",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-addrlifespan=<n>", "Maximum age in days of the peer addresses returned in response to a getaddr "
+                                        "message; older addresses are withheld (default: 7)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-port=<port>", "Listen for connections on <port> (default: 32749 or testnet: 32748)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
@@ -998,6 +1010,13 @@ void SetupServerArgs()
 
     // These probably should be removed
     hidden_args.emplace_back("-printcoinage");
+    // Same family as the four above, and missed when they were registered: each
+    // of these dumps state and then aborts startup, so they are debug tools that
+    // have been unreachable rather than options anyone relies on.
+    hidden_args.emplace_back("-printblock");
+    hidden_args.emplace_back("-printblockindex");
+    hidden_args.emplace_back("-printblocktree");
+    hidden_args.emplace_back("-loadblockindextest");
     hidden_args.emplace_back("-privdb");
 
     // This is hidden because it defaults to true and should NEVER be changed unless you know what you are doing.
@@ -1033,6 +1052,15 @@ void SetupServerArgs()
     hidden_args.emplace_back("-rpcsslcertificatechainfile");
     hidden_args.emplace_back("-rpcsslprivatekeyfile");
     hidden_args.emplace_back("-rpcsslciphers");
+
+    // -socks is also a removed option, but unlike the -rpcssl group it is
+    // refused rather than warned about: AppInit2 returns InitError when it is
+    // set, because silently ignoring a SOCKS-version setting is a privacy risk.
+    // That guard only works if the option parses at all -- while unregistered, a
+    // -socks in the config file is dropped before AppInit2 can test for it, and
+    // on the command line it dies as "Invalid parameter" instead of explaining
+    // itself.
+    hidden_args.emplace_back("-socks");
 
     argsman.AddHiddenArgs(hidden_args);
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1570,10 +1570,6 @@ bool AppInit2(ThreadHandlerPtr threads)
         gArgs.SoftSetBoolArg("-rescan", true);
     }
 
-    // Verify testnet is using the testnet directory for the config file:
-    std::string sTestNetSpecificArg = gArgs.GetArg("-testnetarg", "default");
-    LogPrintf("Using specific arg %s", sTestNetSpecificArg);
-
 
     // ********************************************************* Step 3: parameter-to-internal-flags
 


### PR DESCRIPTION
Eleven options are read by `init.cpp` and friends but have no `AddArg` entry, which means none of
them can be set. Ten are worth making work; one is worth deleting.

Based on `development` @ `2d9ec8e1bf96696d1b511b2f52a75482d93c1cc2`.

### Why an unregistered option is dead, not merely undocumented

- **Command line:** `ParseParameters` looks up `GetArgFlags` and, finding none, fails with
  `Invalid parameter <arg>` (`util/system.cpp:266`). The node refuses to start.
- **Config file:** `ReadConfigStream` logs `Ignoring unknown configuration value <key>` and drops it
  (`util/system.cpp:958`). All seven `ReadConfigFiles` call sites pass `ignore_invalid_keys = true`,
  so this is always the quiet path, never a hard error.

So every read of these options returns its default, permanently, while the code reads them as though
they work.

### Registered as listed options — each drives something

| Option | Consumer | Effect of it being dead |
|---|---|---|
| `-addrlifespan` | `nNodeLifespan`, `net_processing.cpp:1174` | The GETADDR cutoff is frozen at 7 days; addresses older than that are withheld from a reply and the operator cannot change it. |
| `-blocksdir` | `GetBlocksDir`, `util/system.cpp:308` | Block data cannot be relocated. |
| `-logips` | `fLogIPs`, `init.cpp:1128` | Can never be anything but `DEFAULT_LOGIPS` (false), so peer IPs can never be logged. |
| `-minersleep` | `nMinerSleep`, `miner.cpp:1583` | The staking loop's inter-round sleep is frozen at 8000 ms. |
| `-projectnotify` | `project.cpp:930` | The whitelist-change hook can never fire. Its three siblings `-blocknotify`, `-walletnotify` and `-alertnotify` are all registered; this one was missed. |

### Registered as hidden options — not things to advertise

**`-socks`** is the sharpest case. `init.cpp:1559` returns `InitError` for it deliberately, because
silently ignoring a SOCKS-version setting is a privacy risk:

```cpp
if (gArgs.IsArgSet("-socks"))
    return InitError(_("Error: Unsupported argument -socks found. ..."));
```

Unregistered, that guard could not fire from a config file at all — precisely the case it was
written for. From the command line it died as `Invalid parameter` instead of explaining itself. It
is now registered hidden, next to the `-rpcssl` group, which this tree already handles exactly this
way and for exactly this reason (see the comment above those four lines).

**`-printblock`, `-printblockindex`, `-printblocktree`, `-loadblockindextest`** are debug dumps that
abort startup. Their siblings `-printstakemodifier`, `-printpriority`, `-printkeypool` and
`-printcoinage` are already in `hidden_args`; these four were simply missed, so they follow the same
convention rather than being deleted.

### Removed: `-testnetarg`

```cpp
// Verify testnet is using the testnet directory for the config file:
std::string sTestNetSpecificArg = gArgs.GetArg("-testnetarg", "default");
LogPrintf("Using specific arg %s", sTestNetSpecificArg);
```

Read, logged, never used again — no other reference to the variable or the option exists, and the
comment describes a datadir check the code does not perform. Being unregistered too, it has logged
`Using specific arg default` on every start since the ArgsManager port. The other ten are worth
registering because each drives something; this one has nothing to drive, and registering it would
document a no-op in `-help`.

### Testing

- `test_gridcoin`: clean.
- Functional suite: 29/29 passed.
- Behaviour checked directly against a build of this tree:
  - `socks=5` in the config file now stops the node with `Unsupported argument -socks found`, where
    it previously started and ignored the line.
  - `-socks=5` on the command line now gives that same explanatory error instead of
    `Invalid parameter`.
  - `-help` now lists the five documented options.
  - An option still absent from the table logs `Ignoring unknown configuration value` on the same
    binary — the behaviour all eleven had.

### Behaviour an existing configuration would see on upgrade

This is the part worth a careful read, because options that were inert become live:

- **A config file containing `socks=...` will now stop the node** with the explanatory error, where
  before it started and ignored the setting. That is the intent of the guard, but it will surface on
  upgrade for anyone carrying a legacy line.
- A stale `-addrlifespan`, `-blocksdir`, `-logips`, `-minersleep` or `-projectnotify` in an existing
  `gridcoinresearch.conf` starts taking effect, having been silently ignored until now.
- `-testnetarg` in a config file goes from being ignored to... still being ignored, so no change.

If you would rather the newly live options land separately from the `-socks` change, the two commits
split cleanly and I can reorganise.
