### PR TITLE
net: stop holding m_misbehavior_cs across BanMan::Ban

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1816,6 +1816,15 @@ public:
             fBan = nMisbehavior >= gArgs.GetArg("-banscore", 100);
         }
 
+        // The ban lands OUTSIDE m_misbehavior_cs -- holding it across Ban()
+        // was the m_misbehavior_cs -> m_cs_banned half of an AB-BA against
+        // the clear-callback path. Accepted trade-off of the release: a
+        // clearbanned/Unban/sweep that fully completes in this window zeroes
+        // a score this thread already counted, and the Ban() below still
+        // lands afterwards -- a decision made microseconds before the clear
+        // is not unwound by it. Benign (the operator can clear again;
+        // Ban() itself is last-writer-wins under m_cs_banned), and strictly
+        // better than the deadlock.
         if (fBan)
         {
             LogPrint(BCLog::LogFlags::NET, "Misbehaving: %s (%d -> %d) BANNING", addr.ToString(), nMisbehavior - howmuch, nMisbehavior);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1790,13 +1790,33 @@ public:
             return false;
         }
 
-        LOCK(m_misbehavior_cs);
+        // Decide under the lock, ban outside it. Holding m_misbehavior_cs across
+        // Ban() takes BanMan::m_cs_banned second, while ClearBanned / Unban /
+        // SweepBanned take m_cs_banned first and reach m_misbehavior_cs through the
+        // misbehavior-clear callback (BanMan::ZeroMisbehavior ->
+        // ClearMisbehaviorForSubnet). That AB-BA needs no exotic interleaving: a peer
+        // crossing -banscore on a message-handler thread while the periodic banlist
+        // sweep or an RPC clearbanned runs is enough. Keeping m_misbehavior_cs a leaf
+        // removes the edge outright rather than leaving a rule every future caller has
+        // to remember.
+        //
+        // The score is captured here rather than re-read after the lock is dropped:
+        // the ban decision and the transition this call logs must describe the same
+        // update, and another thread may adjust the entry in between.
+        int nMisbehavior;
+        bool fBan;
 
-        int nMisbehavior = GetMisbehaviorScore_(addr) + howmuch;
+        {
+            LOCK(m_misbehavior_cs);
 
-        m_misbehavior[addr] = std::make_pair(nMisbehavior, GetAdjustedTime());
+            nMisbehavior = GetMisbehaviorScore_(addr) + howmuch;
 
-        if (nMisbehavior >= gArgs.GetArg("-banscore", 100))
+            m_misbehavior[addr] = std::make_pair(nMisbehavior, GetAdjustedTime());
+
+            fBan = nMisbehavior >= gArgs.GetArg("-banscore", 100);
+        }
+
+        if (fBan)
         {
             LogPrint(BCLog::LogFlags::NET, "Misbehaving: %s (%d -> %d) BANNING", addr.ToString(), nMisbehavior - howmuch, nMisbehavior);
 
@@ -1871,8 +1891,11 @@ private:
     BanMan* const m_banman;
 
     // Per-address misbehavior scores (relocated from net_processing file scope
-    // in PR 8b). Lock order: cs_main -> cs_wallet -> m_misbehavior_cs ->
-    // BanMan::m_cs_banned (Misbehaving locks this then calls m_banman->Ban).
+    // in PR 8b). m_misbehavior_cs is a LEAF: nothing is called out to while it is
+    // held. Misbehaving() decides under it and releases before m_banman->Ban(), so
+    // the only remaining edge is BanMan::m_cs_banned -> m_misbehavior_cs, taken by
+    // ClearBanned / Unban / SweepBanned through the misbehavior-clear callback.
+    // Lock order: cs_main -> cs_wallet -> BanMan::m_cs_banned -> m_misbehavior_cs.
     mutable CCriticalSection m_misbehavior_cs;
     std::map<CAddress, std::pair<int, int64_t>> m_misbehavior GUARDED_BY(m_misbehavior_cs);
 };

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1900,11 +1900,16 @@ private:
     BanMan* const m_banman;
 
     // Per-address misbehavior scores (relocated from net_processing file scope
-    // in PR 8b). m_misbehavior_cs is a LEAF: nothing is called out to while it is
-    // held. Misbehaving() decides under it and releases before m_banman->Ban(), so
-    // the only remaining edge is BanMan::m_cs_banned -> m_misbehavior_cs, taken by
+    // in PR 8b). m_misbehavior_cs is a leaf with ONE deliberate exception:
+    // gArgs.GetArg (-banscore/-bantime for the decay math) is read while it is
+    // held, taking ArgsManager's cs_args nested. cs_args is itself a terminal
+    // leaf that calls nothing, so the edge cannot form a cycle. Nothing else
+    // is called out to under this lock -- in particular Misbehaving() decides
+    // under it and releases before m_banman->Ban(), so the only cross-
+    // subsystem edge is BanMan::m_cs_banned -> m_misbehavior_cs, taken by
     // ClearBanned / Unban / SweepBanned through the misbehavior-clear callback.
-    // Lock order: cs_main -> cs_wallet -> BanMan::m_cs_banned -> m_misbehavior_cs.
+    // Lock order: cs_main -> cs_wallet -> BanMan::m_cs_banned -> m_misbehavior_cs
+    // (-> cs_args).
     mutable CCriticalSection m_misbehavior_cs;
     std::map<CAddress, std::pair<int, int64_t>> m_misbehavior GUARDED_BY(m_misbehavior_cs);
 };

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -308,6 +308,14 @@ bool LockStackEmpty()
 
 bool GetLockOrderDebugAbort() { return g_debug_lockorder_abort; }
 void SetLockOrderDebugAbort(bool enable) { g_debug_lockorder_abort = enable; }
+void ResetLockOrderTracking()
+{
+    LockData& lockdata = GetLockData();
+    std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
+    lockdata.lockorders.clear();
+    lockdata.invlockorders.clear();
+}
+
 bool GetLockOrderDebugThrowException() { return g_debug_lockorder_throw_exception; }
 void SetLockOrderDebugThrowException(bool enable) { g_debug_lockorder_throw_exception = enable; }
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -74,6 +74,14 @@ bool GetLockOrderDebugAbort();
 void SetLockOrderDebugAbort(bool enable);
 bool GetLockOrderDebugThrowException();
 void SetLockOrderDebugThrowException(bool enable);
+
+//! Forget every lock-order edge recorded so far. The detector registers each
+//! ordered pair once and short-circuits on repeats, so a pair whose conflict
+//! was already reported (or merely registered) earlier in the process is
+//! invisible to later tests. A test that wants to prove a specific inversion
+//! fires must clear the table first, then drive both legs itself. Detection
+//! for subsequently-run code re-registers pairs as they occur.
+void ResetLockOrderTracking();
 #else
 inline void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
 inline void LeaveCritical() {}

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -101,6 +101,14 @@ BOOST_AUTO_TEST_CASE(DoS_ban_then_clear_lock_order)
 
     SetLockOrderDebugAbort(false);
     SetLockOrderDebugThrowException(true);
+
+    // The detector registers each ordered pair once and short-circuits on
+    // repeats -- and the earlier DoS cases have already driven both legs
+    // non-fatally, so without a reset this case can never observe the
+    // conflict and would pass on the unfixed code too (verified by building
+    // the old Misbehaving() against this test). Clear the table so the two
+    // legs below are the pair's first registrations.
+    ResetLockOrderTracking();
 #endif
 
     g_banman->ClearBanned();

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -95,6 +95,13 @@ BOOST_AUTO_TEST_CASE(DoS_ban_then_clear_lock_order)
     // Structured like sync_tests' potential_deadlock_detected: the detector only
     // exists in a DEBUG_LOCKORDER build, so ask it to throw rather than warn
     // there, and let the case degenerate to a plain ban/unban check elsewhere.
+    // Setup clear runs BEFORE the throw flag and the table reset: with
+    // leftover bans from earlier cases it drives the clear-callback leg,
+    // and on the old nesting a conflict here (or in Misbehaving below)
+    // would throw OUTSIDE the try/catch and fail the case as an uncaught
+    // exception instead of through the assertion it exists for.
+    g_banman->ClearBanned();
+
 #ifdef DEBUG_LOCKORDER
     const bool prev_lockorder_abort = GetLockOrderDebugAbort();
     const bool prev_lockorder_throw_exception = GetLockOrderDebugThrowException();
@@ -106,12 +113,13 @@ BOOST_AUTO_TEST_CASE(DoS_ban_then_clear_lock_order)
     // repeats -- and the earlier DoS cases have already driven both legs
     // non-fatally, so without a reset this case can never observe the
     // conflict and would pass on the unfixed code too (verified by building
-    // the old Misbehaving() against this test). Clear the table so the two
-    // legs below are the pair's first registrations.
+    // the old Misbehaving() against this test). Clear the table HERE, after
+    // the setup clear: Misbehaving below then makes the pair's first
+    // registration (the old nesting's A leg), and the ClearBanned inside the
+    // try/catch is what first drives the reverse order -- so the
+    // discriminating throw lands exactly where the catch is waiting.
     ResetLockOrderTracking();
 #endif
-
-    g_banman->ClearBanned();
 
     CAddress addr(ip(0xa0b0c004));
     CNode dummyNode(INVALID_SOCKET, addr, "", true);

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -15,6 +15,7 @@
 #include <test/test_gridcoin.h>
 
 #include <net_processing.h>
+#include <stdexcept>
 #include <stdint.h>
 
 // Tests this internal-to-main.cpp method:
@@ -81,6 +82,49 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 
     // TODO: Why no ClearArg?
     gArgs.ForceSetArg("-banscore", "100");
+}
+
+BOOST_AUTO_TEST_CASE(DoS_ban_then_clear_lock_order)
+{
+    // Misbehaving() reaches BanMan::m_cs_banned through Ban(); ClearBanned()
+    // reaches m_misbehavior_cs the other way, through the misbehavior-clear
+    // callback. If Misbehaving() bans while still holding m_misbehavior_cs the
+    // two orders form an AB-BA, and the pair below is enough to record both
+    // edges in one thread -- no concurrency needed to show it.
+    //
+    // Structured like sync_tests' potential_deadlock_detected: the detector only
+    // exists in a DEBUG_LOCKORDER build, so ask it to throw rather than warn
+    // there, and let the case degenerate to a plain ban/unban check elsewhere.
+#ifdef DEBUG_LOCKORDER
+    const bool prev_lockorder_abort = GetLockOrderDebugAbort();
+    const bool prev_lockorder_throw_exception = GetLockOrderDebugThrowException();
+
+    SetLockOrderDebugAbort(false);
+    SetLockOrderDebugThrowException(true);
+#endif
+
+    g_banman->ClearBanned();
+
+    CAddress addr(ip(0xa0b0c004));
+    CNode dummyNode(INVALID_SOCKET, addr, "", true);
+
+    dummyNode.Misbehaving(1000); // over -banscore whatever an earlier case left it at
+    BOOST_CHECK(g_banman->IsBanned(addr));
+
+    bool error_thrown = false;
+    try {
+        g_banman->ClearBanned();
+    } catch (const std::logic_error&) {
+        error_thrown = true;
+    }
+
+    BOOST_CHECK(!error_thrown);
+    BOOST_CHECK(!g_banman->IsBanned(addr));
+
+#ifdef DEBUG_LOCKORDER
+    SetLockOrderDebugAbort(prev_lockorder_abort);
+    SetLockOrderDebugThrowException(prev_lockorder_throw_exception);
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)


### PR DESCRIPTION
Fixes the `m_misbehavior_cs` ↔ `BanMan::m_cs_banned` AB-BA you flagged during the #2558 stack
review. #3031 recorded it as relocated-not-introduced and handed it to #3039; #3039 merged the
relocation without the fix, and nothing since has touched it.

This is the fix suggested on #3039, verbatim: compute the ban decision under the lock, release,
then call `Ban()`. I had mildly preferred fixing it on the BanMan side (collect the subnets under
`m_cs_banned`, release, then `ZeroMisbehavior`) on diff size, but yours is better for the reason
you gave — it makes the constraint structural instead of leaving a leaf lock every future caller
has to remember not to hold.

### The interleaving

`Misbehaving()` took `m_misbehavior_cs` and called `m_banman->Ban()` inside it, taking
`m_cs_banned` second. `ClearBanned()`, `Unban()` and `SweepBanned()` take `m_cs_banned` first and
reach `m_misbehavior_cs` through the misbehavior-clear callback
(`BanMan::ZeroMisbehavior` → `PeerManagerImpl::ClearMisbehaviorForSubnet`). Nothing exotic is
needed to hit it: a peer crossing `-banscore` on a message-handler thread while the periodic
banlist dump's sweep or an RPC `clearbanned` runs.

### It is observable without writing a concurrency test

The unit suite already takes both legs in one process — `test_gridcoin.cpp:161-165` constructs
`g_peerman` and registers the clear callback on `g_banman`, and `DoS_tests` drives
`CNode::Misbehaving` (which forwards to `g_peerman->Misbehaving`, `net.cpp:512`) and
`BanMan::ClearBanned`. So a `-DENABLE_DEBUG_LOCKORDER` build of `development` reports it directly:

```
potential deadlock detected: m_misbehavior_cs -> m_cs_banned -> m_misbehavior_cs
  #1 'm_cs_banned' in src/banman.cpp:60
  #2 'm_misbehavior_cs' in src/net_processing.cpp:1805
```

After this commit that run is clean — zero occurrences.

`DoS_ban_then_clear_lock_order` pins it, structured exactly like `sync_tests`'
`potential_deadlock_detected`: it asks the detector to throw rather than warn where
`DEBUG_LOCKORDER` is defined, and degenerates to a plain ban/unban check where it is not.

Worth saying plainly: **no workflow sets `-DENABLE_DEBUG_LOCKORDER`**, so in CI today the new case
is the degenerate form and the detector never runs. It still discriminates for anyone building
with it locally, and it is the same bargain the existing `sync_tests` case already makes. A
lock-order CI leg looks worth having, but that is its own change and not this PR.

### One judgement call in the diff

The score is captured under the lock rather than re-read after reacquiring, so the ban decision
and the transition the log line reports describe the same update. Re-reading would let another
thread's adjustment land between the two and produce a log line that never corresponded to any
decision.

The member's lock-order comment is updated to say `m_misbehavior_cs` is now a leaf, since the
old comment documented precisely the edge being removed.

**Testing.** Unit suite and the full functional suite pass; `DEBUG_LOCKORDER` before/after as
above.
