### PR TITLE
txmempool: make addUnchecked lock cs internally

### DIFF
--- a/src/test/addressbook_tests.cpp
+++ b/src/test/addressbook_tests.cpp
@@ -319,10 +319,6 @@ void InjectMempoolTx(const CTransaction& tx)
     CWalletTx wtx(pwalletMain, tx);
     wtx.SetTxState(TxStateInMempool{});
     pwalletMain->mapWallet[tx.GetHash()] = wtx;
-    // addUnchecked's contract requires the caller hold mempool.cs (it does no internal
-    // locking, unlike mempool.remove in RemoveMempoolTx below); acquire it after cs_wallet
-    // per the canonical lock order.
-    LOCK(mempool.cs);
     mempool.addUnchecked(tx.GetHash(), CTxMemPoolEntry(
         tx, /*fee=*/0, /*time=*/0, /*height=*/0,
         ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION)));

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -540,10 +540,6 @@ struct CoinControlSetup
             CWalletTx orphaned(&test_wallet, orphan);
             test_wallet.mapWallet[orphan.GetHash()] = orphaned;
 
-            // addUnchecked does no internal locking (unlike remove/clear/exists):
-            // the caller must hold mempool.cs, acquired last per the canonical
-            // cs_main -> cs_wallet -> subsystem order.
-            LOCK(mempool.cs);
             mempool.addUnchecked(funding.GetHash(), CTxMemPoolEntry(
                 funding, /*fee=*/0, /*time=*/0, /*height=*/0,
                 ::GetSerializeSize(funding, SER_NETWORK, PROTOCOL_VERSION)));

--- a/src/test/psgt_pool_tests.cpp
+++ b/src/test/psgt_pool_tests.cpp
@@ -28,7 +28,6 @@ BOOST_AUTO_TEST_SUITE(psgt_pool_tests)
 //! transactions are made visible.
 static void AddToMempool(const CTransaction& tx)
 {
-    LOCK(mempool.cs);
     mempool.addUnchecked(tx.GetHash(),
                          CTxMemPoolEntry(tx, 0, 1700000000, 1,
                                          ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION)));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -59,12 +59,20 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry)
     // Add to memory pool without checking anything.  Don't call this directly,
     // call AcceptToMemoryPool to properly check the transaction first.
     {
-        // Caller contract: AcceptToMemoryPool holds cs and has already rejected a
-        // tx that exists() in the pool, so this is a fresh txid. insert_or_assign
-        // would only "overwrite" on a duplicate txid -- and an identical txid
-        // implies identical vins, so re-pointing mapNextTx below to the new node
-        // is still correct. (Other mutators lock internally; this one relies on
-        // the caller holding cs, matching the "unchecked = caller-locked" idiom.)
+        // Take cs here rather than requiring it of the caller. Every other mutator
+        // on this class -- remove(), removeConflicts(), TrimToSize(),
+        // DynamicMemoryUsage() -- already locks internally; this was the one whose
+        // locking contract existed only in a comment. cs is a recursive mutex, so
+        // the single production caller (AcceptToMemoryPool, which holds pool.cs
+        // across its check-then-add so that mapNextTx cannot change underneath it)
+        // is unaffected.
+        LOCK(cs);
+
+        // The rest of the caller contract stands, and is not about locking:
+        // AcceptToMemoryPool has already rejected a tx that exists() in the pool,
+        // so this is a fresh txid. insert_or_assign would only "overwrite" on a
+        // duplicate txid -- and an identical txid implies identical vins, so
+        // re-pointing mapNextTx below to the new node is still correct.
         auto it = mapTx.insert_or_assign(hash, entry).first;
         // Point mapNextTx at the transaction stored inside the pool's own map
         // node (std::map never relocates nodes, so the pointer stays valid until

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -63,9 +63,11 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry)
         // on this class -- remove(), removeConflicts(), TrimToSize(),
         // DynamicMemoryUsage() -- already locks internally; this was the one whose
         // locking contract existed only in a comment. cs is a recursive mutex, so
-        // the single production caller (AcceptToMemoryPool, which holds pool.cs
-        // across its check-then-add so that mapNextTx cannot change underneath it)
-        // is unaffected.
+        // the single production caller (AcceptToMemoryPool, which calls from
+        // inside its own pool.cs store scope) is unaffected. What serializes
+        // that caller's exists()-check against this insert is cs_main, held
+        // for its whole call -- its pool.cs acquisitions are three separate
+        // scopes, not one continuous hold.
         LOCK(cs);
 
         // The rest of the caller contract stands, and is not about locking:

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -195,6 +195,9 @@ public:
     //! non-consensus pool; revisit if a tighter memory bound is ever needed.
     static constexpr size_t PER_ENTRY_OVERHEAD = 256;
 
+    //! rief Insert an already-validated transaction. Locks cs internally, like
+    //! every other mutator here; "unchecked" refers to transaction validation,
+    //! which the caller must have done (see AcceptToMemoryPool), not to locking.
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry);
     bool remove(const CTransaction &tx, bool fRecursive = false,
                 MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -195,7 +195,7 @@ public:
     //! non-consensus pool; revisit if a tighter memory bound is ever needed.
     static constexpr size_t PER_ENTRY_OVERHEAD = 256;
 
-    //! rief Insert an already-validated transaction. Locks cs internally, like
+    //! \brief Insert an already-validated transaction. Locks cs internally, like
     //! every other mutator here; "unchecked" refers to transaction validation,
     //! which the caller must have done (see AcceptToMemoryPool), not to locking.
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry);
@@ -344,8 +344,8 @@ public:
 
 private:
     //! Remove an entry's contributions from the secondary indexes, the running
-    //! size total, and the eviction index. Caller holds cs.
-    void eraseIndexes(const CTxMemPoolEntry& entry);
+    //! size total, and the eviction index.
+    void eraseIndexes(const CTxMemPoolEntry& entry) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Build the eviction-ordering key for an entry.
     static CTxMemPoolEvictionKey EvictionKeyFor(const CTxMemPoolEntry& entry)


### PR DESCRIPTION
`addUnchecked()` was the last mutator on `CTxMemPool` whose locking contract lived only in a
comment. `remove()`, `removeConflicts()`, `TrimToSize()` and `DynamicMemoryUsage()` all take `cs`
themselves. This flips `addUnchecked()` to match, which deletes the contract rather than
restating it.

"Unchecked" refers to transaction validation, which the caller still must have done; the header
now says so, because the name reads like it means "unlocked too".

You deferred this twice (#3090, #3091) as a deliberate mempool-wide convention change, so here is
what the two routes actually cost, measured on `development` @ `ee204cd61`.

### Internal locking — this PR

`cs` is recursive (`CCriticalSection = AnnotatedMixin<std::recursive_mutex>`), so the **one**
production caller is unaffected: `AcceptToMemoryPool` re-enters here from inside its own
`pool.cs` store scope. (Maintainer correction: the original text claimed `pool.cs` is held
continuously across the `exists()` check-then-add; it is not -- `exists()`, the `mapNextTx`
scan, and the store are three separate `pool.cs` scopes with unlocked validation work between
them, and what actually serializes the check-then-add is `cs_main`, held for the whole call.
`pool.cs` guards the data structures within that already-serialized window.)

Every other call site is a test — 28 in `txmempool_tests.cpp`, one each in `psgt_pool_tests.cpp`,
`interfaces_tests.cpp` and `addressbook_tests.cpp` — and none of them takes `cs`;
`txmempool_tests.cpp` contains no `LOCK()` at all. Those 31 calls were technically violating the
documented contract. They are now correct by construction.

### The annotation route — what it would take

The note already in the tree at `txmempool.h:253-255` is right, and the numbers make it concrete:
**not one member of this class carries `GUARDED_BY`** (the single grep hit in the header is that
note's own text). So `EXCLUSIVE_LOCKS_REQUIRED(cs)` on `addUnchecked` alone buys nothing — the
analyzer has nothing to check the body against, and callers are only diagnosed if they are
themselves annotated.

Doing it properly is three things, in order, none of them separable:

1. Annotate the pool's members `GUARDED_BY(cs)` — `mapTx`, `mapNextTx`, `m_mrc_by_cpid`,
   `m_mrc_by_fee`, `m_beacon_by_cpid`, `m_mandatory_sidestake_count`, `m_total_tx_size`,
   `m_eviction_index`, `m_unbroadcast`.
2. Fix the fallout in the accessors that currently lock internally: with members guarded, every
   one of them needs its annotation to match what it actually holds, and the ones that return
   references or iterators need to say so.
3. Fix all 31 unlocked test call sites, plus whatever else step 1 turns up.

That is a mempool-wide change with a large test diff, and it ends at the same place for callers:
"hold `cs`". Internal locking gets there in one line and removes the rule instead of encoding it.
I am happy to do the annotation pass as its own PR if you want the compile-time checking — it is
worth having — but it should not be smuggled in behind this.

### Behaviour

None changed. The production path holds the same lock over the same region as before.

**Testing.** Unit suite and the full functional suite pass. No new test: this is a lock
acquisition on a path all 31 test call sites already take unlocked, and a discriminating test
would need TSAN or the compile-time analyzer, i.e. exactly the annotation route above.

