### PR TITLE
wallet: make the default-label receivedby views agree

### DIFF
--- a/src/test/addressbook_tests.cpp
+++ b/src/test/addressbook_tests.cpp
@@ -635,6 +635,52 @@ BOOST_AUTO_TEST_CASE(listreceived_shows_unbooked_address_with_external_receipt)
     RemoveMempoolTx(tx);
 }
 
+// getreceivedbylabel "" answers the same question as the "" row of listreceivedbylabel, and
+// must give the same number. It did not: the twin tallied booked addresses only, so an
+// unbooked address with an external receipt counted in the group and not in the twin. The
+// account twin getreceivedbyaccount "" shares this code path exactly (it is gated behind
+// -enableaccounts, off in this fixture, so it cannot be driven from here).
+//
+// This is also the drift guard for the two separate walks: ListReceived accumulates the
+// qualifying-unbooked set inline while the twins call GetQualifyingUnbookedAddresses, so
+// nothing but this assertion keeps the two definitions of "qualifying" together.
+BOOST_AUTO_TEST_CASE(getreceivedby_default_label_matches_grouped_row)
+{
+    UniValue byLabelArgs(UniValue::VARR);
+    byLabelArgs.push_back(UniValue(0));
+    byLabelArgs.push_back(UniValue(true));
+
+    UniValue twinArgs(UniValue::VARR);
+    twinArgs.push_back("");
+    twinArgs.push_back(UniValue(0));
+
+    const double groupBefore = LabelGroupAmount(listreceivedbylabel(byLabelArgs), "");
+    BOOST_CHECK_EQUAL(getreceivedbylabel(twinArgs).get_real(), groupBefore);
+
+    // Owned key, deliberately NOT added to the address book, paid from outside the wallet.
+    CKey key;
+    key.MakeNewKey(false);
+    BOOST_REQUIRE(pwalletMain->AddKey(key));
+    const CTxDestination dest = CTxDestination(key.GetPubKey().GetID());
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE_EQUAL(pwalletMain->mapAddressBook.count(dest), 0u);
+    }
+
+    CTransaction tx = ExternalPaymentTx(dest, 7 * COIN);
+    InjectMempoolTx(tx);
+
+    // The group moves, as listreceived_shows_unbooked_address_with_external_receipt pins.
+    const double groupAfter = LabelGroupAmount(listreceivedbylabel(byLabelArgs), "");
+    BOOST_CHECK_EQUAL(groupAfter, groupBefore + 7.0);
+
+    // ... and now so does the twin. Without the unbooked rollup this stays at groupBefore,
+    // which is what makes the assertion discriminate rather than restate the line above.
+    BOOST_CHECK_EQUAL(getreceivedbylabel(twinArgs).get_real(), groupAfter);
+
+    RemoveMempoolTx(tx);
+}
+
 // An unbooked owned address that only ever received change from the wallet's own spend stays
 // hidden (it is what CWallet::IsChange means by change); one external receipt then surfaces
 // it with its FULL tally, change included. Also pins the booked-address skip of the new

--- a/src/test/addressbook_tests.cpp
+++ b/src/test/addressbook_tests.cpp
@@ -681,6 +681,65 @@ BOOST_AUTO_TEST_CASE(getreceivedby_default_label_matches_grouped_row)
     RemoveMempoolTx(tx);
 }
 
+// migratelabels books the same set: an owned address with no address-book entry that was paid
+// at least once from outside the wallet is added under "" with purpose "receive", while one
+// that only ever received change is left alone. Booking is what makes the default-label views
+// agree by construction -- afterwards GetAccountAddresses("") returns the address, so the twin
+// and the grouped row read one address set instead of arriving at it two ways.
+BOOST_AUTO_TEST_CASE(migratelabels_books_unbooked_external_receipts)
+{
+    // E: unbooked, paid from outside the wallet.
+    CKey keyE;
+    keyE.MakeNewKey(false);
+    BOOST_REQUIRE(pwalletMain->AddKey(keyE));
+    const CTxDestination destE = CTxDestination(keyE.GetPubKey().GetID());
+
+    // F: unbooked, receives only change from the wallet's own spend.
+    CKey keyF;
+    keyF.MakeNewKey(false);
+    BOOST_REQUIRE(pwalletMain->AddKey(keyF));
+    const CTxDestination destF = CTxDestination(keyF.GetPubKey().GetID());
+
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE_EQUAL(pwalletMain->mapAddressBook.count(destE), 0u);
+        BOOST_REQUIRE_EQUAL(pwalletMain->mapAddressBook.count(destF), 0u);
+    }
+
+    CTransaction txE = ExternalPaymentTx(destE, 3 * COIN);
+    InjectMempoolTx(txE);
+
+    // The wallet spends E's output paying F, so F's receipt is change (GetDebit only reads the
+    // prevout from mapWallet and IsMine on it, so no signature is needed).
+    CMutableTransaction mtxF;
+    mtxF.vin.resize(1);
+    mtxF.vin[0].prevout = COutPoint(txE.GetHash(), 0);
+    mtxF.vout.resize(1);
+    mtxF.vout[0].nValue = 1 * COIN;
+    mtxF.vout[0].scriptPubKey.SetDestination(destF);
+    CTransaction txF(mtxF);
+    InjectMempoolTx(txF);
+
+    const UniValue res = migratelabels(UniValue(UniValue::VARR));
+    BOOST_CHECK(res["booked"].get_int() >= 1);
+
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE_EQUAL(pwalletMain->mapAddressBook.count(destE), 1u);
+        BOOST_CHECK_EQUAL(pwalletMain->mapAddressBook[destE].name, "");
+        BOOST_CHECK_EQUAL(pwalletMain->mapAddressBook[destE].purpose, "receive");
+
+        // Change-only: still invisible to the grouped view, so still not booked.
+        BOOST_CHECK_EQUAL(pwalletMain->mapAddressBook.count(destF), 0u);
+    }
+
+    // Safe to run repeatedly: nothing qualifying is left unbooked.
+    BOOST_CHECK_EQUAL(migratelabels(UniValue(UniValue::VARR))["booked"].get_int(), 0);
+
+    RemoveMempoolTx(txF);
+    RemoveMempoolTx(txE);
+}
+
 // An unbooked owned address that only ever received change from the wallet's own spend stays
 // hidden (it is what CWallet::IsChange means by change); one external receipt then surfaces
 // it with its FULL tally, change included. Also pins the booked-address skip of the new

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1185,7 +1185,9 @@ static const RPCHelpMan getreceivedbyaccount_help{
     "Addresses carrying <account> in the address book are tallied. For the default \"\"\n"
     "account the tally also includes wallet addresses with no address book entry that were\n"
     "paid at least once from outside the wallet -- the same set listreceivedbyaccount groups\n"
-    "under \"\". An unbooked address that only ever received change stays excluded.\n"
+    "under \"\" when called with includeWatchonly=true (this tally, like this RPC's booked\n"
+    "tally, has always included watch-only). An unbooked address that only ever received\n"
+    "change stays excluded.\n"
     "\n"
     "Coinstake receipts are included. A sidestake or MRC payout received from another\n"
     "staker's coinstake counts at face value; a coinstake this wallet staked counts only\n"
@@ -1205,8 +1207,12 @@ static const RPCHelpMan getreceivedbyaccount_help{
 const RPCHelpMan& getreceivedbyaccount_helpman() { return getreceivedbyaccount_help; }
 
 //! Wallet destinations with no address book entry that were paid at least once from outside
-//! the wallet -- exactly the set ListReceived folds into its "" row (see the loop at the end of
-//! ListReceived, and CWallet::IsChange for why a purely internal receipt does not qualify).
+//! the wallet -- the set ListReceived folds into its "" row when invoked over the same
+//! ownership filter (see the loop at the end of ListReceived, and CWallet::IsChange for why a
+//! purely internal receipt does not qualify). Callers here pass ISMINE_ALL, matching the
+//! twins' historical inclusion of watch-only; the list variants include watch-only only with
+//! includeWatchonly=true, so a purely watch-only unbooked address appears in the twins but
+//! not in a default list invocation -- the same asymmetry the booked "" tally has always had.
 //! Generated value qualifies even though our own coinstake is a transaction this wallet
 //! funded, matching the fGenerated arm there.
 //!
@@ -1302,7 +1308,9 @@ static const RPCHelpMan getreceivedbylabel_help{
     "Addresses carrying <label> in the address book are tallied. For the default \"\" label\n"
     "the tally also includes wallet addresses with no address book entry that were paid at\n"
     "least once from outside the wallet -- the same set listreceivedbylabel groups under\n"
-    "\"\". An unbooked address that only ever received change stays excluded.\n"
+    "\"\" when called with includeWatchonly=true (this tally, like this RPC's booked tally,\n"
+    "has always included watch-only). An unbooked address that only ever received change\n"
+    "stays excluded.\n"
     "\n"
     "Coinstake receipts are included. A sidestake or MRC payout received from another\n"
     "staker's coinstake counts at face value; a coinstake this wallet staked counts only\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -738,7 +738,8 @@ UniValue migratelabels(const UniValue& params)
         pwalletMain->SetAddressBookPurpose(dest,
             (IsMine(*pwalletMain, dest) != ISMINE_NO) ? "receive" : "send");
 
-    // Book what the grouped receivedby views already surface under "": owned addresses with no
+    // Book what the grouped receivedby views already surface under "": wallet addresses
+    // (including watch-only, per ISMINE_ALL below) with no
     // address-book entry that were paid at least once from outside the wallet. Booking them is
     // what makes the default-label views agree by construction -- GetAccountAddresses("") then
     // returns them, so the twin tally and the grouped "" row read the same address set instead

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1145,9 +1145,10 @@ static const RPCHelpMan getreceivedbyaccount_help{
     "Returns the total amount received by addresses with <account> in transactions with at least\n"
     "[minconf] confirmations.\n"
     "\n"
-    "Only addresses carrying <account> in the address book are tallied; payments to wallet\n"
-    "addresses without an address book entry are not included even for the default \"\"\n"
-    "account (listreceivedbyaccount counts those under \"\").\n"
+    "Addresses carrying <account> in the address book are tallied. For the default \"\"\n"
+    "account the tally also includes wallet addresses with no address book entry that were\n"
+    "paid at least once from outside the wallet -- the same set listreceivedbyaccount groups\n"
+    "under \"\". An unbooked address that only ever received change stays excluded.\n"
     "\n"
     "Coinstake receipts are included. A sidestake or MRC payout received from another\n"
     "staker's coinstake counts at face value; a coinstake this wallet staked counts only\n"
@@ -1165,6 +1166,42 @@ static const RPCHelpMan getreceivedbyaccount_help{
         HelpExampleRpc("getreceivedbyaccount", "\"myaccount\", 6")},
 };
 const RPCHelpMan& getreceivedbyaccount_helpman() { return getreceivedbyaccount_help; }
+
+//! Wallet destinations with no address book entry that were paid at least once from outside
+//! the wallet -- exactly the set ListReceived folds into its "" row (see the loop at the end of
+//! ListReceived, and CWallet::IsChange for why a purely internal receipt does not qualify).
+//! Generated value qualifies even though our own coinstake is a transaction this wallet
+//! funded, matching the fGenerated arm there.
+//!
+//! Deliberately a second walk rather than shared code: ListReceived needs the per-address
+//! tally it is already accumulating, so folding this in would either duplicate that work or
+//! reshape a function six RPCs depend on. The two are pinned against each other by
+//! getreceivedby_default_label_matches_grouped_row in addressbook_tests.
+static void GetQualifyingUnbookedAddresses(set<CTxDestination>& setAddress, int nMinDepth,
+                                           const isminefilter& filter)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletMain->cs_wallet)
+{
+    std::vector<ReceivedOutput> vReceived;
+
+    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    {
+        const CWalletTx& wtx = it->second;
+
+        int nDepth = 0;
+        if (!ReceiptTxEligible(wtx, nMinDepth, nDepth)) continue;
+
+        const bool fTxFromMe = wtx.IsFromMe(filter);
+
+        TallyTxReceipts(wtx, filter, vReceived);
+
+        for (auto const& received : vReceived) {
+            if (fTxFromMe && !received.fGenerated) continue;
+            if (pwalletMain->mapAddressBook.count(received.dest)) continue;
+
+            setAddress.insert(received.dest);
+        }
+    }
+}
 
 //! Total received by the given address set in transactions with at least nMinDepth
 //! confirmations. Shared tally for getreceivedbyaccount and its label twin getreceivedbylabel.
@@ -1211,6 +1248,12 @@ UniValue getreceivedbyaccount(const UniValue& params)
     set<CTxDestination> setAddress;
     GetAccountAddresses(strAccount, setAddress);
 
+    // The default account is where the grouped view also puts owned addresses carrying no
+    // address book entry, so tally them here or the two answer the same question differently.
+    // ISMINE_ALL is the ownership set TallyReceivedByAddresses already nets the coinstake
+    // principal over, so the qualification test uses it too.
+    if (strAccount.empty()) GetQualifyingUnbookedAddresses(setAddress, nMinDepth, ISMINE_ALL);
+
     return ValueFromAmount(TallyReceivedByAddresses(setAddress, nMinDepth));
 }
 
@@ -1219,9 +1262,10 @@ static const RPCHelpMan getreceivedbylabel_help{
     "Returns the total amount received by addresses with <label> in transactions with at least\n"
     "[minconf] confirmations.\n"
     "\n"
-    "Only addresses carrying <label> in the address book are tallied; payments to wallet\n"
-    "addresses without an address book entry are not included even for the default \"\"\n"
-    "label (listreceivedbylabel counts those under \"\").\n"
+    "Addresses carrying <label> in the address book are tallied. For the default \"\" label\n"
+    "the tally also includes wallet addresses with no address book entry that were paid at\n"
+    "least once from outside the wallet -- the same set listreceivedbylabel groups under\n"
+    "\"\". An unbooked address that only ever received change stays excluded.\n"
     "\n"
     "Coinstake receipts are included. A sidestake or MRC payout received from another\n"
     "staker's coinstake counts at face value; a coinstake this wallet staked counts only\n"
@@ -1255,6 +1299,9 @@ UniValue getreceivedbylabel(const UniValue& params)
     string strLabel = LabelFromValue(params[0]);
     set<CTxDestination> setAddress;
     GetAccountAddresses(strLabel, setAddress);
+
+    // Same default-label rollup as the account twin above.
+    if (strLabel.empty()) GetQualifyingUnbookedAddresses(setAddress, nMinDepth, ISMINE_ALL);
 
     return ValueFromAmount(TallyReceivedByAddresses(setAddress, nMinDepth));
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -678,6 +678,12 @@ UniValue listlabels(const UniValue& params)
     return ret;
 }
 
+//! Defined beside the receivedby* tally further down, where its definition belongs; declared
+//! here because migratelabels books exactly the set it returns.
+static void GetQualifyingUnbookedAddresses(set<CTxDestination>& setAddress, int nMinDepth,
+                                           const isminefilter& filter)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletMain->cs_wallet);
+
 static const RPCHelpMan migratelabels_help{
     "migratelabels",
     "One-time maintenance for the accounts -> labels transition: backfill the purpose\n"
@@ -686,13 +692,24 @@ static const RPCHelpMan migratelabels_help{
     "\n"
     "The address-book names themselves need no conversion -- an account name already IS the\n"
     "label -- so this only fills in the missing purpose so entries are first-class labels (e.g.\n"
-    "so `listlabels \"receive\"` finds them). Safe to run repeatedly: entries that already carry a\n"
-    "purpose are left untouched.",
+    "so `listlabels \"receive\"` finds them).\n"
+    "\n"
+    "It also books wallet addresses that have no address-book entry at all but were paid at\n"
+    "least once from outside the wallet, under the default \"\" label with purpose \"receive\" --\n"
+    "the same set listreceivedbylabel already groups under \"\". This is what setlabel <address>\n"
+    "\"\" would do for each of them, and it makes getreceivedbylabel \"\" and the \"\" row of\n"
+    "listreceivedbylabel agree by construction rather than by parallel tallies. Addresses that\n"
+    "only ever received change are not booked.\n"
+    "\n"
+    "Safe to run repeatedly: entries that already carry a purpose are left untouched, and an\n"
+    "address booked by a previous run is no longer unbooked.",
     {},
     RPCResult{RPCResult::Type::OBJ, "", "",
         {
             {RPCResult::Type::NUM, "examined", "Number of address-book entries examined."},
             {RPCResult::Type::NUM, "updated", "Number of entries whose purpose was backfilled."},
+            {RPCResult::Type::NUM, "booked", "Number of previously unbooked addresses with an "
+                                             "external receipt that were added under \"\"."},
         }},
     RPCExamples{
         HelpExampleCli("migratelabels", "") +
@@ -721,9 +738,29 @@ UniValue migratelabels(const UniValue& params)
         pwalletMain->SetAddressBookPurpose(dest,
             (IsMine(*pwalletMain, dest) != ISMINE_NO) ? "receive" : "send");
 
+    // Book what the grouped receivedby views already surface under "": owned addresses with no
+    // address-book entry that were paid at least once from outside the wallet. Booking them is
+    // what makes the default-label views agree by construction -- GetAccountAddresses("") then
+    // returns them, so the twin tally and the grouped "" row read the same address set instead
+    // of arriving at it two ways.
+    //
+    // minconf 0 deliberately: this is a one-time migration over receipts that already exist,
+    // and an address is no less ours for having been paid in an unconfirmed transaction.
+    //
+    // The pair of calls is exactly what setlabel(<address>, "") does. Re-running is a no-op:
+    // GetQualifyingUnbookedAddresses skips anything already in the address book.
+    set<CTxDestination> setUnbooked;
+    GetQualifyingUnbookedAddresses(setUnbooked, 0, ISMINE_ALL);
+
+    for (auto const& dest : setUnbooked) {
+        pwalletMain->SetAddressBookName(dest, "");
+        pwalletMain->SetAddressBookPurpose(dest, "receive");
+    }
+
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("examined", nExamined);
     ret.pushKV("updated", (int)vUpdate.size());
+    ret.pushKV("booked", (int)setUnbooked.size());
     return ret;
 }
 


### PR DESCRIPTION
Answers the `""`-label parity question from #3188, and takes both routes you would expect to be
alternatives, because they do different jobs.

`listreceivedbyaccount` and `listreceivedbylabel` fold owned addresses that have no address-book
entry, and were paid at least once from outside the wallet, into their `""` row.
`getreceivedbyaccount ""` and `getreceivedbylabel ""` tallied booked addresses only. Same
conceptual query, two answers.

Upstream builds `listreceivedbylabel` from the address book alone, so before #3188 the grouped
view and the twins agreed. #3188 fixed the grouped view for the reported bug — an unbooked address
that received an external payment was invisible — and left the twins behind. This is Gridcoin-only
debt that #3188 introduced, which is why the fix is to bring the twins up rather than to drop the
rollup and reopen the bug.

### Commit 1 — the twins tally the same set

`GetQualifyingUnbookedAddresses()` applies the same test `ListReceived` applies inline: a receipt
qualifies when its transaction was not funded by this wallet, or when the value was generated (our
own coinstake funds the transaction, but minted value is income, not change). Booked addresses are
skipped, so nothing double-counts, and an address that only ever received change stays hidden.

It is deliberately a **second wallet walk** rather than shared code: `ListReceived` needs the
per-address tally it is already accumulating, so folding this in would either duplicate that work
or reshape a function six RPCs depend on. What keeps the two definitions of "qualifying" together
is a test, not the structure — `getreceivedby_default_label_matches_grouped_row` asserts the twin
equals the `""` row across a fresh unbooked external receipt. Mutation-checked: with the rollup
removed it fails `0 != 7`.

`ISMINE_ALL` is used for the qualification test because `TallyReceivedByAddresses` already nets the
coinstake principal over that same ownership set; the twins have always counted watch-only
receipts. Note this leaves a pre-existing asymmetry untouched — the twins are `ISMINE_ALL` while
`ListReceived` uses the caller's filter, so exact parity is against
`listreceivedbylabel <minconf> <includeempty> true`. Orthogonal to this bug; flagging it rather
than changing it silently.

### Commit 2 — `migratelabels` books them

Commit 1 makes the two agree by tallying the same set two ways. This makes them agree by
construction: an owned, unbooked, externally-paid address is added under `""` with purpose
`"receive"` — exactly what `setlabel <address> ""` does — after which `GetAccountAddresses("")`
returns it and both paths read one address set.

This is the "deeper convergence" idea that was deliberately left out of #3188 because it expands
`migratelabels`' contract (`rpcwallet.cpp` only backfilled `purpose` on entries that already
existed). It is now the documented behaviour, in the help text and in the `RPCResult`, which gains
a `booked` count.

`minconf 0`, deliberately: this is a one-time migration over receipts that already exist, and an
address is no less ours for having been paid in a transaction that has not confirmed yet.

Still safe to run repeatedly — a booked address is no longer unbooked — and the test asserts the
second run books nothing rather than trusting it. Mutation-checked: with the booking loop removed
the case fails `0 != 1`.

### Scope

Only the `""` name changes. Every other account or label tallies exactly as before, and both help
texts previously documented the old behaviour explicitly, so both are corrected.

**Testing.** Two new cases in `addressbook_tests`, both mutation-checked. Unit suite and the full
functional suite pass.
