### PR TITLE
validation: scope the policy script flags to the mempool in code

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -57,7 +57,11 @@ static constexpr unsigned int V15_SCRIPT_VERIFY_FLAGS{SCRIPT_VERIFY_LOW_S |
                                                       SCRIPT_VERIFY_MINIMALDATA |
                                                       SCRIPT_VERIFY_CLEANSTACK};
 
-/** For convenience, standard but not mandatory verify flags. */
+/** For convenience, standard but not mandatory verify flags. These feed wallet
+ *  signing, PSGT, and raw-transaction sanity checks only. The mempool's
+ *  policy-tier script flags for input connection live in
+ *  POLICY_SCRIPT_VERIFY_FLAGS (validation.cpp) -- extend that set, not this
+ *  one, to add a relay-policy script rule. */
 static constexpr unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS{STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS};
 
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -460,11 +460,22 @@ bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPr
         // block validity at the same height -- a coordinated change rather than
         // a staggered one, and no window where a staker builds from its own
         // mempool a block its peers reject.
-        // When a flag is added it belongs behind (!fBlock && !fMiner), i.e.
-        // mempool acceptance only -- never when connecting a block, where it
-        // would change which chain this node follows, and never for the miner,
-        // which is assembling a block and must judge by validity alone.
-        const unsigned int policy_flags = 0;
+        // The set itself. Empty today; adding to it is a separate decision each
+        // time, and the comment above is the standard that decision has to meet.
+        static constexpr unsigned int POLICY_SCRIPT_VERIFY_FLAGS = 0;
+
+        // The scoping, in code rather than in a comment: policy applies to mempool
+        // acceptance ONLY. fBlock is connecting a block, where a local flag would
+        // change which chain this node follows; fMiner is assembling one, which must
+        // judge by validity alone. Written as a branch while the set is still empty
+        // precisely so that whoever adds the first flag cannot reach either path by
+        // forgetting to -- which a comment saying "it belongs behind (!fBlock &&
+        // !fMiner)" could not prevent.
+        //
+        // The blame branch below is scoped through this same value rather than
+        // repeating the condition: it runs only when policy_flags != 0, which is
+        // already false on both paths.
+        const unsigned int policy_flags = (!fBlock && !fMiner) ? POLICY_SCRIPT_VERIFY_FLAGS : 0;
 
         int64_t nValueIn = 0;
         int64_t nFees = 0;


### PR DESCRIPTION
Tier B row B-6.

The comment above `policy_flags` said *"when a flag is added it belongs behind `(!fBlock &&
!fMiner)`"*. That is the right rule, and a comment cannot enforce it: whoever adds the first flag
has to remember, and forgetting means a **local policy flag decides block validity** — which chain
this node follows — and what the miner puts in a block.

`policy_flags` is now the branch itself:

```cpp
static constexpr unsigned int POLICY_SCRIPT_VERIFY_FLAGS = 0;
const unsigned int policy_flags = (!fBlock && !fMiner) ? POLICY_SCRIPT_VERIFY_FLAGS : 0;
```

so the set and its scope are separate things and only the set is left to decide. Behaviour today is
identical — the set is still empty.

The blame branch below is deliberately **not** given a second copy of the condition. It already runs
only when `policy_flags != 0`, which is now false on both paths by construction, and a duplicated
condition is one that can drift. The row asked for both; say the word if you would rather have it
stated twice.

### Demonstrated rather than argued

Setting `POLICY_SCRIPT_VERIFY_FLAGS` to `SCRIPT_VERIFY_CLEANSTACK` locally, with v15 inert, and
spending an `OP_1` output with `OP_1` — valid under consensus flags, invalid under CLEANSTACK:

```
MEMPOOL  accepted=false dos=0  reason=non-mandatory-script-verify-flag
BLOCK    accepted=true  dos=0
MINER    accepted=true  dos=0
```

That is the whole design in three lines: the relayer is not scored, the chain this node follows is
unchanged, and the miner judges by validity alone. The flag was reverted — nothing here turns
anything on.

That experiment is also the `nDoS == 0` half of the B-5 DoS row, which cannot become a permanent
test until the policy set is non-empty. The `nDoS == 100` half is pinned in the sibling PR.

**Testing.** Unit suite and the full functional suite pass; build is warning-free.
