### PR TITLE
rpc: render Type::ANY results instead of dropping the section

### DIFF
--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -292,7 +292,6 @@ std::string RPCResults::ToDescriptionString() const
 {
     std::string result;
     for (const auto& r : m_results) {
-        if (r.m_type == RPCResult::Type::ANY) continue; // for testing only
         if (r.m_cond.empty()) {
             result += "\nResult:\n";
         } else {
@@ -509,7 +508,15 @@ void RPCResult::ToSections(Sections& sections, const OuterType outer_type, const
         return;
     }
     case Type::ANY: {
-        CHECK_NONFATAL(false); // Only for testing
+        // Upstream reserves ANY for testing and never renders it, which is why this
+        // asserted and why RPCResults::ToDescriptionString used to skip it outright.
+        // Here it is used for genuinely polymorphic returns -- dumpprivkey,
+        // getaddednodeinfo, sendalert2 and versionreport -- each of which carries a
+        // description written for a reader. Skipping meant those four commands printed
+        // no Result section at all while the text sat in the spec unused. Render the
+        // description with an elided shape, since there is no single shape to give.
+        sections.PushSection({indent + maybe_key + "..." + maybe_separator, Description("any")});
+        return;
     }
     case Type::NONE: {
         sections.PushSection({indent + "null" + maybe_separator, Description("json null")});
@@ -601,7 +608,7 @@ void RPCResult::CheckInnerDoc() const
 // object-typed args until this implementation is extended.
 //
 // TODO: implement object-type rendering here when a command first needs
-// nested objects in m_inner. rpchelpman_tests' every_helpman_renders case
+// nested objects in m_inner. rpchelpman_tests' every_helpman_renders_help case
 // walks every registered command through ToString(), so a spec that trips
 // this fails a test rather than a user's help request.
 std::string RPCArg::ToStringObj(const bool oneline) const

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -508,14 +508,17 @@ void RPCResult::ToSections(Sections& sections, const OuterType outer_type, const
         return;
     }
     case Type::ANY: {
-        // Upstream reserves ANY for testing and never renders it, which is why this
-        // asserted and why RPCResults::ToDescriptionString used to skip it outright.
-        // Here it is used for genuinely polymorphic returns -- dumpprivkey,
-        // getaddednodeinfo, sendalert2 and versionreport -- each of which carries a
-        // description written for a reader. Skipping meant those four commands printed
-        // no Result section at all while the text sat in the spec unused. Render the
-        // description with an elided shape, since there is no single shape to give.
-        sections.PushSection({indent + maybe_key + "..." + maybe_separator, Description("any")});
+        // Upstream v26.0 (this port's baseline) reserved ANY for testing and never
+        // rendered it, which is why this asserted and why
+        // RPCResults::ToDescriptionString used to skip it outright. Upstream has
+        // since converged on rendering it (master commits 6a1a66c180cb and
+        // fa2264791490). Here it is used for genuinely polymorphic
+        // returns -- dumpprivkey, getaddednodeinfo, sendalert2 and versionreport --
+        // each of which carries a description written for a reader. Skipping meant
+        // those four commands printed no Result section at all while the text sat in
+        // the spec unused. Render the description against upstream's "xxx" value
+        // placeholder ("..." would collide with the ELISION rendering above).
+        sections.PushSection({indent + maybe_key + "xxx" + maybe_separator, Description("any")});
         return;
     }
     case Type::NONE: {

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -983,20 +983,57 @@ bool IsVariadicRpc(const std::string& method)
 
 } // anonymous namespace
 
-BOOST_AUTO_TEST_CASE(every_helpman_renders)
+// Every registered command must render its help without throwing, and must actually emit a
+// Result section. Two silent failure modes hide here, and neither is caught anywhere else:
+//
+//   - RPCArg::ToStringObj() asserts on an object nested inside another object's m_inner, so a
+//     spec author can register a command whose `help <cmd>` returns "Internal bug detected".
+//     The daemon survives (CHECK_NONFATAL throws and the RPC layer catches it), which is
+//     exactly why nothing notices. The existing loop below calls GetArgs() and never
+//     ToString(), so it walks straight past that.
+//
+//   - RPCResults::ToDescriptionString() used to skip Type::ANY, so four commands emitted no
+//     Result section despite carrying descriptions. rpc_help.py did not catch it either: its
+//     marker check looks for the literal "Result", so it silently reclassified those four as
+//     legacy, unconverted commands.
+BOOST_AUTO_TEST_CASE(every_helpman_renders_help)
 {
-    // ToStringObj() refuses a nested object argument (see rpc/util.cpp) by
-    // throwing NonFatalCheckError, which reaches a user as an "Internal bug
-    // detected" error from `help <cmd>`. The functional rpc_help.py cannot
-    // catch that: it wraps node.help(name) in `except Exception` and silently
-    // reclassifies the command as legacy. Render every registered command's
-    // help here so a spec that trips the limitation fails a test instead.
     for (const std::string& name : tableRPC.listCommands(/*include_deprecated=*/true)) {
         const CRPCCommand* cmd = tableRPC[name];
         BOOST_REQUIRE_MESSAGE(cmd != nullptr && cmd->helpman != nullptr,
                               name + ": registered command must carry a helpman accessor");
 
-        BOOST_REQUIRE_NO_THROW(cmd->helpman().ToString());
+        std::string rendered;
+        BOOST_CHECK_NO_THROW(rendered = cmd->helpman().ToString());
+
+        BOOST_CHECK_MESSAGE(rendered.find("Result") != std::string::npos,
+                            name + ": help renders no Result section");
+    }
+}
+
+// The four commands whose result is genuinely polymorphic declare RPCResult::Type::ANY. Their
+// descriptions are written for a reader and must reach the rendered help.
+BOOST_AUTO_TEST_CASE(any_result_commands_render_their_description)
+{
+    const std::vector<std::pair<std::string, std::string>> expected{
+        {"dumpprivkey", "base58 WIF"},
+        {"getaddednodeinfo", ""},
+        {"sendalert2", "Summary of what was done"},
+        {"versionreport", "Per-version tally"},
+    };
+
+    for (const auto& [name, snippet] : expected) {
+        const CRPCCommand* cmd = tableRPC[name];
+        BOOST_REQUIRE_MESSAGE(cmd != nullptr && cmd->helpman != nullptr, name + ": not registered");
+
+        const std::string rendered = cmd->helpman().ToString();
+        BOOST_CHECK_MESSAGE(rendered.find("Result") != std::string::npos,
+                            name + ": ANY result renders no Result section");
+
+        if (!snippet.empty()) {
+            BOOST_CHECK_MESSAGE(rendered.find(snippet) != std::string::npos,
+                                name + ": ANY result description is missing from the rendered help");
+        }
     }
 }
 
@@ -1026,6 +1063,7 @@ BOOST_AUTO_TEST_CASE(example_address_is_synthetic_and_valid)
         .Finalize(digest);
     BOOST_CHECK(std::equal(decoded.begin() + 1, decoded.end(), digest));
 }
+
 
 BOOST_AUTO_TEST_CASE(every_helpman_arg_type_matches_client_conversion_table)
 {

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -1016,8 +1016,11 @@ BOOST_AUTO_TEST_CASE(every_helpman_renders_help)
 BOOST_AUTO_TEST_CASE(any_result_commands_render_their_description)
 {
     const std::vector<std::pair<std::string, std::string>> expected{
-        {"dumpprivkey", "base58 WIF"},
-        {"getaddednodeinfo", ""},
+        // Snippets must be unique to the RESULT description: "base58 WIF" also
+        // appears in dumpprivkey's dump_hex argument text, so a missing Result
+        // section would still find it there and pass vacuously.
+        {"dumpprivkey", "returns a JSON object with base58 and hex"},
+        {"getaddednodeinfo", "Shape depends on the 'dns' argument"},
         {"sendalert2", "Summary of what was done"},
         {"versionreport", "Per-version tally"},
     };

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -1006,7 +1006,10 @@ BOOST_AUTO_TEST_CASE(every_helpman_renders_help)
         std::string rendered;
         BOOST_CHECK_NO_THROW(rendered = cmd->helpman().ToString());
 
-        BOOST_CHECK_MESSAGE(rendered.find("Result") != std::string::npos,
+        // Anchor on the newline: the section header renders as "\nResult:" (or
+        // "\nResult (cond):"), while a bare "Result" can match incidental prose
+        // in a command's description.
+        BOOST_CHECK_MESSAGE(rendered.find("\nResult") != std::string::npos,
                             name + ": help renders no Result section");
     }
 }
@@ -1030,7 +1033,7 @@ BOOST_AUTO_TEST_CASE(any_result_commands_render_their_description)
         BOOST_REQUIRE_MESSAGE(cmd != nullptr && cmd->helpman != nullptr, name + ": not registered");
 
         const std::string rendered = cmd->helpman().ToString();
-        BOOST_CHECK_MESSAGE(rendered.find("Result") != std::string::npos,
+        BOOST_CHECK_MESSAGE(rendered.find("\nResult") != std::string::npos,
                             name + ": ANY result renders no Result section");
 
         if (!snippet.empty()) {

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -44,13 +44,12 @@ pattern check runs against them. No edits to this file are required.
 Regression guard
 ----------------
 `CRPCCommand`'s constructor takes the `RPCHelpMan` accessor as a required
-parameter, and the C++ unit test `rpchelpman_tests/every_helpman_renders`
+parameter, and the C++ unit test `rpchelpman_tests/every_helpman_renders_help`
 fails on any registered command whose accessor is null or does not render
 (nothing asserts it at daemon startup). So every discovered command must
 classify as converted -- except category aliases, whose help cannot be introspected through
-the help RPC, and `ANY_RESULT_COMMANDS`, which render no Result section. Any
-other command classified as legacy means a conversion was reverted or the
-discovery walk broke. The guard scales with the command table and needs no
+the help RPC. Any command classified as legacy means a conversion was
+reverted or the discovery walk broke. The guard scales with the command table and needs no
 hand-maintained floor.
 
 What it catches per converted command
@@ -127,13 +126,12 @@ VARIADIC_ACCEPTS_EXTRA_ARGS = {
 # skips Type::ANY entirely -- upstream Bitcoin Core marks that type "for testing
 # only". The description the spec author wrote is therefore never rendered.
 # These are RPCHelpMan-converted regardless: their synopsis line is
-# RPCHelpMan-rendered, which is what the first-line check in classify_command
-# confirms.
-#
-# Listed by name rather than skipped by rule so that a genuinely un-converted
-# command cannot hide among them. Whether ANY should render its description at
-# all is a separate question about src/rpc/util.cpp, not about this test.
-ANY_RESULT_COMMANDS = frozenset({
+# Four commands declare RPCResult::Type::ANY; since src/rpc/util.cpp renders
+# ANY (it used to skip it), they classify as converted like everything else.
+# They stay pinned by name purely as a discovery-walk vacuity guard: a broken
+# walk that discovers nothing would otherwise satisfy the no-legacy assertion
+# below with a vacuously empty set.
+PINNED_DISCOVERY_COMMANDS = frozenset({
     "dumpprivkey",       # src/wallet/rpcdump.cpp
     "getaddednodeinfo",  # src/rpc/net.cpp
     "sendalert2",        # src/rpc/net.cpp
@@ -342,36 +340,32 @@ class RpcHelpTest(GridcoinTestFramework):
             ", ".join(category_aliases) if category_aliases else "(none)",
         )
         if legacy:
-            self.log.info("Allowlisted ANY-result commands (no Result section): %s",
-                          ", ".join(sorted(set(legacy) & ANY_RESULT_COMMANDS)) or "(none)")
-            self.log.info("Unexpected legacy-classified commands: %s",
-                          ", ".join(sorted(set(legacy) - ANY_RESULT_COMMANDS)) or "(none)")
+            self.log.info("Legacy-classified commands: %s", ", ".join(sorted(legacy)))
 
         # Vacuity guard first: an empty or broken discovery walk would satisfy
         # the legacy check below with nothing discovered at all. The four
         # allowlisted commands are pinned by name, so discovery must have seen
         # every one of them.
         discovered = set(name for name, _ in converted) | set(legacy)
-        missing = sorted(ANY_RESULT_COMMANDS - discovered)
+        missing = sorted(PINNED_DISCOVERY_COMMANDS - discovered)
         assert not missing, (
             f"Discovery walk did not find pinned commands {missing}; "
             f"the walk itself is broken, so the legacy guard below is vacuous."
         )
 
         # Regression guard: CRPCCommand's constructor takes the RPCHelpMan
-        # accessor as a required parameter (the every_helpman_renders unit
-        # test enforces it renders), so anything classified as
-        # legacy is either a reverted conversion, a broken discovery walk, or a
-        # new ANY-result command that belongs in the allowlist above.
-        # category-alias commands are excluded because their help text cannot
-        # be introspected through the help RPC alone (see classify_command).
-        unexpected_legacy = sorted(set(legacy) - ANY_RESULT_COMMANDS)
+        # accessor as a required parameter (the every_helpman_renders_help unit
+        # test enforces it renders, Result section included), so anything
+        # classified as legacy is either a reverted conversion or a broken
+        # discovery walk. category-alias commands are excluded because their
+        # help text cannot be introspected through the help RPC alone (see
+        # classify_command).
+        unexpected_legacy = sorted(set(legacy))
         assert not unexpected_legacy, (
-            f"Commands classified as legacy that are not known ANY-result "
-            f"commands: {unexpected_legacy}.\n"
-            f"Either a conversion was reverted, discovery is broken, or these "
-            f"declare RPCResult::Type::ANY and should be added to "
-            f"ANY_RESULT_COMMANDS.\n"
+            f"Commands classified as legacy: {unexpected_legacy}.\n"
+            f"Either a conversion was reverted or discovery is broken -- "
+            f"RPCResult::Type::ANY renders a Result section, so ANY commands "
+            f"classify as converted and no allowlist exists.\n"
             f"All legacy commands seen: {sorted(legacy)}\n"
             f"Category-alias commands seen: {category_aliases}"
         )

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -118,14 +118,6 @@ VARIADIC_ACCEPTS_EXTRA_ARGS = {
     "parselegacysb",  # src/rpc/blockchain.cpp: body uses params[0] only
 }
 
-# Converted commands whose rendered help carries no "Result" section, so the
-# marker check below cannot see them as converted.
-#
-# All four declare RPCResult{RPCResult::Type::ANY, ...} because their return
-# shape is polymorphic, and RPCResults::ToDescriptionString (src/rpc/util.cpp)
-# skips Type::ANY entirely -- upstream Bitcoin Core marks that type "for testing
-# only". The description the spec author wrote is therefore never rendered.
-# These are RPCHelpMan-converted regardless: their synopsis line is
 # Four commands declare RPCResult::Type::ANY; since src/rpc/util.cpp renders
 # ANY (it used to skip it), they classify as converted like everything else.
 # They stay pinned by name purely as a discovery-walk vacuity guard: a broken
@@ -344,8 +336,7 @@ class RpcHelpTest(GridcoinTestFramework):
 
         # Vacuity guard first: an empty or broken discovery walk would satisfy
         # the legacy check below with nothing discovered at all. The four
-        # allowlisted commands are pinned by name, so discovery must have seen
-        # every one of them.
+        # pinned commands must therefore all have been seen by discovery.
         discovered = set(name for name, _ in converted) | set(legacy)
         missing = sorted(PINNED_DISCOVERY_COMMANDS - discovered)
         assert not missing, (


### PR DESCRIPTION
This is question E4 from the open-questions list, and it is the one item there that **diverges from
upstream's treatment of a type**, so it is worth a deliberate nod rather than a silent fix.

`RPCResults::ToDescriptionString()` skipped `RPCResult::Type::ANY` outright (`rpc/util.cpp:302`), so
four commands emit **no Result section at all** despite each spec carrying a description written for
a reader:

| Command | The description users never see |
|---|---|
| `dumpprivkey` (`wallet/rpcdump.cpp:296`) | "When dump_hex is false (default), returns the base58 WIF ..." |
| `getaddednodeinfo` (`rpc/net.cpp:174`) | (shape description) |
| `sendalert2` (`rpc/net.cpp:779`) | "Summary of what was done; see source for the exact shape." |
| `versionreport` (`rpc/blockchain.cpp:4683`) | "Per-version tally (see GetJSONVersionReport)." |

Upstream marks `ANY` "for testing only" — that is why `ToDescriptionString` skips it and why
`RPCResult::ToSections` asserts on it. Here it is used for genuinely polymorphic returns, which that
assumption does not cover. **If you would rather these four grew concrete result shapes instead, say
so and I will do that** — it is more work for the same user-visible outcome, which is why I went the
other way.

### Why nothing caught it

`help <cmd>` just prints no Result section — nothing errors. And `rpc_help.py`'s marker check looks
for the literal `Result`, so it silently classified all four as *legacy, unconverted* commands. That
was invisible behind the stale floor of 30 against 208 converted.

Note the interaction with #3303: that PR adds an `ANY_RESULT_COMMANDS` allowlist to keep those four
honest while they render nothing. Once both land, the allowlist is dead and should be deleted —
whichever merges second is the natural place, and I am happy to do it either way.

### Tests

Two cases, because the existing exhaustive loop (`every_helpman_arg_type_matches_client_conversion_table`)
calls `GetArgs()` and never `ToString()`, so it walks past every rendering failure:

- **`every_helpman_renders_help`** — every registered command: `ToString()` must not throw, and the
  rendered help must contain a Result section. This also closes the *other* silent rendering
  failure in this file: `RPCArg::ToStringObj()` asserts on an object nested inside another object's
  `m_inner`, so a spec author can register a command whose `help <cmd>` returns "Internal bug
  detected" while the daemon lives (`CHECK_NONFATAL` throws, the RPC layer catches). Nothing
  registered does that today; this fails the moment one does.
- **`any_result_commands_render_their_description`** — pins the four by name with a snippet of the
  text each should show.

Mutation-checked: restoring the skip fails both, naming exactly those four commands.

### Also

The note above `ToStringObj()` said `TODO(#2922)`, an orphaned reference since that issue closed. It
now states the condition rather than pointing at a closed issue, and names the test that enforces it.

**Testing.** Unit suite and the full functional suite pass.

### Measured, not asserted

Same binary, same `rpc_help.py`, only the skip line differing:

```
BEFORE   Discovered 213 total RPCs: 208 RPCHelpMan-converted, 4 legacy, 1 category-alias
AFTER    Discovered 213 total RPCs: 212 RPCHelpMan-converted, 0 legacy, 1 category-alias
```

The four "legacy" commands are exactly the four `ANY` commands. `HELPMAN_MARKERS` is the pair of
literals `("Result", "Examples")` and both are required, so a command rendering no Result section is
indistinguishable from a genuine unconverted `throw runtime_error` helper. With this, the tree has
**zero** legacy commands left.
