### PR TITLE
ipc: delete the IPC cookie at shutdown

### DIFF
--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -322,6 +322,10 @@ bool AppInit(int argc, char* argv[])
         // Per-connection auth: a new ServeInit is built per connection; the Ipc
         // lives for the run, torn down after the wait loop.
         std::unique_ptr<interfaces::Ipc> ipc;
+        // Whether this run minted an IPC cookie, so shutdown knows to remove it.
+        // Tracked separately from `ipc`: WriteCookie runs before the Ipc is built,
+        // so a failure in between would otherwise leave the credential on disk.
+        bool cookie_written = false;
         // Note the default: this block runs only when -multiprocess was explicitly
         // set (command line or config file). There is no implicit/optional MP mode
         // in the daemon, so a failure here is a failure to honor an explicit
@@ -329,6 +333,7 @@ bool AppInit(int argc, char* argv[])
         if (gArgs.GetBoolArg("-multiprocess", false)) {
             try {
                 std::string cookie = ipc::WriteCookie(GetDataDir());
+                cookie_written = true;
                 interfaces::NodeIdentity identity;
                 identity.network = Params().NetworkIDString();
                 // Fingerprint the wallet this node serves. Empty when there is no
@@ -390,6 +395,11 @@ bool AppInit(int argc, char* argv[])
         }
 #ifdef ENABLE_MULTIPROCESS
         if (ipc) ipc->disconnectIncoming();
+        // The cookie is a live credential for as long as the file exists, so it goes
+        // when the socket does -- mirroring upstream's DeleteAuthCookie(). It is also
+        // what ReadCookie() uses to mean "a node is running", so leaving it behind
+        // sends the next GUI to a socket nobody is listening on.
+        if (cookie_written) ipc::DeleteCookie(GetDataDir());
 #endif
     }
 

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -300,7 +300,7 @@ void DeleteCookie(const fs::path& dir)
 
     // Absent is the expected case after an unclean exit, and fs::remove reports
     // that by returning false with no error, not by setting ec. Only a real
-    // failure -- a permission problem, or a directory in the way -- lands here.
+    // failure -- a permission problem, or a non-empty directory in the way -- lands here.
     if (ec) {
         LogPrintf("WARN: %s: could not remove the IPC cookie %s (%s)", __func__,
                   (dir / COOKIE_FILE).string(), ec.message());

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -6,6 +6,7 @@
 
 #include "clientversion.h"
 #include "crypto/sha256.h"
+#include "logging.h"
 #include "random.h"
 #include "tinyformat.h"
 #include "util/strencodings.h"
@@ -290,6 +291,20 @@ std::optional<std::string> ReadCookie(const fs::path& dir)
         contents->pop_back();
     }
     return contents;
+}
+
+void DeleteCookie(const fs::path& dir)
+{
+    boost::system::error_code ec;
+    fs::remove(dir / COOKIE_FILE, ec);
+
+    // Absent is the expected case after an unclean exit, and fs::remove reports
+    // that by returning false with no error, not by setting ec. Only a real
+    // failure -- a permission problem, or a directory in the way -- lands here.
+    if (ec) {
+        LogPrintf("WARN: %s: could not remove the IPC cookie %s (%s)", __func__,
+                  (dir / COOKIE_FILE).string(), ec.message());
+    }
 }
 
 std::string ComputeIdentityToken(const std::vector<unsigned char>& wallet_uuid)

--- a/src/ipc/handshake.h
+++ b/src/ipc/handshake.h
@@ -64,6 +64,18 @@ std::string WriteCookie(const fs::path& dir);
 //! file is absent (the node is not running -- do not dial).
 std::optional<std::string> ReadCookie(const fs::path& dir);
 
+//! Node side: remove <dir>/ipc.cookie at shutdown, mirroring upstream's
+//! DeleteAuthCookie(). The cookie is a live 256-bit credential for as long as the
+//! file exists, and it outlived the process that minted it: a stale file is
+//! readable by anything that can read the datadir, and its presence is also what
+//! ReadCookie() uses to mean "the node is running", so a GUI dials a socket nobody
+//! is listening on and reports a connection failure instead of "not running".
+//!
+//! Never throws: shutdown is the wrong place to raise, and the file legitimately
+//! may not be there (an unclean previous exit, or a user who removed it by hand).
+//! A failure to remove is logged.
+void DeleteCookie(const fs::path& dir);
+
 //! Compute the node identity token: HEX(SHA256(domain-tag ‖ LE32(len) ‖ uuid)).
 //! Deterministic in \p wallet_uuid; returns "" (identity unavailable) when the
 //! UUID is empty. The raw UUID never crosses the wire -- only this hash does.

--- a/src/test/ipc_handshake_tests.cpp
+++ b/src/test/ipc_handshake_tests.cpp
@@ -2,8 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
+#include "fs.h"
+#include "tinyformat.h"
 #include "interfaces/init.h"
 #include "ipc/handshake.h"
+#include "util/time.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -54,6 +57,59 @@ bool HasSoft(const ipc::HandshakeResult& r, ipc::SoftWarn w)
 BOOST_AUTO_TEST_SUITE(ipc_handshake_tests)
 
 // ---- ComputeIdentityToken ----
+
+BOOST_AUTO_TEST_CASE(cookie_round_trip_and_delete)
+{
+    // Own temp directory rather than GetDataDir(): this only needs somewhere to put a
+    // file, and the datadir path applies an owner-only DACL on first creation.
+    const fs::path dir = fs::temp_directory_path() / strprintf("grc_ipc_cookie_%d", GetTimeMillis());
+    fs::create_directories(dir);
+
+    // Seeded directly rather than through WriteCookie(). WriteCookie applies an
+    // owner-only DACL to the temp file it renames into place and THROWS where the
+    // platform cannot -- which is the case under Wine, where the Windows
+    // cross-compile leg runs this suite ("could not be restricted to the current
+    // user -- its DACL is not protected"). The delete path is what this case is
+    // about, and it has to be testable on every platform the suite runs on.
+    const std::string cookie(64, 'a');
+    {
+        fsbridge::ofstream out(dir / "ipc.cookie", std::ios::binary);
+        out << cookie;
+    }
+
+    const std::optional<std::string> read_back = ipc::ReadCookie(dir);
+    BOOST_REQUIRE(read_back.has_value());
+    BOOST_CHECK_EQUAL(*read_back, cookie);
+
+    ipc::DeleteCookie(dir);
+
+    // Gone from disk, and gone as far as a GUI is concerned -- ReadCookie returning
+    // nullopt is what "no node is running" means to ipc::connect.
+    BOOST_CHECK(!fs::exists(dir / "ipc.cookie"));
+    BOOST_CHECK(!ipc::ReadCookie(dir).has_value());
+
+    // Removing an absent cookie is not an error. Shutdown must stay quiet after an
+    // unclean previous exit, or when a user removed the file by hand.
+    BOOST_CHECK_NO_THROW(ipc::DeleteCookie(dir));
+
+    // And the real writer where the platform allows it, so the pair is covered
+    // end to end on the platforms that can express the permission.
+    try {
+        const std::string written = ipc::WriteCookie(dir);
+        BOOST_CHECK_EQUAL(written.size(), 64u); // 256 bits, hex
+
+        const std::optional<std::string> written_back = ipc::ReadCookie(dir);
+        BOOST_REQUIRE(written_back.has_value());
+        BOOST_CHECK_EQUAL(*written_back, written);
+
+        ipc::DeleteCookie(dir);
+        BOOST_CHECK(!ipc::ReadCookie(dir).has_value());
+    } catch (const std::runtime_error& e) {
+        BOOST_TEST_MESSAGE(std::string("WriteCookie is not available here: ") + e.what());
+    }
+
+    fs::remove_all(dir);
+}
 
 BOOST_AUTO_TEST_CASE(identity_token_empty_uuid_is_empty)
 {


### PR DESCRIPTION
Tier B row B-10 from the backport review: mirror upstream's `DeleteAuthCookie()`.

The daemon mints a 256-bit IPC authentication cookie at startup and left the file behind on exit.
Two consequences, and the second is the one that arrives as a bug report:

- The cookie is a live credential for exactly as long as the file exists, so a *stopped* node left
  one readable by anything that can read the datadir.
- `ReadCookie()` returning a value is also what `ipc::connect` uses to mean **a node is running**.
  A leftover file therefore sends the next GUI to a socket nobody is listening on, and it reports a
  connection failure rather than "not running".

### Two details in the diff

`DeleteCookie()` never throws. Shutdown is the wrong place to raise, and an absent cookie is the
expected case after an unclean exit — `fs::remove` reports that by returning false without setting
the `error_code`, so only a real failure logs.

Whether a cookie was written is tracked in its own flag rather than keyed off the `Ipc` pointer,
because `WriteCookie()` runs **before** the `Ipc` is built: a failure in between would otherwise
leave the credential on disk with nothing to remove it.

### Verified end to end, not by inspection

The shutdown path lives inside `#ifdef ENABLE_MULTIPROCESS`, and `test/functional/` has **no
`-multiprocess` coverage at all** — so a unit test cannot reach it. Built a
`-DENABLE_MULTIPROCESS=ON` daemon and ran it on regtest:

```
patched    cookie present while running: YES (64 bytes)  ->  after shutdown: removed
mutated    cookie present while running: YES (64 bytes)  ->  after shutdown: STILL THERE
restored   cookie present while running: YES (64 bytes)  ->  after shutdown: removed
```

where *mutated* is this commit with only the `DeleteCookie` call commented out — i.e. the behaviour
on `development` today.

`cookie_round_trip_and_delete` covers the helper itself: read back, delete, and delete again on an
absent file, which must stay quiet. It seeds the cookie file directly and exercises the real
`WriteCookie()` only inside a `try/catch`, which is not squeamishness — `WriteCookie()` applies an
owner-only DACL to the temp file it renames into place and **throws** where the platform cannot,
which is the case under Wine, where the Windows cross-compile leg runs this suite:

```
Refusing to serve IPC: '...\ipc.cookie.tmp' could not be restricted to the current user
-- its DACL is not protected (it still inherits ACEs from the parent).
```

The delete path has to be testable everywhere the suite runs, so it does not depend on the write
path being available. Worth flagging separately: this means **`-multiprocess` cannot write a cookie
under Wine at all**. That is pre-existing and not addressed here.

**Testing.** Unit suite and the full functional suite pass.
