### PR TITLE
lint, scraper: fail new bare asserts, and drop the one on the part path

### DIFF
--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -13,6 +13,7 @@
 #include "rpc/server.h"
 #include "rpc/protocol.h"
 #include "rpc/util.h"
+#include "util/check.h"
 #include "serialize.h"
 #ifdef SCRAPER_NET_PK_AS_ADDRESS
 #include <key_io.h>
@@ -209,20 +210,35 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
 
                 ++split.cntPartsRcvd;
 
-                // Was an assert. This runs on peer data -- a PART message, counted against
-                // refs built from a manifest a peer sent -- and an assert on that path is a
-                // crash primitive the moment the invariant is wrong, whether or not it can be
-                // reached today. It does hold today: refs carries one entry per (manifest,
-                // slot) naming this part, and this branch runs only for a part that was not
-                // already present(), so each slot is counted at most once.
+                // Invariant: cntPartsRcvd <= vParts.size(). This is a theorem of
+                // the counter's two writers, not an assumption: addPart() pairs
+                // each new vParts slot with at most one immediate count (part
+                // already present) or exactly one refs entry, and this branch
+                // counts each ref exactly once, on the part's single
+                // absent-to-present transition (part data is never cleared while
+                // refs exist). So the count equals the number of slots whose
+                // parts are present.
                 //
-                // Overshooting is not fatal either way: isComplete() requires
-                // cntPartsRcvd == vParts.size(), so a manifest that overshot simply never
-                // completes and is culled like any other stalled one. Say so and carry on.
-                if (split.cntPartsRcvd > split.vParts.size()) {
-                    LogPrintf("WARN: %s: received %u parts for a manifest with %u; it will never "
-                              "complete and will be culled.",
-                              __func__, (unsigned)split.cntPartsRcvd, (unsigned)split.vParts.size());
+                // Assume() rather than a bare assert: it halts in
+                // ABORT_ON_FAILED_ASSUME builds, so a future edit that breaks the
+                // writer discipline fails loudly in development, and it is a
+                // no-abort identity in production -- this runs on peer data, and
+                // the failure mode is benign anyway: isComplete() compares with
+                // equality, so an overshot manifest never completes and is culled
+                // like any other stalled one.
+                //
+                // The counts are read into locals under cs_manifest first:
+                // Assume() wraps its argument in a lambda, and thread-safety
+                // analysis does not carry lock-held state across lambda
+                // boundaries.
+                const size_t parts_received = split.cntPartsRcvd;
+                const size_t parts_declared = split.vParts.size();
+                if (!Assume(parts_received <= parts_declared)) {
+                    LogPrintf("WARN: %s: part %s pushed a manifest to %u received parts "
+                              "against %u declared; the count is corrupt, so the manifest "
+                              "will never complete and will be culled.",
+                              __func__, hash.GetHex(),
+                              (unsigned)parts_received, (unsigned)parts_declared);
                 }
 
                 if (split.isComplete())

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -208,7 +208,23 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
                 LOCK(split.cs_manifest);
 
                 ++split.cntPartsRcvd;
-                assert(split.cntPartsRcvd <= split.vParts.size());
+
+                // Was an assert. This runs on peer data -- a PART message, counted against
+                // refs built from a manifest a peer sent -- and an assert on that path is a
+                // crash primitive the moment the invariant is wrong, whether or not it can be
+                // reached today. It does hold today: refs carries one entry per (manifest,
+                // slot) naming this part, and this branch runs only for a part that was not
+                // already present(), so each slot is counted at most once.
+                //
+                // Overshooting is not fatal either way: isComplete() requires
+                // cntPartsRcvd == vParts.size(), so a manifest that overshot simply never
+                // completes and is culled like any other stalled one. Say so and carry on.
+                if (split.cntPartsRcvd > split.vParts.size()) {
+                    LogPrintf("WARN: %s: received %u parts for a manifest with %u; it will never "
+                              "complete and will be culled.",
+                              __func__, (unsigned)split.cntPartsRcvd, (unsigned)split.vParts.size());
+                }
+
                 if (split.isComplete())
                 {
                     split.Complete();

--- a/test/lint/lint-assertions.sh
+++ b/test/lint/lint-assertions.sh
@@ -31,4 +31,59 @@ if [[ ${OUTPUT} != "" ]]; then
     EXIT_CODE=1
 fi
 
+# A bare assert() ADDED to first-party code is a crash primitive: on a peer-facing
+# path it hands a remote party an abort, and everywhere else it turns a recoverable
+# state into a stopped node. This rule is diff-scoped rather than tree-wide -- the
+# tree carries several hundred inherited asserts and a tree-wide rule would only ever
+# be silenced -- so it asks one thing of new code: justify it or use something that
+# does not abort.
+#
+# Scope is a deny-list, not a named path set: everything first-party is covered, so a
+# new peer-facing file is covered the day it is added. That is deliberate. Every
+# previous sweep of this tree enumerated peer-facing files BY NAME and every one of
+# them omitted src/script/, the largest peer-data-driven evaluator here.
+#
+# Deliberate ones carry "LINT-OK-ASSERT: <reason>" ON THE SAME LINE -- the check reads the
+# diff line by line, so a comment on the line above would not be seen. That trailing reason
+# is the review record for why aborting is the right answer at that site.
+#
+# COMMIT_RANGE follows lint-whitespace.sh: unset means HEAD, i.e. the working tree.
+# The quality workflow exports it as base..head for the whole lint step, so on a pull
+# request this sees exactly the commits under review. On a plain push that expression
+# expands to a bare ".." -- say so and check nothing, rather than passing silently on a
+# range git cannot parse.
+if [ -z "${COMMIT_RANGE:-}" ]; then
+    ASSERT_COMMIT_RANGE="HEAD"
+else
+    ASSERT_COMMIT_RANGE="${COMMIT_RANGE}"
+fi
+
+if [ "${ASSERT_COMMIT_RANGE}" = ".." ] || ! git rev-parse --quiet --verify "${ASSERT_COMMIT_RANGE%%..*}" > /dev/null 2>&1; then
+    echo "lint-assertions: no usable COMMIT_RANGE (${ASSERT_COMMIT_RANGE}); skipping the added-assert check."
+    exit ${EXIT_CODE}
+fi
+
+VENDORED_EXCLUDES=(
+    ":(exclude)src/bdb53/*"
+    ":(exclude)src/leveldb/*"
+    ":(exclude)src/univalue/*"
+    ":(exclude)src/secp256k1/*"
+    ":(exclude)src/crc32c/*"
+    ":(exclude)src/minisketch/*"
+    ":(exclude)src/ipc/libmultiprocess/*"
+)
+
+DIFF_ADDED=$(git diff -U0 "${ASSERT_COMMIT_RANGE}" -- "*.cpp" "*.h" "${VENDORED_EXCLUDES[@]}" 2>/dev/null)
+ADDED_ASSERTS=$(echo "${DIFF_ADDED}" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -E "(^|[^_[:alnum:]])assert[[:space:]]*\(" | grep -vE "static_assert|LINT-OK-ASSERT")
+
+if [[ ${ADDED_ASSERTS} != "" ]]; then
+    echo "New bare assert() in first-party code. On a peer-facing path an assert is a remote"
+    echo "abort; elsewhere it stops a node that could have carried on. Prefer returning an"
+    echo "error, or CHECK_NONFATAL in RPC code. If aborting really is right here, say why with"
+    echo "a trailing LINT-OK-ASSERT: <reason> comment on the same line."
+    echo
+    echo "${ADDED_ASSERTS}"
+    EXIT_CODE=1
+fi
+
 exit ${EXIT_CODE}

--- a/test/lint/lint-assertions.sh
+++ b/test/lint/lint-assertions.sh
@@ -47,6 +47,10 @@ fi
 # diff line by line, so a comment on the line above would not be seen. That trailing reason
 # is the review record for why aborting is the right answer at that site.
 #
+# A pre-existing assert MOVED between files inside the range reads as added and is
+# flagged. Accepted: the strict direction, and a move of an assert is a fine moment
+# to re-justify it (or convert it -- see the guidance below).
+#
 # COMMIT_RANGE follows lint-whitespace.sh: unset means HEAD, i.e. the working tree.
 # The quality workflow exports it as base..head for the whole lint step, so on a pull
 # request this sees exactly the commits under review. On a plain push that expression
@@ -58,7 +62,12 @@ else
     ASSERT_COMMIT_RANGE="${COMMIT_RANGE}"
 fi
 
-if [ "${ASSERT_COMMIT_RANGE}" = ".." ] || ! git rev-parse --quiet --verify "${ASSERT_COMMIT_RANGE%%..*}" > /dev/null 2>&1; then
+# Both endpoints must resolve: git diff errors are suppressed below, so an
+# unresolvable side would otherwise yield an empty diff and a silent pass --
+# the exact vacuous-pass failure this rule exists to avoid.
+if [ "${ASSERT_COMMIT_RANGE}" = ".." ] \
+    || ! git rev-parse --quiet --verify "${ASSERT_COMMIT_RANGE%%..*}" > /dev/null 2>&1 \
+    || ! git rev-parse --quiet --verify "${ASSERT_COMMIT_RANGE##*..}" > /dev/null 2>&1; then
     echo "lint-assertions: no usable COMMIT_RANGE (${ASSERT_COMMIT_RANGE}); skipping the added-assert check."
     exit ${EXIT_CODE}
 fi
@@ -69,18 +78,36 @@ VENDORED_EXCLUDES=(
     ":(exclude)src/univalue/*"
     ":(exclude)src/secp256k1/*"
     ":(exclude)src/crc32c/*"
-    ":(exclude)src/minisketch/*"
+    ":(exclude)src/crypto/ctaes/*"
     ":(exclude)src/ipc/libmultiprocess/*"
 )
 
-DIFF_ADDED=$(git diff -U0 "${ASSERT_COMMIT_RANGE}" -- "*.cpp" "*.h" "${VENDORED_EXCLUDES[@]}" 2>/dev/null)
-ADDED_ASSERTS=$(echo "${DIFF_ADDED}" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -E "(^|[^_[:alnum:]])assert[[:space:]]*\(" | grep -vE "static_assert|LINT-OK-ASSERT")
+# Both endpoints resolved above, so a diff failure here is environmental --
+# fail loudly rather than passing on an empty diff.
+if ! DIFF_ADDED=$(git diff -U0 "${ASSERT_COMMIT_RANGE}" -- "*.cpp" "*.h" "${VENDORED_EXCLUDES[@]}" 2>/dev/null); then
+    echo "lint-assertions: git diff failed for ${ASSERT_COMMIT_RANGE}; refusing to pass vacuously."
+    exit 1
+fi
+# Marker-carrying lines are excused first: the marker lives in a comment, so it
+# must be honored before comment text is stripped. Then // tails, complete
+# /* */ spans, unterminated /* openings, and block-comment continuation lines
+# (leading *) are dropped, so assert( in prose -- a comment discussing an
+# assert, commented-out code -- does not read as a call site. static_assert is
+# neutralized by token substitution rather than dropping the line, so a bare
+# assert sharing a line with one still fails.
+ADDED_CANDIDATES=$(printf '%s\n' "${DIFF_ADDED}" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -vE "LINT-OK-ASSERT" | grep -vE "^\+[[:space:]]*\*([[:space:]/]|$)")
+ADDED_ASSERTS=$(printf '%s\n' "${ADDED_CANDIDATES}" | sed -E -e 's|//.*$||' -e 's@/\*([^*]|\*+[^/*])*\*+/@@g' -e 's@/\*.*$@@' -e 's|static_assert|STATIC_ASSERT_|g' | grep -E "(^|[^_[:alnum:]])assert[[:space:]]*\(")
 
 if [[ ${ADDED_ASSERTS} != "" ]]; then
     echo "New bare assert() in first-party code. On a peer-facing path an assert is a remote"
-    echo "abort; elsewhere it stops a node that could have carried on. Prefer returning an"
-    echo "error, or CHECK_NONFATAL in RPC code. If aborting really is right here, say why with"
-    echo "a trailing LINT-OK-ASSERT: <reason> comment on the same line."
+    echo "abort; elsewhere it stops a node that could have carried on. Prefer, in order:"
+    echo "  - returning an error: peer-reachable code rejects and carries on, never aborts;"
+    echo "  - CHECK_NONFATAL for RPC code (throws; surfaced to the caller);"
+    echo "  - Assert() from util/check.h for an invariant that genuinely must halt: it"
+    echo "    always evaluates and halts even under -DNDEBUG, unlike bare assert;"
+    echo "  - Assume() from util/check.h for a should-hold check tolerated in production."
+    echo "If a bare assert really is right, say why with a trailing"
+    echo "LINT-OK-ASSERT: <reason> comment on the same line."
     echo
     echo "${ADDED_ASSERTS}"
     EXIT_CODE=1


### PR DESCRIPTION
Two halves of one argument (maintainer edit: an opening reference to the author's local review tracking was removed per the thread below): an `assert()` reached by peer data is a remote abort,
and an `assert()` anywhere else stops a node that could have carried on.

### The lint

A third rule in `test/lint/lint-assertions.sh`, beside the two already there (side effects, and
`CHECK_NONFATAL` for RPC code).

**It is diff-scoped, deliberately.** This tree carries **347** first-party asserts, most inherited.
A tree-wide rule would be silenced within a week rather than obeyed, and a baseline file listing 347
sites is a maintenance burden with no reviewer attached. What this asks of *new* code is one thing:
justify the abort, or use something that does not abort.

**Scope is a deny-list, not a named path set**, and that is the load-bearing choice. Every previous sweep of this tree enumerated peer-facing files *by name*, and every one of them
omitted `src/script/` — the largest peer-data-driven evaluator here, with 15 asserts across four
files. When this was written I had read the five in the `.cpp` files (`interpreter.cpp`'s four,
`standard.cpp`'s one); the other ten, in `script.h` and `sign.cpp`, were read during review and
are tabled in the thread. All fifteen are unreachable from peer input — the two
`assert(!"invalid opcode")` switch-defaults because each inner `switch (opcode)` enumerates exactly
the labels of the `case` group enclosing it — but that is luck, not process: a name-based path set
would have been written without them again. A deny-list covers a new
peer-facing file the day it is added.

A deliberate assert carries a trailing `LINT-OK-ASSERT: <reason>`, which becomes the review record
for why aborting is right at that site. The check reads the diff line by line, so the marker has to
be on the same line — the comment says so rather than leaving it to be discovered.

`COMMIT_RANGE` follows `lint-whitespace.sh`, and `cmake_quality.yml:129` already exports it as
`base..head` for the whole lint step, so **on a pull request this sees exactly the commits under
review**. On a plain push that expression expands to a bare `..`; the rule now reports that it is
skipping rather than passing silently on a range git cannot parse.

Exercised five ways:

| Case | Result |
|---|---|
| commit removes an assert | pass |
| commit adds a bare assert (first-party) | **fail**, printing the offending line |
| same line with `LINT-OK-ASSERT` | pass |
| adds a bare assert in vendored code | pass (deny-listed) |
| `COMMIT_RANGE=".."` | skips, with a message |

### The assert

`scraper_net.cpp`'s part handler asserted `cntPartsRcvd <= vParts.size()` while counting a `PART`
message against refs built from a manifest **a peer sent**.

The invariant does hold today — `refs` carries one entry per (manifest, slot) naming this part, and
the branch runs only for a part that was not already `present()`, so each slot is counted at most
once. But an assert on that path is a crash primitive the moment that stops being true, and this is
the site the review singled out.

Overshooting was never fatal in the first place: `isComplete()` requires
`cntPartsRcvd == vParts.size()`, so a manifest that overshot simply never completes and is culled
like any other stalled one. It now logs and carries on.

### Not in this PR

The sweep itself — reading and converting or justifying the remaining first-party asserts — is the
other half of the row and wants to be incremental. The ratchet is what stops the number growing
while that happens. Inventory, if useful: `addrman.cpp` 14, `chainman.cpp` 13, `script/` 15,
`netbase.cpp` 4, `net.cpp` 3, `validation.cpp` 3, the scrapers 6 (now 5), and
`net_processing.cpp` / `txmempool.cpp` have **none**.

**Testing.** Unit suite, the full functional suite and `lint-all.sh` all pass.


