### PR TITLE
ci: source-build and cache Intel openssl@3 (no Homebrew bottle)

### DIFF
--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -548,7 +548,9 @@ jobs:
       - name: Determine openssl@3 version for the Intel build cache
         id: sslver
         run: |
-          echo "version=$(curl -fsSL https://formulae.brew.sh/api/formula/openssl@3.json | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["versions"]["stable"])')" >> "$GITHUB_OUTPUT"
+          # versions.stable alone misses Homebrew revision bumps (rebuilds
+          # against new deps, e.g. 3.x.y_1), which must invalidate the cache.
+          echo "version=$(curl -fsSL https://formulae.brew.sh/api/formula/openssl@3.json | /usr/bin/python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["versions"]["stable"] + ("_" + str(d["revision"]) if d.get("revision") else ""))')" >> "$GITHUB_OUTPUT"
 
       - name: Cache the source-built Intel openssl@3
         uses: actions/cache@v5
@@ -565,8 +567,12 @@ jobs:
           # No-op when the cached keg matches the current formula version;
           # a source build (~15 min) only on a cache miss or a version bump.
           arch -x86_64 /usr/local/bin/brew install --build-from-source openssl@3
-          # The cache carries the keg, not the link farm -- relink explicitly.
-          arch -x86_64 /usr/local/bin/brew link --overwrite openssl@3 || true
+          # The cache carries only the keg: a restored run has no
+          # /usr/local/opt/openssl@3 symlink, and the configure step resolves
+          # OPENSSL_ROOT_DIR through exactly that path. openssl@3 is keg-only,
+          # so linking needs --force; no fallback swallow -- a link failure
+          # here must fail the job, not surface later as a configure mystery.
+          arch -x86_64 /usr/local/bin/brew link --force --overwrite openssl@3
           arch -x86_64 /usr/local/bin/brew install qt boost libevent miniupnpc qrencode libzip ccache cmake capnp
 
       - name: Configure Ccache

--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -537,13 +537,37 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Homebrew stopped shipping x86_64 macOS bottles for openssl@3 (Tier 3
+      # platform demotion), and qt depends on it, so a plain install aborts on
+      # "no bottle available". Source-build it once per formula version and
+      # carry the built keg between runs: the version comes from the formulae
+      # API (no brew needed before the bootstrap below), and a restored,
+      # current keg makes the install line a fast no-op. Everything else in
+      # this job still has Intel bottles today; if another formula loses its
+      # bottle, give it the same treatment.
+      - name: Determine openssl@3 version for the Intel build cache
+        id: sslver
+        run: |
+          echo "version=$(curl -fsSL https://formulae.brew.sh/api/formula/openssl@3.json | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["versions"]["stable"])')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the source-built Intel openssl@3
+        uses: actions/cache@v5
+        with:
+          path: /usr/local/Cellar/openssl@3
+          key: openssl3-intel-${{ steps.sslver.outputs.version }}
+
       - name: Install x86_64 Homebrew and Dependencies
         run: |
           # Install a separate x86_64 Homebrew at /usr/local (Intel prefix).
           # The ARM64 runner has Rosetta 2, so x86_64 binaries run transparently.
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" </dev/null
           arch -x86_64 /usr/local/bin/brew update
-          arch -x86_64 /usr/local/bin/brew install qt boost openssl libevent miniupnpc qrencode libzip ccache cmake capnp
+          # No-op when the cached keg matches the current formula version;
+          # a source build (~15 min) only on a cache miss or a version bump.
+          arch -x86_64 /usr/local/bin/brew install --build-from-source openssl@3
+          # The cache carries the keg, not the link farm -- relink explicitly.
+          arch -x86_64 /usr/local/bin/brew link --overwrite openssl@3 || true
+          arch -x86_64 /usr/local/bin/brew install qt boost libevent miniupnpc qrencode libzip ccache cmake capnp
 
       - name: Configure Ccache
         uses: actions/cache@v5


### PR DESCRIPTION
Homebrew has stopped shipping x86_64 macOS bottles for openssl@3 under its Tier 3 platform demotion (verified against the formulae API: the current bottle list carries arm64 and Linux platforms only, while the formula itself is neither deprecated nor disabled). Since qt depends on openssl@3, the macOS Intel job's dependency install now aborts deterministically on 'no bottle available' — currently blocking every PR's merge gate (first seen on #3307 and #3313).

Every other formula the job installs still has an Intel (sonoma) bottle today, so the fix is targeted: build openssl@3 from source once per formula version, and cache the built keg.

- The cache key is the upstream formula version, read from the formulae API before the Homebrew bootstrap (no brew needed for the key).
- A restored, current keg makes the 'brew install --build-from-source openssl@3' line a fast no-op; a stale keg (version bump) rebuilds; a cache miss builds. No branching required.
- The link farm is not part of the keg, so the job relinks explicitly after the install line.
- Cost: ~15 minutes of compile on the first run after each upstream openssl version bump; effectively zero otherwise.

The sonoma-only pattern on the surviving bottles shows the direction Homebrew is taking x86_64 macOS; if another formula loses its Intel bottle, it gets the same treatment (the comment in the workflow says so). Retiring the Intel job was considered and rejected: Intel Macs remain in active use in this project's user base.

This PR's own CI run exercises the fix live, including the first (cache-cold) source build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)