### PR TITLE
researcher: stop an unreadable BOINC data directory aborting startup

### DIFF
--- a/src/gridcoin/boinc.cpp
+++ b/src/gridcoin/boinc.cpp
@@ -9,18 +9,34 @@
 #include <optional>
 #include <vector>
 
+namespace {
+//! \brief fs::exists() that reports an unprobeable path as absent.
+//!
+//! The throwing overload raises filesystem_error when the path cannot be
+//! stat()ed at all -- most commonly EACCES on a directory owned by another
+//! user. Probing for BOINC is a best-effort guess among candidates, and every
+//! caller here wants "no" for a candidate it is not allowed to look at, not an
+//! exception unwinding out of startup.
+bool PathExists(const fs::path& path)
+{
+    boost::system::error_code ec;
+
+    return fs::exists(path, ec) && !ec;
+}
+} // anonymous namespace
+
 fs::path GRC::ResolveBoincDataDir(const std::vector<fs::path>& candidates)
 {
     // Pass 1: Prefer a directory with client_state.xml (active BOINC installation).
     for (const auto& candidate : candidates) {
-        if (fs::exists(candidate / "client_state.xml")) {
+        if (PathExists(candidate / "client_state.xml")) {
             return candidate;
         }
     }
 
     // Pass 2: Fall back to any directory that exists (installed but not yet run).
     for (const auto& candidate : candidates) {
-        if (fs::exists(candidate)) {
+        if (PathExists(candidate)) {
             return candidate;
         }
     }
@@ -76,7 +92,7 @@ static fs::path FindBoincDataDir()
 
             fs::path path = std::wstring(szPath);
 
-            if (fs::exists(path)){
+            if (PathExists(path)){
                 return path;
             } else {
                 LogPrintf("Cannot find BOINC data dir %s.", path.string());
@@ -86,9 +102,9 @@ static fs::path FindBoincDataDir()
         RegCloseKey(hKey);
     }
 
-    if (fs::exists("C:\\ProgramData\\BOINC\\")){
+    if (PathExists("C:\\ProgramData\\BOINC\\")){
         return "C:\\ProgramData\\BOINC\\";
-    } else if(fs::exists("C:\\Documents and Settings\\All Users\\Application Data\\BOINC\\")) {
+    } else if(PathExists("C:\\Documents and Settings\\All Users\\Application Data\\BOINC\\")) {
         return "C:\\Documents and Settings\\All Users\\Application Data\\BOINC\\";
     }
     #endif
@@ -113,7 +129,7 @@ static fs::path FindBoincDataDir()
     #endif
 
     #ifdef __APPLE__
-    if (fs::exists("/Library/Application Support/BOINC Data/")) {
+    if (PathExists("/Library/Application Support/BOINC Data/")) {
         return "/Library/Application Support/BOINC Data/";
     }
     #endif

--- a/src/test/gridcoin/boinc_tests.cpp
+++ b/src/test/gridcoin/boinc_tests.cpp
@@ -112,4 +112,40 @@ BOOST_AUTO_TEST_CASE(it_returns_empty_for_empty_candidate_list)
     BOOST_CHECK(GRC::ResolveBoincDataDir(candidates).empty());
 }
 
+//! A candidate the process is not allowed to stat has to read as absent.
+//!
+//! boost::filesystem::exists() throws filesystem_error on EACCES rather than
+//! returning false. The distro BOINC packages install /var/lib/boinc-client owned
+//! by the boinc user with mode 0750, so a wallet running as an ordinary user
+//! cannot probe it -- and the exception unwound all the way out of AppInit and
+//! aborted the daemon at startup.
+BOOST_AUTO_TEST_CASE(it_skips_a_candidate_it_cannot_probe)
+{
+    BoincDataDirTestSetup setup;
+
+    fs::path unreadable = setup.CreateActiveDir("unreadable");
+    fs::path readable = setup.CreateActiveDir("readable");
+
+    fs::permissions(unreadable, fs::no_perms);
+
+    // Root ignores the mode bits, and not every filesystem carries them, so
+    // confirm the probe really is blocked before asserting on the consequence.
+    boost::system::error_code probe;
+    fs::exists(unreadable / "client_state.xml", probe);
+
+    if (!probe) {
+        fs::permissions(unreadable, fs::owner_all);
+        BOOST_TEST_MESSAGE("skipped: this process can still probe a no-perms directory");
+        return;
+    }
+
+    std::vector<fs::path> candidates = {unreadable, readable};
+    const fs::path resolved = GRC::ResolveBoincDataDir(candidates);
+
+    // Restore before the assertion so the fixture can always clean up.
+    fs::permissions(unreadable, fs::owner_all);
+
+    BOOST_CHECK_EQUAL(resolved, readable);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/boinc_tests.cpp
+++ b/src/test/gridcoin/boinc_tests.cpp
@@ -23,7 +23,19 @@ struct BoincDataDirTestSetup
 
     ~BoincDataDirTestSetup()
     {
-        fs::remove_all(test_root);
+        // A test that fails mid-case can leave a permission-stripped
+        // directory behind; restore access before removing, and never throw
+        // from a destructor during unwind -- a throwing remove_all here turns
+        // a clean test failure into SIGABRT plus a leaked no-perms directory
+        // under /tmp.
+        boost::system::error_code ec;
+        for (fs::recursive_directory_iterator it(test_root, ec), end; !ec && it != end; it.increment(ec)) {
+            fs::permissions(it->path(), fs::owner_all, ec);
+            ec.clear();
+        }
+        fs::permissions(test_root, fs::owner_all, ec);
+        ec.clear();
+        fs::remove_all(test_root, ec);
     }
 
     //! Create a candidate directory (installed but not active).


### PR DESCRIPTION
**Branch:** `boinc/tolerate-unreadable-datadir` @ `63bdf234e` (1 commit of mine, rebased 2026-09-01 from
`ed1583a9c`, plus the maintainer's review commit `63bdf234e`, which makes the test fixture's
teardown best-effort)
**Base:** `upstream/development` @ `2d186ff2d` (merge of #3317). Independent of everything else in flight.

---

`GRC::ResolveBoincDataDir` probes its candidates with the **throwing**
`boost::filesystem::exists` overload, which raises `filesystem_error` rather than returning false
when the path cannot be `stat()`ed at all. Nothing between there and `AppInit` catches it except
the daemon's `PrintException`, which rethrows, so the daemon terminates during initialization:

```
EXCEPTION: N5boost10filesystem16filesystem_errorE
boost::filesystem::status: Permission denied [system:13]: "/var/lib/boinc-client/client_state.xml"
gridcoin in AppInit()
terminate called after throwing an instance of 'boost::filesystem::filesystem_error'
```

Exit status -6. No wallet.

### This is a realistic configuration, not a corner

Ubuntu 24.04's `boinc-client` (`7.24.1+dfsg-4build1`, the Debian package rebuilt) installs
`/var/lib/boinc-client` as `drwxr-x--- boinc:boinc` — checked on the box that hit this, not
assumed. A wallet run as an ordinary user on a machine with BOINC installed from the distro
therefore cannot start.

Setting `boincdatadir=` in the config does avoid it — `FindBoincDataDir` returns that before probing
anything — but the failure gives the user no hint that this is what happened, or that a BOINC
install they never pointed the wallet at is what is stopping it.

I hit it on a development box, where it took out **every functional test that starts a node**:
on this head that is all 31 scripts in the runner (the one survivor in my tree was the
beacon-activation test, which lives on a companion branch and points `-boincdatadir` inside its
own test directory). It is not visible in CI because the runners have no BOINC installed at all.

### The fix

Probing for BOINC is a best-effort guess among candidates, and every caller wants "no" for a
candidate it is not allowed to look at — not an exception unwinding out of startup. All of them now
route through a `PathExists()` helper on the `error_code` overload (`boinc.cpp`).

The Windows and macOS literal paths get the same treatment. A directory whose ACL denies the wallet
is the same class of problem, and there is no reason for those two to keep the throwing form.

A machine with a readable BOINC directory resolves exactly as before, and a machine with none still
ends at the existing "Cannot find BOINC data directory" guidance. On the distro layout above the
outcome is in between: `client_state.xml` cannot be probed, so the first pass skips the candidate,
but the directory itself is still `stat`-able (that only needs search permission on `/var/lib`), so
the second pass resolves it. `ReadClientStateXml`'s existing `filesystem_error` handler then reports
that it could not access the BOINC data directory and to check permissions, which is the right
message: the wallet starts and the user is told which directory to fix. One further change in
behaviour: a candidate whose `stat` fails for a reason other than permissions (`ELOOP`,
`ENAMETOOLONG`, I/O error) now reads as absent instead of throwing.

### Testing

New unit case `it_skips_a_candidate_it_cannot_probe` in `boinc_tests`: make a candidate's
`client_state.xml` unprobeable, assert the resolver skips to the next, readable candidate. It
self-skips (a pass with a `BOOST_TEST_MESSAGE`, which is invisible at ctest's default log level,
so a skip and a run are indistinguishable on every CI leg) when the process can still `stat` the
file anyway — root ignores the mode bits, and not every filesystem carries them — so it is honest
on a runner where the setup does not take. In CI that means the pin is exercised on the hosted
Linux and macOS unit jobs, which run as a non-root user, and self-skips in the root-in-Docker
distro matrix and on the Wine leg, where `fs::permissions` only toggles read-only.

**Mutation-checked:** with the fix reverted, that test aborted the suite with `SIGABRT` on my
head: Boost.Test would report the resolver's `filesystem_error` as an ordinary failure, but the
throw skipped the fixture's permission restore, so the fixture destructor's `remove_all` threw on
the still-unreadable directory and terminated the process. The maintainer's `63bdf234e` makes the
teardown best-effort, so a regression now surfaces as a clean test failure instead.

On the rebased head: full unit suite green (no errors detected) and the default functional suite,
31 scripts on this head, all passing locally on the affected host — which, without this commit, fails every script that starts a
node with the exit-status -6 above. Fork CI 6/6 green at `cb7de0846`.
