### PR TITLE
txmempool, miner, validation: make pooled-transaction access const-correct, drop GetTxMutable

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -83,11 +83,11 @@ namespace {
 class COrphan
 {
 public:
-    CTransaction* ptx;
+    const CTransaction* ptx;
     set<uint256> setDependsOn;
     double dFeePerKb;
 
-    COrphan(CTransaction* ptxIn)
+    COrphan(const CTransaction* ptxIn)
     {
         ptx = ptxIn;
         dFeePerKb = 0;
@@ -409,14 +409,14 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
         map<uint256, vector<COrphan*> > mapDependers;
 
         // This vector will be sorted into a priority queue:
-        std::vector<std::pair<double, CTransaction*>> vecPriority;
+        std::vector<std::pair<double, const CTransaction*>> vecPriority;
         vecPriority.reserve(mempool.mapTx.size());
 
         Fraction foundation_fee_fraction = FoundationSideStakeAllocation();
 
-        for (auto& [_, entry] : mempool.mapTx)
+        for (const auto& [_, entry] : mempool.mapTx)
         {
-            CTransaction& tx = entry.GetTxMutable();
+            const CTransaction& tx = entry.GetTx();
             if (tx.IsCoinBase() || tx.IsCoinStake() || !IsFinalTx(tx, nHeight))
                 continue;
 
@@ -561,7 +561,7 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
         {
             // Take highest priority transaction off the priority queue:
             double dFeePerKb = vecPriority.front().first;
-            CTransaction& tx = *(vecPriority.front().second);
+            const CTransaction& tx = *(vecPriority.front().second);
 
             std::pop_heap(vecPriority.begin(), vecPriority.end());
             vecPriority.pop_back();

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -20,11 +20,11 @@ struct CMutableTransaction;
 class CInPoint
 {
 public:
-    CTransaction* ptx;
+    const CTransaction* ptx;
     unsigned int n;
 
     CInPoint() { SetNull(); }
-    CInPoint(CTransaction* ptxIn, unsigned int nIn) { ptx = ptxIn; n = nIn; }
+    CInPoint(const CTransaction* ptxIn, unsigned int nIn) { ptx = ptxIn; n = nIn; }
     void SetNull() { ptx = nullptr; n = (unsigned int)-1; }
     bool IsNull() const { return (ptx == nullptr && n == (unsigned int)-1); }
 };

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(a_consensus_script_failure_scores_the_relayer)
     // NO DoS score, which would make the control below pass for the wrong reason.
     spender.vout[0].nValue = COIN / 2;
 
-    CTransaction tx(spender);   // ConnectInputs takes a non-const reference
+    const CTransaction tx(spender);
     CTxDB txdb("r");
 
     // Control: v15 inert. CLEANSTACK is not in the flag set, the top of the stack

--- a/src/test/txmempool_tests.cpp
+++ b/src/test/txmempool_tests.cpp
@@ -28,6 +28,8 @@
 
 #include <univalue.h>
 
+#include <type_traits>
+
 namespace {
 //! Build a v2 transaction carrying the supplied contracts (if any).
 CTransaction MakeTx(const std::vector<GRC::Contract>& contracts = {},
@@ -152,7 +154,10 @@ BOOST_AUTO_TEST_CASE(addunchecked_preserves_mapnexttx_and_lookup)
     CTxMemPoolEntry entry(tx, 0, 0, 0, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
     BOOST_CHECK(pool.addUnchecked(hash, entry));
 
-    // mapNextTx points back at the stored transaction.
+    // mapNextTx points back at the stored transaction, through a pointer that
+    // cannot be used to mutate it (the entry's cached metadata depends on that).
+    static_assert(std::is_same_v<decltype(CInPoint::ptx), const CTransaction*>,
+                  "CInPoint::ptx must not grant mutable access to a pooled transaction");
     auto it = pool.mapNextTx.find(vin.prevout);
     BOOST_REQUIRE(it != pool.mapNextTx.end());
     BOOST_REQUIRE(it->second.ptx != nullptr);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -79,7 +79,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry)
         // Point mapNextTx at the transaction stored inside the pool's own map
         // node (std::map never relocates nodes, so the pointer stays valid until
         // the entry is removed).
-        CTransaction& stored_tx = it->second.GetTxMutable();
+        const CTransaction& stored_tx = it->second.GetTx();
         for (unsigned int i = 0; i < stored_tx.vin.size(); i++)
             mapNextTx[stored_tx.vin[i].prevout] = CInPoint(&stored_tx, i);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -100,15 +100,10 @@ public:
     CTxMemPoolEntry(const CTransaction& tx, CAmount fee, int64_t time,
                     int height, size_t tx_size);
 
+    //! The stored transaction is exposed read-only: the cached fee/size/sigops/
+    //! contract-tag metadata this entry carries is computed once in the constructor and would
+    //! silently go stale if the transaction could be mutated in place.
     const CTransaction& GetTx() const { return tx; }
-    //! Non-const access to the stored transaction, used ONLY to obtain a stable
-    //! CTransaction* for legacy non-const APIs: addUnchecked()'s mapNextTx wiring
-    //! and the miner's COrphan / vecPriority structures (which hold CTransaction*).
-    //! Callers MUST NOT mutate the transaction -- doing so would silently
-    //! invalidate this entry's cached fee/size/sigops/contract-tag metadata.
-    //! (Making those legacy consumers const-correct so this can be removed is a
-    //! tracked follow-up.)
-    CTransaction& GetTxMutable() { return tx; }
 
     CAmount GetFee() const { return nFee; }
     size_t GetTxSize() const { return nTxSize; }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -304,7 +304,7 @@ bool HasMasterKeyInput(const CTransaction& tx, const MapPrevTx& inputs, int bloc
     return false;
 }
 
-bool DisconnectInputs(CTransaction& tx, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool DisconnectInputs(const CTransaction& tx, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Relinquish previous transactions' spent pointers
     if (!tx.IsCoinBase())
@@ -339,7 +339,7 @@ bool DisconnectInputs(CTransaction& tx, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs
 }
 
 
-bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool,
+bool FetchInputs(const CTransaction& tx, CValidationState& state, CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool,
                  bool fBlock, bool fMiner, MapPrevTx& inputsRet, bool& fInvalid)
 {
     // FetchInputs can return false either because we just haven't seen some inputs
@@ -415,7 +415,7 @@ bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const s
 
 std::atomic<uint64_t> g_connectinputs_signature_checks{0};
 
-bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
+bool ConnectInputs(const CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
     const CBlockIndex* pindexBlock, bool fBlock, bool fMiner)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
@@ -2207,7 +2207,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
     }
 
     // Check for conflicts with in-memory transactions
-    CTransaction* ptxOld = nullptr;
+    const CTransaction* ptxOld = nullptr;
     {
         LOCK(pool.cs); // protect pool.mapNextTx
         for (unsigned int i = 0; i < tx.vin.size(); i++)

--- a/src/validation.h
+++ b/src/validation.h
@@ -109,7 +109,7 @@ const CTxOut& GetOutputFor(const CTxIn& input, const MapPrevTx& inputs);
 */
 CAmount GetValueIn(const CTransaction& tx, const MapPrevTx& inputs);
 
-bool DisconnectInputs(CTransaction& tx, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool DisconnectInputs(const CTransaction& tx, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Fetch from memory and/or disk. inputsRet keys are transaction hashes.
     @param[in] tx The transaction to fetch inputs for
@@ -127,7 +127,7 @@ bool DisconnectInputs(CTransaction& tx, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs
 // nBestHeight. Block-processing callers (ConnectInputs / CreateNewBlock)
 // hold cs_main for other reasons, but FetchInputs itself is callable
 // from RPC paths (signrawtransaction*) without cs_main.
-bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool, bool fBlock, bool fMiner, MapPrevTx& inputsRet, bool& fInvalid);
+bool FetchInputs(const CTransaction& tx, CValidationState& state, CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool, bool fBlock, bool fMiner, MapPrevTx& inputsRet, bool& fInvalid);
 
 /** Sanity check previous transactions, then, if all checks succeed,
     mark them as spent by tx.
@@ -150,7 +150,7 @@ bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const s
 //! either way -- only the cost differs.
 extern std::atomic<uint64_t> g_connectinputs_signature_checks;
 
-bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx, const CBlockIndex* pindexBlock, bool fBlock, bool fMiner) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool ConnectInputs(const CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx, const CBlockIndex* pindexBlock, bool fBlock, bool fMiner) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool GetCoinAge(const CTransaction& tx, CTxDB& txdb, uint64_t& nCoinAge) EXCLUSIVE_LOCKS_REQUIRED(cs_main); // ppcoin: get transaction coin age
 


### PR DESCRIPTION
Closes the follow-up recorded on #3090. When `CTxMemPoolEntry` gained its cached fee/size/sigops/
contract-tag metadata, a mutable accessor had to stay because two legacy consumers stored a
non-const `CTransaction*`. Your reply on the `miner.cpp` thread:

> It's not read-only: this loop stores &tx into COrphan(&tx) and vecPriority (both non-const CTransaction* by legacy design), so a const binding won't compile without converting those structures. Documented GetTxMutable's no-mutation contract in 57f6acfe6; the const-correctness refactor of COrphan/vecPriority is a tracked follow-up.

and on the `txmempool.h` thread:

> […] It can't be made private+friend: the miner legitimately needs a non-const CTransaction* (COrphan::ptx and vecPriority hold CTransaction* and the loop stores &tx). The comment now forbids mutation and names the two legitimate consumers. Making COrphan/vecPriority const-correct so GetTxMutable can be removed is tracked as a follow-up.

This is that refactor, done in full rather than the miner half alone. The miner half by itself
would not have retired the accessor, because `addUnchecked` also needed a mutable pointer to build
`CInPoint`, and `CInPoint::ptx` is `CTransaction*`. So the root of the change is `CInPoint`.

### What changes

- `CInPoint::ptx` and its constructor take `const CTransaction*`. Every reader of `mapNextTx`
  only dereferences: `remove`, `removeConflicts`, `AcceptToMemoryPool`'s (disabled) replacement
  check, `rpcwallet.cpp` and `txmempool_tests.cpp`; `psgt_pool.cpp` only queries the map by key.
  Grepped on the final head; no site writes through the pointer.
- `addUnchecked` wires `mapNextTx` from `GetTx()`.
- `AcceptToMemoryPool`'s `ptxOld` local becomes `const CTransaction*`.
- The miner's `COrphan::ptx`, its constructor, and the `vecPriority` element type become
  `const CTransaction*`; the per-entry loop binds `const auto& [_, entry]` and
  `const CTransaction& tx = entry.GetTx()`, and the heap-pop binding is const too.
- `GetTxMutable()` is deleted. Its no-mutation rationale moves onto `GetTx()`.
- The const binding in the miner exposed the next layer: `FetchInputs` and `ConnectInputs` took
  `CTransaction&` while only reading it. `connectinputs_tests.cpp` carried the comment
  "ConnectInputs takes a non-const reference" beside a `CTransaction` copy, but the copy is the
  `CMutableTransaction` to `CTransaction` conversion and is needed whatever the parameter's
  constness, so the comment was wrong and is dropped; the local is now `const`. Both functions
  take `const CTransaction&` now, and `DisconnectInputs`, whose body is read-only in the same way,
  follows. No production caller changes: a non-const argument binds to a const parameter.
- `txmempool_tests.cpp` gains a `static_assert` that `CInPoint::ptx` is a pointer to const, so
  reintroducing mutable access is a compile error rather than a comment violation.

The Copilot suggestion on #3090 was `private + friend`, or a differently named accessor that does
not imply mutability; this removes the accessor instead, which is strictly stronger and leaves
nothing to befriend.

### Behaviour

None changed. Every touched site was already read-only in practice; the compiler now enforces it.

**Testing.** Unit suite and the full functional suite pass locally on the head. The
`static_assert` is the only new check; it is compile-time, and I confirmed it fails to compile
on `development` before this change (where `CInPoint::ptx` is still `CTransaction*`).

https://claude.ai/code/session_01GtjiCGE4qYMeyrMgjt3QQc
