### PR TITLE
rpc, test: add disconnectnode and make the framework's disconnect_nodes work

### DIFF
--- a/doc/rpc-heritage.md
+++ b/doc/rpc-heritage.md
@@ -8,8 +8,8 @@ Each RPC's bucket + fingerprint baseline is a **column on its `vRPCCommands[]` r
 - **presence** on every registered RPC (the row's `heritage_<bucket>` parses to a known bucket; classify-at-birth is also compiler-enforced by the required constructor field);
 - **surface-fingerprint drift** on `pure-upstream`, `mixed` & `removed-upstream` -- `fp` = `sha256("ARGS:" + args[in RPCHelpMan declaration order] + "|KEYS:" + sorted(result pushKV keys, gathered by cycle-safe recursive descent through called result-builder helpers))[:12]`. A mismatch means the input/output surface changed; re-confirm the bucket and update the row + this doc. `pure-gridcoin` is not fingerprinted (`heritage_fp` empty), and any fingerprinted RPC whose output isn't literal-key-trackable -- a dynamically-keyed object, or a positional array of scalars -- uses `heritage_fp` `manual` (drift reviewed by hand).
 
-## Tally (215)
-- pure-upstream (backport-safe): **14**
+## Tally (216)
+- pure-upstream (backport-safe): **15**
 - mixed (careful porting): **58**
 - removed-upstream (frozen fork, deleted from current upstream): **16**
 - pure-gridcoin (no current upstream analogue): **127**
@@ -19,6 +19,7 @@ Each RPC's bucket + fingerprint baseline is a **column on its `vRPCCommands[]` r
 |---|---|---|---|---|
 | `abandontransaction` | src/wallet/rpcwallet.cpp | `(txid)` | `{}` | `8a15aece8d9f` |
 | `clearbanned` | src/rpc/net.cpp | `()` | `{}` | `e169db2f48c0` |
+| `disconnectnode` | src/rpc/net.cpp | `(address, nodeid)` | `{}` | `b194f6d2d2e2` |
 | `getbestblockhash` | src/rpc/blockchain.cpp | `()` | `{}` | `e169db2f48c0` |
 | `getblockcount` | src/rpc/blockchain.cpp | `()` | `{}` | `e169db2f48c0` |
 | `getblockhash` | src/rpc/blockchain.cpp | `(index)` | `{}` | `bd157738fbdb` |

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -331,6 +331,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblocksbatch"         , 2 },
     { "getblockhash"           , 0 },
     { "setmocktime"            , 0 },
+    { "disconnectnode"         , 1 },
     { "setban"                 , 2 },
     { "setban"                 , 3 },
     { "showblock"              , 0 },

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -306,6 +306,53 @@ static const RPCHelpMan setban_help{
 };
 const RPCHelpMan& setban_helpman() { return setban_help; }
 
+static const RPCHelpMan disconnectnode_help{
+    "disconnectnode",
+    "Immediately disconnects from the specified peer node.\n"
+    "Strictly one out of 'address' and 'nodeid' can be provided to identify the node.",
+    {
+        {"address", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+            "The IP address/port of the node, as shown in getpeerinfo's \"addr\" field. "
+            "Pass \"\" to select the node by nodeid instead."},
+        {"nodeid", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+            "The node ID (see getpeerinfo for node IDs)."},
+    },
+    RPCResult{RPCResult::Type::NONE, "", ""},
+    RPCExamples{
+        HelpExampleCli("disconnectnode", "\"192.168.0.6:32749\"") +
+        HelpExampleCli("disconnectnode", "\"\" 1") +
+        HelpExampleRpc("disconnectnode", "\"192.168.0.6:32749\"") +
+        HelpExampleRpc("disconnectnode", "\"\", 1")},
+};
+const RPCHelpMan& disconnectnode_helpman() { return disconnectnode_help; }
+
+UniValue disconnectnode(const UniValue& params)
+{
+    if (!g_connman) {
+        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+    }
+
+    const UniValue& address_arg = params[0];
+    const UniValue& id_arg = params[1];
+    const bool have_address = !address_arg.isNull() && !address_arg.get_str().empty();
+    const bool have_id = !id_arg.isNull();
+
+    bool success = false;
+    if (have_address && !have_id) {
+        success = g_connman->DisconnectNode(address_arg.get_str());
+    } else if (!have_address && have_id) {
+        success = g_connman->DisconnectNode(static_cast<NodeId>(id_arg.get_int64()));
+    } else {
+        throw JSONRPCError(RPC_INVALID_PARAMS, "Only one of address and nodeid should be provided.");
+    }
+
+    if (!success) {
+        throw JSONRPCError(RPC_CLIENT_NODE_NOT_CONNECTED, "Node not found in connected nodes");
+    }
+
+    return NullUniValue;
+}
+
 UniValue setban(const UniValue& params)
 {
     const std::string strCommand = params[1].get_str();

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -334,13 +334,15 @@ UniValue disconnectnode(const UniValue& params)
 
     const UniValue& address_arg = params[0];
     const UniValue& id_arg = params[1];
-    const bool have_address = !address_arg.isNull() && !address_arg.get_str().empty();
-    const bool have_id = !id_arg.isNull();
-
     bool success = false;
-    if (have_address && !have_id) {
+    // Branch conditions copied from upstream verbatim so the error surface
+    // stays backport-safe: a non-null address with no id takes the address
+    // branch even when empty (DisconnectNode("") finds nothing and reports
+    // not-connected), and an empty address with an id is the positional-CLI
+    // spelling of disconnect-by-id.
+    if (!address_arg.isNull() && id_arg.isNull()) {
         success = g_connman->DisconnectNode(address_arg.get_str());
-    } else if (!have_address && have_id) {
+    } else if (!id_arg.isNull() && (address_arg.isNull() || address_arg.get_str().empty())) {
         success = g_connman->DisconnectNode(static_cast<NodeId>(id_arg.get_int64()));
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMS, "Only one of address and nodeid should be provided.");

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -309,7 +309,8 @@ const RPCHelpMan& setban_helpman() { return setban_help; }
 static const RPCHelpMan disconnectnode_help{
     "disconnectnode",
     "Immediately disconnects from the specified peer node.\n"
-    "Strictly one out of 'address' and 'nodeid' can be provided to identify the node.",
+    "Strictly one out of 'address' and 'nodeid' can be provided to identify the node.\n"
+    "To disconnect by nodeid, set 'address' to the empty string.",
     {
         {"address", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
             "The IP address/port of the node, as shown in getpeerinfo's \"addr\" field. "

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -615,6 +615,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getblockchaininfo",       &getblockchaininfo,       cat_network, &getblockchaininfo_helpman, heritage_mixed, "1d89fd23ddb0" },
     { "getnetworkinfo",          &getnetworkinfo,          cat_network, &getnetworkinfo_helpman, heritage_mixed, "54255a461949" },
     { "clearbanned",             &clearbanned,             cat_network, &clearbanned_helpman, heritage_pure_upstream, "e169db2f48c0" },
+    { "disconnectnode",          &disconnectnode,          cat_network, &disconnectnode_helpman, heritage_pure_upstream, "b194f6d2d2e2" },
     { "currenttime",             &currenttime,             cat_network, &currenttime_helpman, heritage_pure_gridcoin, "" },
     { "getaddednodeinfo",        &getaddednodeinfo,        cat_network, &getaddednodeinfo_helpman, heritage_mixed, "3825ee523156" },
     { "getnodeaddresses",        &getnodeaddresses,        cat_network, &getnodeaddresses_helpman, heritage_mixed, "c696e3da4da2" },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -381,6 +381,7 @@ extern UniValue ping(const UniValue& params);
 extern UniValue rpc_exportstats(const UniValue& params);
 extern UniValue rpc_getrecentblocks(const UniValue& params);
 extern UniValue setban(const UniValue& params);
+extern UniValue disconnectnode(const UniValue& params);
 extern UniValue showblock(const UniValue& params);
 
 // Voting
@@ -591,6 +592,7 @@ extern const RPCHelpMan& sendscraperfilemanifest_helpman();
 extern const RPCHelpMan& sendtoaddress_helpman();
 extern const RPCHelpMan& setaccount_helpman();
 extern const RPCHelpMan& setban_helpman();
+extern const RPCHelpMan& disconnectnode_helpman();
 extern const RPCHelpMan& sethdseed_helpman();
 extern const RPCHelpMan& setlabel_helpman();
 extern const RPCHelpMan& settxfee_helpman();

--- a/test/functional/feature_reorg.py
+++ b/test/functional/feature_reorg.py
@@ -10,13 +10,14 @@ independently-staked block-1s can draw the same coinstake kernel; when the
 proof-of-stake hashes collide (~13% of runs) the duplicate-proof-of-stake guard
 makes each node reject the other's block and the shorter node never reorganizes.
 It cannot be made deterministic from Python without a setmocktime RPC,
-invalidateblock, or disconnectnode (none currently exposed). See the note in
-test_runner.py's EXTENDED_SCRIPTS. The logic below is the best-effort reference
-implementation for when one of those primitives lands.
+invalidateblock, or disconnectnode. setmocktime and disconnectnode now exist;
+invalidateblock does not. See the note in test_runner.py's EXTENDED_SCRIPTS.
+The logic below is the best-effort reference implementation, written before
+those primitives landed and not yet rewritten to use them.
 
-Investor-mode only (no beacon/CPID). Gridcoin's RPC surface has no
-disconnectnode, so instead of split-then-reconnect we build divergent chains on
-two nodes that start ISOLATED, then connect them and assert the node on the
+Investor-mode only (no beacon/CPID). This predates disconnectnode, so instead
+of split-then-reconnect it builds divergent chains on two nodes that start
+ISOLATED, then connect them and assert the node on the
 shorter/lower-trust chain reorganizes onto the longer one.
 
 Two things make the reorg propagate reliably (relying on connect-time header sync

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -49,7 +49,10 @@ class RpcNetTest(GridcoinTestFramework):
         sleeping. Blocks staked on the unmocked node carry real timestamps,
         which are in this node's past and accepted as such.
         """
-        self.mock_time += 6
+        # Derive from the call-time clock, never only the run_test baseline:
+        # the rate-limit entry is stamped at accept time with real time, and a
+        # slow (sanitizer/valgrind) run can eat a start-time-anchored margin.
+        self.mock_time = max(self.mock_time, int(time.time())) + 6
         node.setmocktime(self.mock_time)
 
     def run_test(self):
@@ -77,10 +80,10 @@ class RpcNetTest(GridcoinTestFramework):
 
         # --- disconnectnode: argument validation, none of which touches the link ---
         both = "Only one of address and nodeid should be provided."
-        assert_raises_rpc_error(-32602, both, node0.disconnectnode)
-        assert_raises_rpc_error(-32602, both, node0.disconnectnode, "")
-        assert_raises_rpc_error(-32602, both, node0.disconnectnode, "127.0.0.1:1", 0)
         not_found = "Node not found in connected nodes"
+        assert_raises_rpc_error(-32602, both, node0.disconnectnode)
+        assert_raises_rpc_error(-29, not_found, node0.disconnectnode, "")
+        assert_raises_rpc_error(-32602, both, node0.disconnectnode, "127.0.0.1:1", 0)
         assert_raises_rpc_error(-29, not_found, node0.disconnectnode, "", 999999)
         assert_raises_rpc_error(-29, not_found, node0.disconnectnode, "127.0.0.1:1")
         # Control: every reject above left the link alone.

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -7,11 +7,20 @@
 Investor-mode only. Two nodes are started unconnected (regtest has no
 auto-peering), then linked via the framework's connect_nodes (addnode under the
 hood). Exercises getconnectioncount / getpeerinfo and verifies a block mined on
-node0 propagates to node1 over the daemon-to-daemon link.
+node0 propagates to node1 over the daemon-to-daemon link. Then exercises
+disconnectnode: argument validation, disconnect by address and by nodeid, that
+a block mined while split does not cross, and that the link can be re-made.
 """
 
+import time
+
 from test_framework.test_framework import GridcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+    p2p_port,
+)
 
 
 class RpcNetTest(GridcoinTestFramework):
@@ -28,8 +37,24 @@ class RpcNetTest(GridcoinTestFramework):
         self.add_nodes(self.num_nodes, self.extra_args)
         self.start_nodes()
 
+    def open_inbound_window(self, node):
+        """Move node's clock past the inbound rate limit before re-dialing it.
+
+        The daemon accepts at most one inbound connection per 5 s from a given
+        IP and scores a faster retry as misbehaviour (net.cpp, the accept loop
+        in ThreadSocketHandler), so dialing a node straight after disconnecting
+        from it is silently dropped, and retrying walks the dialer toward a ban.
+        Every node here is 127.0.0.1. The limit reads GetAdjustedTime, which
+        setmocktime pins, so the accepting side is moved 6 s forward instead of
+        sleeping. Blocks staked on the unmocked node carry real timestamps,
+        which are in this node's past and accepted as such.
+        """
+        self.mock_time += 6
+        node.setmocktime(self.mock_time)
+
     def run_test(self):
         node0, node1 = self.nodes
+        self.mock_time = int(time.time())
 
         # --- start unconnected ---
         assert_equal(node0.getconnectioncount(), 0)
@@ -49,6 +74,60 @@ class RpcNetTest(GridcoinTestFramework):
         assert_equal(node1.getbestblockhash(), node0.getbestblockhash())
         assert_equal(node1.getblockcount(), 2)
         self.log.info("block propagation over P2P link OK; tips synced at height 2")
+
+        # --- disconnectnode: argument validation, none of which touches the link ---
+        both = "Only one of address and nodeid should be provided."
+        assert_raises_rpc_error(-32602, both, node0.disconnectnode)
+        assert_raises_rpc_error(-32602, both, node0.disconnectnode, "")
+        assert_raises_rpc_error(-32602, both, node0.disconnectnode, "127.0.0.1:1", 0)
+        not_found = "Node not found in connected nodes"
+        assert_raises_rpc_error(-29, not_found, node0.disconnectnode, "", 999999)
+        assert_raises_rpc_error(-29, not_found, node0.disconnectnode, "127.0.0.1:1")
+        # Control: every reject above left the link alone.
+        assert_greater_than(node0.getconnectioncount(), 0)
+        assert_greater_than(node1.getconnectioncount(), 0)
+        self.log.info("disconnectnode rejects malformed and unknown targets")
+
+        # --- disconnect by address, from the side that dialed ---
+        # connect_nodes(0, 1) had node0 dial node1, so node0 lists the peer
+        # under the exact address it dialed.
+        target = "127.0.0.1:%d" % p2p_port(1)
+        assert any(peer['addr'] == target for peer in node0.getpeerinfo())
+        node0.disconnectnode(target)
+        self.wait_until(lambda: node0.getconnectioncount() == 0
+                        and node1.getconnectioncount() == 0, timeout=10)
+        self.log.info("disconnectnode by address dropped the link on both sides")
+
+        # --- a block mined while split stays on the miner ---
+        node0.generatetoaddress(1, node0.getnewaddress())
+        assert_equal(node0.getblockcount(), 3)
+        assert_equal(node1.getblockcount(), 2)
+
+        # --- reconnect; the re-made link carries the block ---
+        # Connect-time header sync alone does not pull a block the peer already
+        # has (node1 answers the version exchange and never sends getblocks;
+        # feature_reorg.py records the same stall), so stake one more block on
+        # node0: the fresh announcement over the established link is what
+        # propagates, and the getblocks it triggers brings block 3 with it.
+        self.open_inbound_window(node1)
+        self.connect_nodes(0, 1)
+        node0.generatetoaddress(1, node0.getnewaddress())
+        self.sync_blocks([node0, node1])
+        assert_equal(node1.getblockcount(), 4)
+        self.log.info("re-made link synced the block mined while split")
+
+        # --- disconnect by nodeid through the framework helper, then once more
+        #     with the roles reversed so the helper is exercised from the side
+        #     that accepted the connection ---
+        self.disconnect_nodes(0, 1)
+        assert_equal(node0.getconnectioncount(), 0)
+        assert_equal(node1.getconnectioncount(), 0)
+        # node0 has never accepted an inbound connection, so no window to open.
+        self.connect_nodes(1, 0)
+        self.disconnect_nodes(0, 1)
+        assert_equal(node0.getconnectioncount(), 0)
+        assert_equal(node1.getconnectioncount(), 0)
+        self.log.info("disconnect_nodes works from either side of the link")
 
 
 if __name__ == "__main__":

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -657,6 +657,10 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         IP is dropped by the daemon's inbound rate limit (and scored as
         misbehaviour), so a test that disconnects and reconnects must move the
         accepting node's clock forward with setmocktime, or wait, in between.
+
+        Completion is detected by the captured peer ids disappearing from both
+        nodes' getpeerinfo -- not by connection counts, which unrelated churn
+        can satisfy while the link still lives.
         """
         def dialed_peer_ids(node, target_num):
             target = "127.0.0.1:" + str(p2p_port(target_num))

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -670,8 +670,6 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
             self.log.warning("disconnect_nodes: {} and {} were not connected".format(a, b))
             return
 
-        expected_a = node_a.getconnectioncount() - links
-        expected_b = node_b.getconnectioncount() - links
         for node, ids in ((node_a, ids_a), (node_b, ids_b)):
             for peer_id in ids:
                 try:
@@ -682,8 +680,16 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
                     if e.error['code'] != -29:  # RPC_CLIENT_NODE_NOT_CONNECTED
                         raise
 
-        wait_until_helper(lambda: node_a.getconnectioncount() <= expected_a
-                          and node_b.getconnectioncount() <= expected_b, timeout=5)
+        # Wait on the specific peer ids disappearing, not on connection
+        # counts: counts can hit the target through unrelated churn (another
+        # peer dropping, a new inbound arriving) while the a<->b link lives.
+        def links_gone():
+            live_a = {p['id'] for p in node_a.getpeerinfo()}
+            live_b = {p['id'] for p in node_b.getpeerinfo()}
+            return not (set(ids_a) & live_a) and not (set(ids_b) & live_b)
+
+        wait_until_helper(links_gone, timeout=5,
+                          timeout_factor=self.options.timeout_factor)
 
     def split_network(self):
         """

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -658,9 +658,10 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         misbehaviour), so a test that disconnects and reconnects must move the
         accepting node's clock forward with setmocktime, or wait, in between.
 
-        Completion is detected by the captured peer ids disappearing from both
-        nodes' getpeerinfo -- not by connection counts, which unrelated churn
-        can satisfy while the link still lives.
+        Completion is detected by the captured peer ids disappearing from the
+        dialing sides' getpeerinfo, plus each accepting side's connection
+        count dropping by the links it accepted (an accepted link cannot be
+        identified by address -- the acceptor sees an ephemeral port).
         """
         def dialed_peer_ids(node, target_num):
             target = "127.0.0.1:" + str(p2p_port(target_num))
@@ -674,6 +675,9 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
             self.log.warning("disconnect_nodes: {} and {} were not connected".format(a, b))
             return
 
+        count_a_before = node_a.getconnectioncount()
+        count_b_before = node_b.getconnectioncount()
+
         for node, ids in ((node_a, ids_a), (node_b, ids_b)):
             for peer_id in ids:
                 try:
@@ -684,13 +688,19 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
                     if e.error['code'] != -29:  # RPC_CLIENT_NODE_NOT_CONNECTED
                         raise
 
-        # Wait on the specific peer ids disappearing, not on connection
-        # counts: counts can hit the target through unrelated churn (another
-        # peer dropping, a new inbound arriving) while the a<->b link lives.
+        # Two-part completion check. The dialing side of each link is waited on
+        # by peer id -- precise, immune to unrelated churn. The ACCEPTING side
+        # of a dialed link cannot be identified by address (it sees an
+        # ephemeral source port), so that side is bounded by its connection
+        # count dropping by the number of links it accepted; id-precision
+        # where identifiable, count-bound where not.
         def links_gone():
             live_a = {p['id'] for p in node_a.getpeerinfo()}
             live_b = {p['id'] for p in node_b.getpeerinfo()}
-            return not (set(ids_a) & live_a) and not (set(ids_b) & live_b)
+            if (set(ids_a) & live_a) or (set(ids_b) & live_b):
+                return False
+            return (node_a.getconnectioncount() <= count_a_before - len(ids_b)
+                    and node_b.getconnectioncount() <= count_b_before - len(ids_a))
 
         wait_until_helper(links_gone, timeout=5,
                           timeout_factor=self.options.timeout_factor)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -639,35 +639,51 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         connect_nodes_helper(self.nodes[a], b)
 
     def disconnect_nodes(self, a, b):
-        def disconnect_nodes_helper(from_connection, node_num):
-            def get_peer_ids():
-                result = []
-                for peer in from_connection.getpeerinfo():
-                    if "testnode{}".format(node_num) in peer['subver']:
-                        result.append(peer['id'])
-                return result
+        """Disconnect every P2P link between nodes a and b and wait for both
+        sides to drop it.
 
-            peer_ids = get_peer_ids()
-            if not peer_ids:
-                self.log.warning("disconnect_nodes: {} and {} were not connected".format(
-                    from_connection.index,
-                    node_num,
-                ))
-                return
-            for peer_id in peer_ids:
+        Bitcoin Core's helper tags each node with -uacomment=testnode<n> and
+        picks peers out of getpeerinfo by subver; this daemon does not take
+        -uacomment, so the link is found from the address the dialing side
+        connected to instead. connect_nodes(x, y) makes x dial
+        127.0.0.1:<p2p_port(y)>, and x's getpeerinfo reports exactly that
+        string as "addr". The accepting side only sees an ephemeral port, so
+        the disconnect is issued from whichever side dialed, and completion is
+        checked by both connection counts falling by the number of links. The
+        RPC server takes positional params only, so nodeid is passed with an
+        empty address in front of it.
+
+        Re-dialing a node within 5 s of its last inbound accept from the same
+        IP is dropped by the daemon's inbound rate limit (and scored as
+        misbehaviour), so a test that disconnects and reconnects must move the
+        accepting node's clock forward with setmocktime, or wait, in between.
+        """
+        def dialed_peer_ids(node, target_num):
+            target = "127.0.0.1:" + str(p2p_port(target_num))
+            return [peer['id'] for peer in node.getpeerinfo() if peer['addr'] == target]
+
+        node_a, node_b = self.nodes[a], self.nodes[b]
+        ids_a = dialed_peer_ids(node_a, b)
+        ids_b = dialed_peer_ids(node_b, a)
+        links = len(ids_a) + len(ids_b)
+        if links == 0:
+            self.log.warning("disconnect_nodes: {} and {} were not connected".format(a, b))
+            return
+
+        expected_a = node_a.getconnectioncount() - links
+        expected_b = node_b.getconnectioncount() - links
+        for node, ids in ((node_a, ids_a), (node_b, ids_b)):
+            for peer_id in ids:
                 try:
-                    from_connection.disconnectnode(nodeid=peer_id)
+                    node.disconnectnode("", peer_id)
                 except JSONRPCException as e:
-                    # If this node is disconnected between calculating the peer id
-                    # and issuing the disconnect, don't worry about it.
-                    # This avoids a race condition if we're mass-disconnecting peers.
+                    # The peer can vanish between the getpeerinfo above and
+                    # the disconnect; that is the outcome we wanted.
                     if e.error['code'] != -29:  # RPC_CLIENT_NODE_NOT_CONNECTED
                         raise
 
-            # wait to disconnect
-            wait_until_helper(lambda: not get_peer_ids(), timeout=5)
-
-        disconnect_nodes_helper(self.nodes[a], b)
+        wait_until_helper(lambda: node_a.getconnectioncount() <= expected_a
+                          and node_b.getconnectioncount() <= expected_b, timeout=5)
 
     def split_network(self):
         """

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -137,7 +137,7 @@ BASE_SCRIPTS = [
     #   - wallet_basic.py: raw-tx + sendtoaddress spend, balance, confirmations
     #   - wallet_backup.py: backupwallet + dumpprivkey/importprivkey round-trip
     #   - mempool_accept.py: sendrawtransaction accept + double-spend rejection
-    #   - rpc_net.py: two-node getpeerinfo/addnode + block propagation
+    # rpc_net.py: two-node peer state, disconnectnode, and disconnect_nodes coverage
     #   - feature_sidestake.py: local sidestaking config + reward split
     # (feature_reorg.py is in EXTENDED_SCRIPTS — flaky on the shared-premine
     #  regtest stack; see the note there.)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -137,7 +137,7 @@ BASE_SCRIPTS = [
     #   - wallet_basic.py: raw-tx + sendtoaddress spend, balance, confirmations
     #   - wallet_backup.py: backupwallet + dumpprivkey/importprivkey round-trip
     #   - mempool_accept.py: sendrawtransaction accept + double-spend rejection
-    # rpc_net.py: two-node peer state, disconnectnode, and disconnect_nodes coverage
+    #   - rpc_net.py: two-node peer state, disconnectnode, disconnect_nodes
     #   - feature_sidestake.py: local sidestaking config + reward split
     # (feature_reorg.py is in EXTENDED_SCRIPTS — flaky on the shared-premine
     #  regtest stack; see the note there.)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -114,7 +114,9 @@ EXTENDED_SCRIPTS = [
     # It cannot be made deterministic from Python without one of: a setmocktime
     # RPC (to put the two nodes in different stake-time slots), invalidateblock
     # (to force a reorg from a single staker), or disconnectnode (to split a
-    # shared chain). Re-promote to BASE_SCRIPTS once one of those lands.
+    # shared chain). setmocktime and disconnectnode now exist; the test has not
+    # yet been rewritten around them. Re-promote to BASE_SCRIPTS once it is and
+    # repeated runs show it stable.
     'feature_reorg.py',
 ]
 


### PR DESCRIPTION
First of the two primitives `feature_reorg.py` is still waiting on. Your 2026-08-21 status on
#2932:

> **3. `feature_reorg` remains quarantined** in `EXTENDED_SCRIPTS` (flaky on the shared-premine regtest stack). Of the three primitives it was waiting on, **`setmocktime` has since landed**; `invalidateblock` and `disconnectnode` still do not exist. Those two would let it return to the default suite.

`disconnectnode` is the cheap one: all four `CConnman::DisconnectNode` overloads already exist,
so the RPC is a thin wrapper. `invalidateblock` is not: it needs a way to mark a block permanently
invalid so it is not simply reconnected, and `CBlockIndex` has no block-status field to hang that
on. That is a separate PR, and so is the `feature_reorg` rewrite itself, which needs repeated-run
evidence before it can leave `EXTENDED_SCRIPTS`. This PR does not touch the quarantine.

### The RPC

Upstream's surface: `disconnectnode ( "address" nodeid )`, exactly one of the two,
`RPC_INVALID_PARAMS` if both or neither, `RPC_CLIENT_NODE_NOT_CONNECTED` if nothing matches, null
on success. The branch conditions are upstream's verbatim (maintainer commit `e0212ff8f`): an
empty address alone takes the address branch and reports not-connected, and an empty address
beside a nodeid is the positional spelling of disconnect-by-id. Filed as `pure-upstream` in the
heritage ledger with the fingerprint the lint recomputed. `client.cpp` converts `nodeid` as numeric. No network gate: `reorganize`, which
force-reorganises the chain, has none.

### The framework helper was dead code

`test_framework.py` already carried Bitcoin Core's `disconnect_nodes`, and it could never have
worked against this daemon for two independent reasons:

1. It called `disconnectnode(nodeid=peer_id)` by name. This RPC server only accepts positional
   params (`server.cpp` throws "Params must be an array" for an object).
2. It found peers by the `testnode<n>` tag Core puts in `subver` via `-uacomment`. This daemon
   does not take `-uacomment`, so no peer ever matched and the helper returned after a warning.

It is rewritten to find each link from the address the dialing side connected to
(`connect_nodes(x, y)` makes `x` dial `127.0.0.1:<p2p_port(y)>`, and `x`'s `getpeerinfo` reports
exactly that string as `addr`), to pass `nodeid` positionally behind an empty address, and to
wait for both connection counts to fall by the number of links rather than for a subver match.

### Test

`rpc_net.py`, after its existing propagation check:

- argument validation for none, empty address only, both, unknown nodeid and unknown address,
  with a control after them that the link survived every reject;
- disconnect by address from the dialing side, waited to zero on both sides;
- a block mined while split stays at height 3 on node0 and 2 on node1;
- reconnect, stake one more block, and `sync_blocks` to height 4 on both, so the re-made link is
  shown to carry both the block mined while split and the new one;
- `disconnect_nodes` by nodeid, then again with the dial direction reversed, so the helper is
  exercised from the accepting side too.

The `wait_until` on both connection counts reaching zero is the check that discriminates: with
the disconnect a no-op, it times out before the split-height assertion is ever reached.

Two things the first runs of this test hit, both pre-existing daemon behaviour. The second is now
written down where the next test author will find it; the first already was, on
`add_p2p_connection_spaced`:

1. **Re-dialing a node within 5 s is dropped.** The accept loop in `ThreadSocketHandler` allows
   one inbound connection per 5 s per IP and scores a faster retry as misbehaviour, so
   `connect_nodes` straight after a disconnect connects at the socket level and is reset before
   the version exchange, then times out. The test moves the accepting node's clock past the
   window with `setmocktime` (`open_inbound_window`, which since `e0212ff8f` derives the
   window from the call-time clock rather than the run_test baseline) rather than sleeping; the `disconnect_nodes`
   docstring says why a split-and-reconnect test needs this.
2. **Connect-time sync does not pull a block the peer already has.** After the reconnect node1
   completes the version exchange at `blocks=2` against node0's `blocks=3` and never sends
   `getblocks`. The gate is a process-wide one-shot: `net_processing.cpp` asks for blocks from
   at most one peer per process (`static int nAskedForBlocks`), so no later connection re-asks at
   any height. `feature_reorg.py` already records this stall as intermittent, and its recipe:
   stake a fresh block over the established link, whose announcement triggers the `getblocks`
   that brings the older block along. The one-shot makes the stall deterministic; the test uses
   the same recipe and asserts height 4.

**Testing.** Unit suite and the full functional suite pass locally. The heritage lint passes
with the new row.

https://claude.ai/code/session_01GtjiCGE4qYMeyrMgjt3QQc
