### PR TITLE
wallet: keep an evicted own transaction rebroadcastable through the import-time re-accept

### DIFF
--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -9,6 +9,8 @@
 #include "key_io.h"
 #include "rpc/protocol.h"
 #include "rpc/server.h"
+#include "txdb.h"
+#include "txmempool.h"
 
 #include <algorithm>
 
@@ -2013,6 +2015,104 @@ BOOST_AUTO_TEST_CASE(mempool_removal_expiry_preserves_mempool_state)
         // EXPIRY: no state change (just logs)
         // State should remain InMempool — ReacceptWalletTransactions will handle it
         BOOST_CHECK(test_wallet.mapWallet[hash].isInMempool());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(reaccept_keeps_own_unconfirmed_tx_rebroadcastable)
+{
+    // ReacceptWalletTransactions() runs during init before the persisted
+    // unbroadcast set is reloaded (AppInit2 order), so the mempool is empty
+    // when it inspects the wallet. An own transaction that is unconfirmed and
+    // not in the mempool is exactly the state ResendWalletTransactions()
+    // handles (depth -1). If re-accept declares it conflicted on the strength
+    // of that empty mempool, RelayWalletTransaction() refuses it from then on
+    // and nothing ever rebroadcasts it. Uses the fixture's file-backed wallet
+    // because re-accept writes any state change back through CWalletDB.
+    CKey key;
+    key.MakeNewKey(true);
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE(pwalletMain->AddKey(key));
+    }
+
+    CMutableTransaction mtx;
+    mtx.vout.resize(1);
+    mtx.vout[0].nValue = 1 * COIN;
+    mtx.vout[0].scriptPubKey = CScript() << key.GetPubKey() << OP_CHECKSIG;
+    CTransaction tx(mtx);
+    const uint256 hash = tx.GetHash();
+
+    {
+        LOCK(pwalletMain->cs_wallet);
+        CWalletTx wtx(pwalletMain, tx);
+        wtx.SetTxState(TxStateInMempool{});
+        wtx.fFromMe = true;
+        pwalletMain->mapWallet[hash] = wtx;
+    }
+    BOOST_REQUIRE(!mempool.exists(hash));
+
+    pwalletMain->ReacceptWalletTransactions();
+
+    {
+        LOCK(pwalletMain->cs_wallet);
+        const CWalletTx& wtx = pwalletMain->mapWallet[hash];
+        BOOST_CHECK_MESSAGE(!wtx.isInactive(),
+            "re-accept marked an own unconfirmed tx conflicted against an empty mempool");
+        BOOST_CHECK(wtx.isInMempool());
+        pwalletMain->mapWallet.erase(hash);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(reaccept_marks_own_unconfirmed_tx_conflicted_when_input_spent_in_chain)
+{
+    // Control for the case above: absence from the mempool is not a conflict,
+    // but an input that the tx index records as spent by another confirmed
+    // transaction is, and re-accept must still mark that inactive.
+    CKey key;
+    key.MakeNewKey(true);
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE(pwalletMain->AddKey(key));
+    }
+
+    // A fabricated confirmed parent whose only output is already spent by
+    // someone else (a non-null vSpent slot); the wtx below spends it too.
+    const uint256 parent_hash = uint256S("41000000000000000000000000000000000000000000000000000000000000c1");
+    {
+        CTxIndex parent_index(CDiskTxPos(1, 1, 1), 1);
+        parent_index.vSpent[0] = CDiskTxPos(2, 2, 2);
+        CTxDB txdb("r+");
+        BOOST_REQUIRE(txdb.TxnBegin());
+        BOOST_REQUIRE(txdb.UpdateTxIndex(parent_hash, parent_index));
+        BOOST_REQUIRE(txdb.TxnCommit());
+    }
+
+    CMutableTransaction mtx;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(parent_hash, 0);
+    mtx.vout.resize(1);
+    mtx.vout[0].nValue = 1 * COIN;
+    mtx.vout[0].scriptPubKey = CScript() << key.GetPubKey() << OP_CHECKSIG;
+    CTransaction tx(mtx);
+    const uint256 hash = tx.GetHash();
+
+    {
+        LOCK(pwalletMain->cs_wallet);
+        CWalletTx wtx(pwalletMain, tx);
+        wtx.SetTxState(TxStateInMempool{});
+        wtx.fFromMe = true;
+        pwalletMain->mapWallet[hash] = wtx;
+    }
+    BOOST_REQUIRE(!mempool.exists(hash));
+
+    pwalletMain->ReacceptWalletTransactions();
+
+    {
+        LOCK(pwalletMain->cs_wallet);
+        const CWalletTx& wtx = pwalletMain->mapWallet[hash];
+        BOOST_CHECK(wtx.isInactive());
+        BOOST_CHECK(!pwalletMain->IsAbandoned(hash));
+        pwalletMain->mapWallet.erase(hash);
     }
 }
 

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -2020,14 +2020,17 @@ BOOST_AUTO_TEST_CASE(mempool_removal_expiry_preserves_mempool_state)
 
 BOOST_AUTO_TEST_CASE(reaccept_keeps_own_unconfirmed_tx_rebroadcastable)
 {
-    // ReacceptWalletTransactions() runs during init before the persisted
-    // unbroadcast set is reloaded (AppInit2 order), so the mempool is empty
-    // when it inspects the wallet. An own transaction that is unconfirmed and
-    // not in the mempool is exactly the state ResendWalletTransactions()
-    // handles (depth -1). If re-accept declares it conflicted on the strength
-    // of that empty mempool, RelayWalletTransaction() refuses it from then on
-    // and nothing ever rebroadcasts it. Uses the fixture's file-backed wallet
-    // because re-accept writes any state change back through CWalletDB.
+    // An own transaction still tagged in-mempool but absent from the pool is
+    // what an EXPIRY or SIZELIMIT eviction leaves behind (both keep the tag),
+    // and the import/rescan RPCs run ReacceptWalletTransactions() afterwards.
+    // Unconfirmed and not in the mempool is exactly the state
+    // ResendWalletTransactions() handles (depth -1). If re-accept declares it
+    // conflicted on the strength of the empty pool, RelayWalletTransaction()
+    // refuses it from then on and nothing ever rebroadcasts it. The input's
+    // parent is indexed with its output unspent, so the chain-spent guard
+    // evaluates a real slot rather than passing on an empty vin. Uses the
+    // global TestingSetup wallet because re-accept writes any state change
+    // back through CWalletDB.
     CKey key;
     key.MakeNewKey(true);
     {
@@ -2035,7 +2038,24 @@ BOOST_AUTO_TEST_CASE(reaccept_keeps_own_unconfirmed_tx_rebroadcastable)
         BOOST_REQUIRE(pwalletMain->AddKey(key));
     }
 
+    // A fabricated confirmed parent whose only output nobody has spent (a
+    // null vSpent slot); the wtx below spends it.
+    CMutableTransaction parent_mtx;
+    parent_mtx.vout.resize(1);
+    parent_mtx.vout[0].nValue = 2 * COIN;
+    parent_mtx.vout[0].scriptPubKey = CScript() << key.GetPubKey() << OP_CHECKSIG;
+    const CTransaction parent(parent_mtx);
+    {
+        CTxIndex parent_index(CDiskTxPos(1, 1, 1), 1);
+        CTxDB txdb("r+");
+        BOOST_REQUIRE(txdb.TxnBegin());
+        BOOST_REQUIRE(txdb.UpdateTxIndex(parent.GetHash(), parent_index));
+        BOOST_REQUIRE(txdb.TxnCommit());
+    }
+
     CMutableTransaction mtx;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(parent.GetHash(), 0);
     mtx.vout.resize(1);
     mtx.vout[0].nValue = 1 * COIN;
     mtx.vout[0].scriptPubKey = CScript() << key.GetPubKey() << OP_CHECKSIG;
@@ -2061,6 +2081,12 @@ BOOST_AUTO_TEST_CASE(reaccept_keeps_own_unconfirmed_tx_rebroadcastable)
         BOOST_CHECK(wtx.isInMempool());
         pwalletMain->mapWallet.erase(hash);
     }
+    {
+        CTxDB txdb("r+");
+        BOOST_REQUIRE(txdb.TxnBegin());
+        BOOST_REQUIRE(txdb.EraseTxIndex(parent));
+        BOOST_REQUIRE(txdb.TxnCommit());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(reaccept_marks_own_unconfirmed_tx_conflicted_when_input_spent_in_chain)
@@ -2077,19 +2103,23 @@ BOOST_AUTO_TEST_CASE(reaccept_marks_own_unconfirmed_tx_conflicted_when_input_spe
 
     // A fabricated confirmed parent whose only output is already spent by
     // someone else (a non-null vSpent slot); the wtx below spends it too.
-    const uint256 parent_hash = uint256S("41000000000000000000000000000000000000000000000000000000000000c1");
+    CMutableTransaction parent_mtx;
+    parent_mtx.vout.resize(1);
+    parent_mtx.vout[0].nValue = 3 * COIN;
+    parent_mtx.vout[0].scriptPubKey = CScript() << key.GetPubKey() << OP_CHECKSIG;
+    const CTransaction parent(parent_mtx);
     {
         CTxIndex parent_index(CDiskTxPos(1, 1, 1), 1);
         parent_index.vSpent[0] = CDiskTxPos(2, 2, 2);
         CTxDB txdb("r+");
         BOOST_REQUIRE(txdb.TxnBegin());
-        BOOST_REQUIRE(txdb.UpdateTxIndex(parent_hash, parent_index));
+        BOOST_REQUIRE(txdb.UpdateTxIndex(parent.GetHash(), parent_index));
         BOOST_REQUIRE(txdb.TxnCommit());
     }
 
     CMutableTransaction mtx;
     mtx.vin.resize(1);
-    mtx.vin[0].prevout = COutPoint(parent_hash, 0);
+    mtx.vin[0].prevout = COutPoint(parent.GetHash(), 0);
     mtx.vout.resize(1);
     mtx.vout[0].nValue = 1 * COIN;
     mtx.vout[0].scriptPubKey = CScript() << key.GetPubKey() << OP_CHECKSIG;
@@ -2113,6 +2143,12 @@ BOOST_AUTO_TEST_CASE(reaccept_marks_own_unconfirmed_tx_conflicted_when_input_spe
         BOOST_CHECK(wtx.isInactive());
         BOOST_CHECK(!pwalletMain->IsAbandoned(hash));
         pwalletMain->mapWallet.erase(hash);
+    }
+    {
+        CTxDB txdb("r+");
+        BOOST_REQUIRE(txdb.TxnBegin());
+        BOOST_REQUIRE(txdb.EraseTxIndex(parent));
+        BOOST_REQUIRE(txdb.TxnCommit());
     }
 }
 

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -2079,8 +2079,11 @@ BOOST_AUTO_TEST_CASE(reaccept_keeps_own_unconfirmed_tx_rebroadcastable)
         BOOST_CHECK_MESSAGE(!wtx.isInactive(),
             "re-accept marked an own unconfirmed tx conflicted against an empty mempool");
         BOOST_CHECK(wtx.isInMempool());
-        pwalletMain->mapWallet.erase(hash);
     }
+    // Drop the entry from mapWallet and from the wallet DB in one call:
+    // re-accept writes a state change through CWalletDB, so erasing the map
+    // alone would leave the record on disk for whatever loads it next.
+    BOOST_REQUIRE(pwalletMain->EraseFromWallet(hash));
     {
         CTxDB txdb("r+");
         BOOST_REQUIRE(txdb.TxnBegin());
@@ -2142,8 +2145,11 @@ BOOST_AUTO_TEST_CASE(reaccept_marks_own_unconfirmed_tx_conflicted_when_input_spe
         const CWalletTx& wtx = pwalletMain->mapWallet[hash];
         BOOST_CHECK(wtx.isInactive());
         BOOST_CHECK(!pwalletMain->IsAbandoned(hash));
-        pwalletMain->mapWallet.erase(hash);
     }
+    // Drop the entry from mapWallet and from the wallet DB in one call:
+    // re-accept writes a state change through CWalletDB, so erasing the map
+    // alone would leave the record on disk for whatever loads it next.
+    BOOST_REQUIRE(pwalletMain->EraseFromWallet(hash));
     {
         CTxDB txdb("r+");
         BOOST_REQUIRE(txdb.TxnBegin());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2337,9 +2337,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
         }
         // entry_time is non-zero only when reloading from unbroadcast.dat: preserve
         // the original pool-entry time so tx age and eviction ordering survive a
-        // restart. In practice this only affects the node's non-wallet reloaded txs;
-        // a wallet tx is re-pooled with a fresh time by ReacceptWalletTransactions
-        // before LoadUnbroadcast runs, so its persisted time is not applied.
+        // restart. This applies to the wallet's own transactions too:
+        // ReacceptWalletTransactions runs before LoadUnbroadcast but does not
+        // re-pool anything (it only reconciles wallet state), so the reload is
+        // what puts them back, with their persisted time.
         CTxMemPoolEntry entry(tx, nFees, entry_time != 0 ? entry_time : GetAdjustedTime(),
                               nBestHeight, nSize);
         pool.addUnchecked(hash, entry);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2337,10 +2337,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
         }
         // entry_time is non-zero only when reloading from unbroadcast.dat: preserve
         // the original pool-entry time so tx age and eviction ordering survive a
-        // restart. This applies to the wallet's own transactions too:
-        // ReacceptWalletTransactions runs before LoadUnbroadcast but does not
-        // re-pool anything (it only reconciles wallet state), so the reload is
-        // what puts them back, with their persisted time.
+        // restart. In practice this only affects the node's non-wallet reloaded txs;
+        // a wallet tx is re-pooled with a fresh time by ReacceptWalletTransactions
+        // before LoadUnbroadcast runs, so its persisted time is not applied.
         CTxMemPoolEntry entry(tx, nFees, entry_time != 0 ? entry_time : GetAdjustedTime(),
                               nBestHeight, nSize);
         pool.addUnchecked(hash, entry);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -295,14 +295,18 @@ std::pair<bool, bool> ValidateMempoolTx(CWalletTx& wtx, const CTxIndex& txindex,
     }
 
     if (!fTxIndexFound) {
-        // Not in the mempool and not in the chain is depth -1, the state
-        // ResendWalletTransactions() exists to rebroadcast. It is also what
-        // every own unconfirmed transaction looks like at this point of
-        // startup: AppInit2 runs this pass before the persisted unbroadcast
-        // set is reloaded, so an empty mempool proves nothing. Only an input
-        // that another confirmed transaction has already spent makes it
-        // conflicted; RelayWalletTransaction() refuses inactive transactions,
-        // so marking it inactive here would end its rebroadcast for good.
+        // Reached for a transaction still tagged in-mempool that the pool no
+        // longer holds: an EXPIRY or SIZELIMIT eviction keeps the tag, and the
+        // import/rescan RPCs (importprivkey, importwallet, restoreseedphrase)
+        // run this pass afterwards. A restarted wallet's own transactions do
+        // not come here: the in-mempool tag does not survive the wallet.dat
+        // round trip, so they reload as unrecognized and take
+        // ResolveUnrecognizedTx instead. Not in the mempool and not in the
+        // chain is depth -1, the state ResendWalletTransactions() exists to
+        // rebroadcast. Only an input that another confirmed transaction has
+        // already spent makes it conflicted; RelayWalletTransaction() refuses
+        // inactive transactions, so marking it inactive here would end its
+        // rebroadcast for good.
         if (HasChainSpentInput(wtx, txdb)) {
             LogPrint(BCLog::LogFlags::VERBOSE,
                     "ReacceptWalletTransactions: tx %s not in mempool or chain and an input is "

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -263,9 +263,25 @@ std::pair<bool, bool> ValidateConfirmedTx(CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIR
     return {false, false};
 }
 
+//! True when one of wtx's inputs is recorded in the tx index as already spent.
+//! The caller has established that wtx itself is not in the index, so the
+//! spender is a different, chain-confirmed transaction: wtx is genuinely
+//! conflicted, not merely absent from the mempool.
+bool HasChainSpentInput(const CWalletTx& wtx, CTxDB& txdb)
+{
+    for (const CTxIn& txin : wtx.vin) {
+        CTxIndex prev;
+        if (!txdb.ReadTxIndex(txin.prevout.hash, prev)) continue;
+        if (txin.prevout.n < prev.vSpent.size() && !prev.vSpent[txin.prevout.n].IsNull()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 //! Validate a mempool tx: verify still in mempool, try to confirm from index if not.
 //! Returns {updated, repeat}.
-std::pair<bool, bool> ValidateMempoolTx(CWalletTx& wtx, const CTxIndex& txindex, bool fTxIndexFound) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+std::pair<bool, bool> ValidateMempoolTx(CWalletTx& wtx, const CTxIndex& txindex, bool fTxIndexFound, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (mempool.exists(wtx.GetHash()))
         return {false, false}; // Still in mempool, nothing to do
@@ -279,11 +295,27 @@ std::pair<bool, bool> ValidateMempoolTx(CWalletTx& wtx, const CTxIndex& txindex,
     }
 
     if (!fTxIndexFound) {
+        // Not in the mempool and not in the chain is depth -1, the state
+        // ResendWalletTransactions() exists to rebroadcast. It is also what
+        // every own unconfirmed transaction looks like at this point of
+        // startup: AppInit2 runs this pass before the persisted unbroadcast
+        // set is reloaded, so an empty mempool proves nothing. Only an input
+        // that another confirmed transaction has already spent makes it
+        // conflicted; RelayWalletTransaction() refuses inactive transactions,
+        // so marking it inactive here would end its rebroadcast for good.
+        if (HasChainSpentInput(wtx, txdb)) {
+            LogPrint(BCLog::LogFlags::VERBOSE,
+                    "ReacceptWalletTransactions: tx %s not in mempool or chain and an input is "
+                    "spent by a confirmed transaction, marking inactive\n",
+                    wtx.GetHash().ToString());
+            wtx.SetTxState(TxStateInactive{false});
+            return {true, false};
+        }
         LogPrint(BCLog::LogFlags::VERBOSE,
-                "ReacceptWalletTransactions: tx %s not in mempool or chain, marking inactive\n",
+                "ReacceptWalletTransactions: tx %s not in mempool or chain, left unconfirmed "
+                "for rebroadcast\n",
                 wtx.GetHash().ToString());
-        wtx.SetTxState(TxStateInactive{false});
-        return {true, false};
+        return {false, false};
     }
 
     return {false, false};
@@ -2440,7 +2472,7 @@ void CWallet::ReacceptWalletTransactions()
                 fRepeat |= repeat;
             }
             else if (wtx.isInMempool()) {
-                auto [updated, repeat] = ValidateMempoolTx(wtx, txindex, fTxIndexFound);
+                auto [updated, repeat] = ValidateMempoolTx(wtx, txindex, fTxIndexFound, txdb);
                 fUpdated |= updated;
                 fRepeat |= repeat;
             }


### PR DESCRIPTION
**Re-scoped 2026-09-04 after review.** The first version of this body claimed the fix reached the
startup re-accept. It does not, as the review showed empirically: an own transaction tagged
in-mempool does not survive the `wallet.dat` round trip (the tag serializes as the null block-hash
sentinel and reloads as `TxStateUnrecognized`), so every restarted own unconfirmed transaction
takes `ResolveUnrecognizedTx`, which this PR leaves alone. The startup half is now an explicit
follow-up, below. What the change does fix is the runtime re-accept, and the title, this body, the
in-diff comment and the tests now say only that.

Found while trying to write the wallet-rebroadcast functional test deferred on #3112, which
needed a wallet transaction that is unconfirmed and not in the mempool.

### The defect

`ReacceptWalletTransactions()` runs at startup and again from the import/rescan RPCs
(`importprivkey`, `importwallet`, `restoreseedphrase`). For an entry still tagged
`TxStateInMempool`, `ValidateMempoolTx` checks the mempool and then the tx index, and on finding
the transaction in neither it set `TxStateInactive{false}`.

An entry can be in exactly that state legitimately: an `EXPIRY` or `SIZELIMIT` eviction keeps the
in-mempool tag on purpose (the wallet's `TransactionRemovedFromMempool` arm leaves it for
rebroadcast), so after the pool evicts an own transaction, the next import or rescan branded it
conflicted. That is not a display change: `gettransaction` already reports depth -1 for an
evicted transaction, and the GUI already renders depth -1 as *Conflicted*, before and after this
PR. What changed hands is the rebroadcast. `RelayWalletTransaction` refuses inactive
transactions, so `ResendWalletTransactions`, whose whole job is the unconfirmed-and-not-in-mempool
case, never announced it again; and `TxStateInactive{false}` is written to disk as the
`CONFLICTED` sentinel, so the branding survived every later restart. A valid evicted transaction
was conflicted for good.

### The fix

Unconfirmed and not in the mempool is depth -1, the exact state `ResendWalletTransactions` exists
for, so the entry is left in `TxStateInMempool`. It is marked inactive only when it really is
conflicted: when another confirmed transaction has already spent one of its inputs. The tx index
answers that, so `HasChainSpentInput` reads each input's `CTxIndex` and looks for a non-null
`vSpent` slot. One `ReadTxIndex` per input, for each wallet entry still tagged in-mempool but in
neither the mempool nor the index, per re-accept pass.

One consequence to endorse deliberately: `AbandonTransaction` gates on the state tag, so an
evicted transaction that the old code had flipped to inactive could be abandoned, and one this
code leaves in-mempool cannot be, until it confirms, conflicts, or is re-evicted after a
rebroadcast. That gate wanting to become a real mempool-membership check is noted for the
follow-up rather than changed here.

### What this does not fix: the startup path

At startup the same transaction arrives as `TxStateUnrecognized` and goes through
`ResolveUnrecognizedTx`, whose last-resort branch marks it inactive (writing the `CONFLICTED`
sentinel) and then calls `AcceptWalletTransaction` to try to re-pool it. The review's probe test
serialized an in-mempool transaction through the real `wallet.dat` stream, reloaded it, ran the
re-accept against an empty mempool and watched it end inactive on this head. So a restart with an
unconfirmed own transaction still shows it conflicted, and that branch wants the same
`HasChainSpentInput` gate, resolving to in-mempool when the inputs are unspent, together with the
`AbandonTransaction` gate change above. Filed as a follow-up rather than folded in here, because it
changes which path un-sticks an evicted transaction for abandonment and deserves its own review.

### Tests

Two cases in `wallet_tests`, both on the global `TestingSetup` wallet and calling
`ReacceptWalletTransactions()` for real (it writes any state change back through `CWalletDB`, so
an in-memory `CWallet` is not enough):

- `reaccept_keeps_own_unconfirmed_tx_rebroadcastable`: an own transaction tagged in-mempool,
  absent from the pool, spending an indexed parent output that nobody has spent, stays in
  `TxStateInMempool`. On the previous code it fails with "re-accept marked an own unconfirmed tx
  conflicted against an empty mempool". The parent is indexed so the chain-spent guard evaluates
  a real `vSpent` slot rather than passing on an empty `vin`.
- `reaccept_marks_own_unconfirmed_tx_conflicted_when_input_spent_in_chain`: the control. The
  same shape with the parent's `vSpent` slot set is marked inactive and not abandoned.

Both erase their wallet entries and their fabricated `CTxIndex` entries on exit. The two keys they
add stay in the shared wallet (there is no `RemoveKey`); nothing downstream counts keys.

A functional repro was written first and abandoned: the regtest wallet is rebuilt from scratch on
every daemon start (no `wallet.dat` is written), so the path cannot be reached from Python.

### The adjacent `AcceptToMemoryPool` comment is left as it was

The first version of this PR rewrote the `entry_time` comment to say re-accept "does not re-pool
anything". That was wrong for the startup path: `ResolveUnrecognizedTx` does re-pool a restarted
own transaction, with a fresh time, before `LoadUnbroadcast` runs, which is what the original
comment said. The hunk is dropped.

**Testing.** Unit suite and the full functional suite pass locally on the head.

https://claude.ai/code/session_01GtjiCGE4qYMeyrMgjt3QQc
