### PR TITLE
rpc: make importprivkey require an unlocked wallet, like the other dump/import RPCs

### DIFF
--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -6,6 +6,9 @@
 #include "init.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
+#include "key_io.h"
+#include "rpc/protocol.h"
+#include "rpc/server.h"
 
 #include <algorithm>
 
@@ -808,6 +811,77 @@ BOOST_AUTO_TEST_CASE(addcscript_is_idempotent)
     CScript fetched;
     BOOST_CHECK(pwalletMain->GetCScript(script_id, fetched));
     BOOST_CHECK(fetched == redeem_script);
+}
+
+BOOST_AUTO_TEST_CASE(importprivkey_requires_an_unlocked_wallet)
+{
+    // importprivkey works on the process-global wallet, and regtest cannot
+    // reach a locked one (the functional framework rebuilds the wallet on
+    // every start), so an encrypted, locked wallet is swapped in for this case.
+    // In-memory rather than file-backed: EncryptWallet on a file-backed wallet
+    // rewrites wallet.dat, which the mocked Berkeley DB of this binary refuses,
+    // and the RPC only touches the database when the wallet is file-backed.
+    CWallet locked;
+    struct SwapWallet {
+        CWallet* m_saved;
+        explicit SwapWallet(CWallet* replacement) : m_saved(pwalletMain) { pwalletMain = replacement; }
+        ~SwapWallet() { pwalletMain = m_saved; }
+    } swap(&locked);
+
+    // One key before encryption: Unlock() proves the passphrase by decrypting
+    // a crypted key, so an empty wallet can never be unlocked again.
+    {
+        CKey seed;
+        seed.MakeNewKey(true);
+        LOCK(locked.cs_wallet);
+        BOOST_REQUIRE(locked.AddKey(seed));
+    }
+    const SecureString passphrase("importprivkey-test");
+    BOOST_REQUIRE(locked.EncryptWallet(passphrase));
+    locked.Lock();
+    BOOST_REQUIRE(locked.IsCrypted());
+    BOOST_REQUIRE(locked.IsLocked());
+
+    CKey key;
+    key.MakeNewKey(true);
+    const CKeyID id = key.GetPubKey().GetID();
+
+    UniValue params(UniValue::VARR);
+    params.push_back(EncodeSecret(key));
+    params.push_back("");
+    params.push_back(false); // no rescan: there is no chain in this binary
+
+    auto expect_unlock_needed = [&](const char* what) {
+        try {
+            importprivkey(params);
+            BOOST_FAIL(std::string(what) + ": importprivkey did not throw on a locked wallet");
+        } catch (const UniValue& err) {
+            BOOST_CHECK_EQUAL(find_value(err, "code").get_int(), RPC_WALLET_UNLOCK_NEEDED);
+        }
+    };
+
+    // Locked: refused with the unlock code, and nothing is left behind.
+    expect_unlock_needed("first import");
+    {
+        LOCK(locked.cs_wallet);
+        BOOST_CHECK(!locked.HaveKey(id));
+        BOOST_CHECK_EQUAL(locked.mapKeyMetadata.count(id), 0u);
+    }
+
+    // Unlocked: the same call imports.
+    BOOST_REQUIRE(locked.Unlock(passphrase));
+    importprivkey(params);
+    {
+        LOCK(locked.cs_wallet);
+        BOOST_CHECK(locked.HaveKey(id));
+    }
+
+    // Locked again, re-importing a key the wallet already holds: this is the
+    // call that used to return success without consulting the lock, and the
+    // behaviour change reviewed on its own. It is refused like any other.
+    locked.Lock();
+    BOOST_REQUIRE(locked.IsLocked());
+    expect_unlock_needed("re-import of a held key");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -127,7 +127,10 @@ UniValue importprivkey(const UniValue& params)
     // Without it a locked wallet failed later inside AddKey with
     // RPC_WALLET_ERROR, after MarkDirty and a mapKeyMetadata entry had
     // already been written, and a re-import of a key the wallet already held
-    // returned success without ever consulting the lock.
+    // returned success without ever consulting the lock. The check runs with
+    // cs_wallet already held (walletlock takes the same lock before Lock()),
+    // so the lock state cannot flip between this check and AddKey below.
+    LOCK2(cs_main, pwalletMain->cs_wallet);
     EnsureWalletIsUnlocked();
 
     string strSecret = params[0].get_str();
@@ -149,8 +152,6 @@ UniValue importprivkey(const UniValue& params)
 
     CKeyID vchAddress = key.GetPubKey().GetID();
     {
-        LOCK2(cs_main, pwalletMain->cs_wallet);
-
         pwalletMain->MarkDirty();
 
         // Don't throw error in case a key is already there

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -123,6 +123,13 @@ const RPCHelpMan& importprivkey_helpman() { return importprivkey_help; }
 
 UniValue importprivkey(const UniValue& params)
 {
+    // Same enforce-first shape as importwallet, dumpprivkey and dumpwallet.
+    // Without it a locked wallet failed later inside AddKey with
+    // RPC_WALLET_ERROR, after MarkDirty and a mapKeyMetadata entry had
+    // already been written, and a re-import of a key the wallet already held
+    // returned success without ever consulting the lock.
+    EnsureWalletIsUnlocked();
+
     string strSecret = params[0].get_str();
     string strLabel = "";
     if (params.size() > 1)
@@ -139,9 +146,6 @@ UniValue importprivkey(const UniValue& params)
     {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
     }
-
-    if (fWalletUnlockStakingOnly)
-        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Wallet is unlocked for staking only.");
 
     CKeyID vchAddress = key.GetPubKey().GetID();
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -691,7 +691,9 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 
         // Need to completely rewrite the wallet file; if we don't, bdb might keep
         // bits of the unencrypted private key in slack space in the database file.
-        CDB::Rewrite(strWalletFile);
+        // An in-memory wallet has no file: rewriting an empty name would create
+        // a stray ".rewrite" in the working directory instead.
+        if (fFileBacked) CDB::Rewrite(strWalletFile);
 
     }
     NotifyStatusChanged(this);


### PR DESCRIPTION
The follow-up you asked for on #2967. Your comment on the `rpcdump.cpp` thread:

> Adding the note plus the enforcement call to `importprivkey` would be a behavior change (encrypted wallets that currently succeed at `AddKey` would start throwing RPC_WALLET_UNLOCK_NEEDED). That's out of scope for a "no behavior changes" conversion PR. If you want a follow-up that brings `importprivkey` into the same enforce-then-note shape as the other 3, suggest filing it separately so the behavior change is reviewed on its own.

This is that follow-up, as a PR so the change and its test can be reviewed together. The
behaviour change is named exactly below. It delivers the enforcement half only: the help-text
passphrase note the thread paired it with was dropped from all three `rpcdump.cpp` help texts by
the #2922 helpman lift and is not restored here.

### What happens today on an encrypted, locked wallet

`dumpprivkey` and `dumpwallet` call `EnsureWalletIsUnlocked()` as their first statement, and
`importwallet` right after opening the dump file (`dumpseedphrase` does too, after its seed
check; `dumpcontracts` handles no keys and needs none). `importprivkey` never did. It calls
`MarkDirty()`, then the already-have-key check (which does not consult the lock), then writes a
`mapKeyMetadata` entry, and only then fails inside `AddKey`, because
`CCryptoKeyStore::AddKeyPubKey` returns false when locked. The caller gets `RPC_WALLET_ERROR`
"Error adding key to wallet" instead of `RPC_WALLET_UNLOCK_NEEDED`, and the wallet keeps the
metadata entry and the dirty flag. No key is ever stored in plaintext; this is an error-code and
bookkeeping defect.

### The change

`EnsureWalletIsUnlocked()` first, like `dumpprivkey` and `dumpwallet`. The staking-only check
`importprivkey` carried is dropped, because `EnsureWalletIsUnlocked()` makes the same check with
the same code (its message gains an "Error: " prefix, matching the siblings). `dumpprivkey` still
carries the identical dead check after its own `EnsureWalletIsUnlocked()`; one line, out of scope
here.

### The behaviour change, precisely

Exactly one call that succeeds today starts throwing: **re-importing a key the wallet already
holds, on a locked wallet**. The early return `if (pwalletMain->HaveKey(vchAddress)) return
NullUniValue;` ran before anything touched the lock, so that call returned success. It is now
refused with `RPC_WALLET_UNLOCK_NEEDED` like every other locked-wallet call. Every other locked
import already failed; only its error code and side effects change.

### Test

`wallet_tests/importprivkey_requires_an_unlocked_wallet`. Regtest cannot reach a locked wallet
(the functional framework rebuilds the wallet on every daemon start, so `encryptwallet` cannot
produce one), so the case swaps an encrypted, locked in-memory wallet into `pwalletMain` for its
duration, with an RAII restore. Two things the binary forced: the wallet holds one key before
encryption, because `CCryptoKeyStore::Unlock` proves the passphrase by decrypting a crypted key
and an empty wallet can never be unlocked; and it is in-memory rather than file-backed, because
`EncryptWallet` rewrites `wallet.dat`, which the mocked Berkeley DB refuses, and the RPC only
touches the database for a file-backed wallet.

Three legs: the locked import throws the unlock code and leaves no key and no metadata entry; the
same call imports once unlocked; the re-import of the now-held key on the re-locked wallet is
refused. With the `rpcdump.cpp` change stashed, the whole `wallet_tests` suite file fails at
exactly this case, on the first and third legs.

### One more line, found by the test

`EncryptWallet` rewrote the wallet file unconditionally. For an in-memory wallet that is
`CDB::Rewrite("")`, which drops a stray `.rewrite` file in the working directory (the test found
it in the CI checkout). Gated on `fFileBacked`; no production wallet is in-memory.

**Testing.** Unit suite and the full functional suite pass locally on the head.

https://claude.ai/code/session_01GtjiCGE4qYMeyrMgjt3QQc
