### PR TITLE
test: add a regtest chain fixture, and cover the block assembly loop

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1424,6 +1424,60 @@ void ThreadAppInit2(ThreadHandlerPtr th)
 
 
 
+CKey GetRegtestPremineKey()
+{
+    // Genesis coinbase pays 10 UTXOs to the P2PKH of the secp256k1
+    // privkey-scalar=1 compressed pubkey (HASH160 751e76e8...).
+    const unsigned char kRegtestSecret[32] = {
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1
+    };
+    CKey regtest_key;
+    regtest_key.Set(kRegtestSecret, kRegtestSecret + 32, /*fCompressedIn=*/true);
+    return regtest_key;
+}
+
+void PlantRegtestPremineKey(CWallet* pwallet)
+{
+    assert(pwallet);
+
+    // Plant the private key matching the regtest genesis premine into the
+    // wallet on every -regtest start so the staker can spend it. The BDB env
+    // is mocked (in-memory) under regtest, so this re-runs each start and the
+    // key is never persisted to disk.
+    //
+    // Acquire cs_main before cs_wallet (canonical order; ScanForWalletTransactions
+    // below also takes LOCK2(cs_main, cs_wallet)). Holding both up front avoids the
+    // cs_wallet -> cs_main inversion that -DENABLE_DEBUG_LOCKORDER would flag.
+    LOCK2(cs_main, pwallet->cs_wallet);
+    const CKey regtest_key = GetRegtestPremineKey();
+    if (!regtest_key.IsValid()) {
+        LogPrintf("ERROR: regtest premine key did not validate");
+    } else if (!pwallet->HaveKey(regtest_key.GetPubKey().GetID())) {
+        if (!pwallet->AddKeyPubKey(regtest_key, regtest_key.GetPubKey())) {
+            LogPrintf("ERROR: failed to plant regtest premine key");
+        } else {
+            // Force nTimeFirstKey down to before genesis so
+            // ScanForWalletTransactions doesn't skip the genesis block
+            // via its wallet-birthday optimization (regtest genesis nTime
+            // is 1296688602; the wallet was created "now", so without
+            // this nudge the scan would skip all of history).
+            pwallet->LoadKeyMetadata(regtest_key.GetPubKey(), CKeyMetadata(1));
+
+            LogPrintf("regtest: planted premine private key, address %s",
+                      EncodeDestination(regtest_key.GetPubKey().GetID()));
+            // Genesis is loaded before the key is in the wallet, so the
+            // wallet has no record of the premine coinbase outputs. Walk
+            // the chain from genesis to surface them. pindexGenesisBlock
+            // is GUARDED_BY(cs_main), already held via the LOCK2 above.
+            if (pindexGenesisBlock) {
+                int n = pwallet->ScanForWalletTransactions(pindexGenesisBlock, /*fUpdate=*/true);
+                LogPrintf("regtest: scanned %d wallet transactions after premine key plant", n);
+            }
+        }
+    }
+}
+
 /** Initialize Gridcoin.
  *  @pre Parameters should be parsed and config file should be read.
  */
@@ -2127,50 +2181,8 @@ bool AppInit2(ThreadHandlerPtr threads)
         }
     }
 
-    if (Params().IsMockableChain())
-    {
-        // Regtest premine key. Genesis coinbase pays 10 UTXOs to the P2PKH of
-        // the secp256k1 privkey-scalar=1 compressed pubkey (HASH160
-        // 751e76e8...). Plant the matching private key into the wallet on
-        // every -regtest start so the staker can spend the premine. The
-        // BDB env is mocked (in-memory) under regtest, so this re-runs each
-        // start and the key is never persisted to disk.
-        //
-        // Acquire cs_main before cs_wallet (canonical order; ScanForWalletTransactions
-        // below also takes LOCK2(cs_main, cs_wallet)). Holding both up front avoids the
-        // cs_wallet -> cs_main inversion that -DENABLE_DEBUG_LOCKORDER would flag.
-        LOCK2(cs_main, pwalletMain->cs_wallet);
-        const unsigned char kRegtestSecret[32] = {
-            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1
-        };
-        CKey regtest_key;
-        regtest_key.Set(kRegtestSecret, kRegtestSecret + 32, /*fCompressedIn=*/true);
-        if (!regtest_key.IsValid()) {
-            LogPrintf("ERROR: regtest premine key did not validate");
-        } else if (!pwalletMain->HaveKey(regtest_key.GetPubKey().GetID())) {
-            if (!pwalletMain->AddKeyPubKey(regtest_key, regtest_key.GetPubKey())) {
-                LogPrintf("ERROR: failed to plant regtest premine key");
-            } else {
-                // Force nTimeFirstKey down to before genesis so
-                // ScanForWalletTransactions doesn't skip the genesis block
-                // via its wallet-birthday optimization (regtest genesis nTime
-                // is 1296688602; the wallet was created "now", so without
-                // this nudge the scan would skip all of history).
-                pwalletMain->LoadKeyMetadata(regtest_key.GetPubKey(), CKeyMetadata(1));
-
-                LogPrintf("regtest: planted premine private key, address %s",
-                          EncodeDestination(regtest_key.GetPubKey().GetID()));
-                // Genesis is loaded before the key is in the wallet, so the
-                // wallet has no record of the premine coinbase outputs. Walk
-                // the chain from genesis to surface them. pindexGenesisBlock
-                // is GUARDED_BY(cs_main), already held via the LOCK2 above.
-                if (pindexGenesisBlock) {
-                    int n = pwalletMain->ScanForWalletTransactions(pindexGenesisBlock, /*fUpdate=*/true);
-                    LogPrintf("regtest: scanned %d wallet transactions after premine key plant", n);
-                }
-            }
-        }
+    if (Params().IsMockableChain()) {
+        PlantRegtestPremineKey(pwalletMain);
     }
 
     LogPrintf("%s", strErrors.str());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -33,6 +33,7 @@
 #include "node/coherence.h"
 #include "node/mempool_persist.h"
 #include "node/psgt_pool.h"
+#include <util/check.h>
 #include <util/proc_hardening.h>
 #include <util/string.h>
 #include <util/syserror.h>
@@ -1439,7 +1440,7 @@ CKey GetRegtestPremineKey()
 
 void PlantRegtestPremineKey(CWallet* pwallet)
 {
-    assert(pwallet);
+    Assert(pwallet);
 
     // Plant the private key matching the regtest genesis premine into the
     // wallet on every -regtest start so the staker can spend it. The BDB env

--- a/src/init.h
+++ b/src/init.h
@@ -23,6 +23,23 @@ extern CWallet* pwalletMain;
 
 void InitLogging();
 
+//! \brief The private key behind the regtest genesis premine.
+//!
+//! The regtest genesis coinbase pays 10 UTXOs to the P2PKH of the secp256k1
+//! privkey-scalar=1 compressed pubkey. Exposed so that test fixtures can sign
+//! spends of the premine without restating the constant.
+CKey GetRegtestPremineKey();
+
+//! \brief Plant the regtest premine key into \p pwallet and surface its coins.
+//!
+//! Idempotent: does nothing if the wallet already holds the key. On a fresh
+//! plant it also nudges nTimeFirstKey below the genesis timestamp and rescans
+//! from pindexGenesisBlock, because genesis is loaded before the key exists and
+//! the wallet-birthday optimisation would otherwise skip it.
+//!
+//! Callers must NOT hold cs_main or pwallet->cs_wallet; both are taken here.
+void PlantRegtestPremineKey(CWallet* pwallet);
+
 void StartShutdown();
 
 void Shutdown(void* parg);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -13,6 +13,8 @@ add_executable(test_gridcoin
     csv_tests.cpp
     dos_tests.cpp
     accounting_tests.cpp
+    chain_setup.cpp
+    miner_block_assembly_tests.cpp
     addressbook_tests.cpp
     addrman_tests.cpp
     allocator_tests.cpp

--- a/src/test/chain_setup.cpp
+++ b/src/test/chain_setup.cpp
@@ -15,6 +15,7 @@
 #include "miner.h"
 #include "net.h"
 #include "node/blockstorage.h"
+#include "node/chainman.h"
 #include "primitives/block.h"
 #include "script/sign.h"
 #include "test/psgt_test_helpers.h"
@@ -27,6 +28,7 @@
 
 #include <memory>
 #include <set>
+#include <string>
 
 namespace grc_test {
 
@@ -297,6 +299,28 @@ ChainState::ChainState()
 
 ChainState::~ChainState()
 {
+    // Put the committed chain back to genesis.
+    //
+    // ChainTipRestorer below restores the in-memory chain, but a case that
+    // drove real block connection has also committed its blocks: SetBestChain
+    // writes through CTxDB and WriteHashBestChain, and that index is a
+    // process-global handle opened once on the shared datadir. The next
+    // construction's LoadBlockIndex() reads whatever the last one committed, so
+    // its nBestHeight == 0 precondition fires on a chain this fixture left
+    // behind. Restoring memory is not enough for a fixture that commits.
+    //
+    // Rewinding through the same path that wrote it keeps the index consistent,
+    // and leaves the disk where the next construction expects it. Done here
+    // rather than by deleting the database: the handle is global and shared,
+    // and dropping it underneath the wallet is not this fixture's call.
+    {
+        LOCK(cs_main);
+
+        if (pindexGenesisBlock != nullptr && nBestHeight > 0) {
+            ForceReorganizeToHash(pindexGenesisBlock->GetBlockHash());
+        }
+    }
+
     // AppendBlockFile caches a FILE* and the current block file number; both
     // are process-global and must not outlive the datadir this fixture used.
     {

--- a/src/test/chain_setup.cpp
+++ b/src/test/chain_setup.cpp
@@ -457,11 +457,17 @@ CTransaction CreateCoinstakeShaped(const CTransaction& txFrom, uint32_t n, CAmou
 
 void AddToMempool(const CTransaction& tx, CAmount fee)
 {
-    LOCK(mempool.cs);
+    int height;
+    {
+        LOCK(cs_main);
+        height = nBestHeight;
+    }
 
+    // addUnchecked locks mempool.cs internally; a caller-side lock here would
+    // be the redundant pattern #3314 removed.
     mempool.addUnchecked(
         tx.GetHash(),
-        CTxMemPoolEntry(tx, fee, tx.nTime, nBestHeight,
+        CTxMemPoolEntry(tx, fee, tx.nTime, height,
                         ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION)));
 }
 
@@ -474,7 +480,10 @@ void MakeBlockAndCoinstake(CBlock& block, CMutableTransaction& coinbase,
     // version the chain actually runs, and it is >= 12, which is what makes
     // CreateRestOfTheBlock compute the coinstake size reserve rather than
     // starting from a flat 1000 bytes.
-    block.nVersion = ComputeBlockVersion(nBestHeight + 1);
+    {
+        LOCK(cs_main);
+        block.nVersion = ComputeBlockVersion(nBestHeight + 1);
+    }
     block.nTime = static_cast<unsigned int>(FIXTURE_TX_TIME + 1000);
     block.vtx.resize(2);
 

--- a/src/test/chain_setup.cpp
+++ b/src/test/chain_setup.cpp
@@ -414,8 +414,8 @@ CTransaction CreateSpendToScript(const CTransaction& txFrom, uint32_t n, CAmount
         mtx.vout[i].scriptPubKey = script_pub_key;
     }
 
-    // Any rounding remainder goes to the fee rather than to an output, so the
-    // fee a test asks for is the fee the miner will compute.
+    // Any rounding remainder goes to the first output rather than to the fee,
+    // so the fee a test asks for is exactly the fee the miner will compute.
     mtx.vout[0].nValue += value_out - each * n_outputs;
 
     BOOST_REQUIRE_MESSAGE(SignSignature(PremineKeystore(), txFrom, mtx, 0),

--- a/src/test/chain_setup.cpp
+++ b/src/test/chain_setup.cpp
@@ -11,6 +11,7 @@
 #include "fs.h"
 #include "gridcoin/staking/kernel.h"
 #include "init.h"
+#include "gridcoin/staking/status.h"
 #include "miner.h"
 #include "net.h"
 #include "node/blockstorage.h"
@@ -304,6 +305,12 @@ ChainState::~ChainState()
     }
 
     mempool.clear();
+
+    // CreateAndProcessBlock() drives the real miner, which records its kernel
+    // search in the process-global miner status; StakingActive() then answers
+    // true for the rest of the run, and interfaces_tests pins it false.
+    g_miner_status.ClearLastSearch();
+    g_miner_status.ClearLastStake();
 
     // The restorers unwind in reverse declaration order from here.
 }

--- a/src/test/chain_setup.cpp
+++ b/src/test/chain_setup.cpp
@@ -94,6 +94,11 @@ struct ChainTipRestorer
     CBlockIndex* m_pindex_genesis;
     uint256 m_hash_best;
     int m_best_height;
+    //! Set by UpdateSyncTime on every connect and read by OutOfSyncByAge, which
+    //! gates the scraper's unauthenticated manifest path among others. A suite
+    //! that mines leaves it at a fresh block's time, and every later suite then
+    //! believes the node is in sync.
+    int64_t m_previous_block_time;
     //! Whatever an earlier suite left in mapBlockIndex, held aside for the
     //! fixture's lifetime. LoadBlockIndex() only creates genesis into an empty
     //! map, and which suites leave entries behind depends on link order: the
@@ -110,6 +115,7 @@ struct ChainTipRestorer
         m_pindex_genesis = pindexGenesisBlock;
         m_hash_best = hashBestChain;
         m_best_height = nBestHeight;
+        m_previous_block_time = g_previous_block_time.load();
         m_preexisting_index = std::move(mapBlockIndex);
         mapBlockIndex.clear();
 
@@ -135,6 +141,7 @@ struct ChainTipRestorer
         pindexGenesisBlock = m_pindex_genesis;
         hashBestChain = m_hash_best;
         nBestHeight = m_best_height;
+        g_previous_block_time.store(m_previous_block_time);
     }
 };
 

--- a/src/test/chain_setup.cpp
+++ b/src/test/chain_setup.cpp
@@ -273,7 +273,18 @@ ChainState::ChainState()
 
     // Give the wallet the premine key and let it see the genesis outputs, so
     // CreateAndProcessBlock() has something to stake.
-    if (pwalletMain) PlantRegtestPremineKey(pwalletMain);
+    //
+    // The plant helper rescans only when it adds the key. A second fixture in
+    // the same process finds the key already there, because keys are never
+    // erased, while WalletTxRestorer removed the coinbase entry the first
+    // fixture's rescan added. So rescan here unconditionally; the helper's own
+    // rescan, when it runs, is repeated harmlessly.
+    if (pwalletMain) {
+        PlantRegtestPremineKey(pwalletMain);
+
+        LOCK(cs_main);
+        pwalletMain->ScanForWalletTransactions(pindexGenesisBlock, /*fUpdate=*/true);
+    }
 }
 
 ChainState::~ChainState()

--- a/src/test/chain_setup.cpp
+++ b/src/test/chain_setup.cpp
@@ -1,0 +1,481 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "test/chain_setup.h"
+
+#include "chainparams.h"
+#include "chainparamsbase.h"
+#include "consensus/consensus.h"
+#include "dbwrapper.h"
+#include "fs.h"
+#include "gridcoin/staking/kernel.h"
+#include "init.h"
+#include "miner.h"
+#include "net.h"
+#include "node/blockstorage.h"
+#include "primitives/block.h"
+#include "script/sign.h"
+#include "test/psgt_test_helpers.h"
+#include "txmempool.h"
+#include "util/system.h"
+#include "validation.h"
+#include "wallet/wallet.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <set>
+
+namespace grc_test {
+
+namespace {
+
+//! Every fixture transaction carries this timestamp. Fixed rather than
+//! wall-clock so runs are reproducible, and comfortably after the regtest
+//! genesis timestamp (1296688602) because ConnectInputs rejects a transaction
+//! older than the input it spends.
+constexpr int64_t FIXTURE_TX_TIME = 1600000000;
+
+//! Restores the process-wide chain parameters. The in-tree idiom
+//! (block_rewards_tests.cpp) calls SelectParams alone; the path cache must go
+//! with it, because the datadir is network-specific.
+struct ParamsRestorer
+{
+    std::string m_chain;
+
+    ParamsRestorer() : m_chain(Params().NetworkIDString()) {}
+
+    ~ParamsRestorer()
+    {
+        SelectParams(m_chain);
+        gArgs.ClearPathCache();
+    }
+};
+
+//! Restores the consensus globals LoadBlockIndex() overwrites for regtest.
+//! It writes them before its own failure return, so even a construction that
+//! goes on to throw has already mutated them.
+struct ConsensusGlobalsRestorer
+{
+    unsigned int m_stake_min_age;
+    int m_coinbase_maturity;
+    int m_grandfather;
+    int m_max_outbound;
+
+    ConsensusGlobalsRestorer()
+        : m_stake_min_age(nStakeMinAge)
+        , m_coinbase_maturity(nCoinbaseMaturity)
+        , m_grandfather(nGrandfather)
+        , m_max_outbound(MAX_OUTBOUND_CONNECTIONS)
+    {
+    }
+
+    ~ConsensusGlobalsRestorer()
+    {
+        nStakeMinAge = m_stake_min_age;
+        nCoinbaseMaturity = m_coinbase_maturity;
+        nGrandfather = m_grandfather;
+        MAX_OUTBOUND_CONNECTIONS = m_max_outbound;
+    }
+};
+
+//! Saves the chain tip globals and NULLS them, which is a precondition rather
+//! than tidiness: CTxDB::LoadBlockIndex returns "hashBestChain not found"
+//! whenever pindexGenesisBlock is non-null and the database holds no
+//! hashBestChain record, and LoadBlockIndex() then bails before it would create
+//! genesis. Suites that run earlier in this binary routinely leave that global
+//! non-null, and several leave it dangling (see project_tests.cpp's
+//! TestStateGuard, which records that a dangling pindexGenesisBlock is benign on
+//! Linux but a wild-pointer fault under the Windows cross-compile's Wine run).
+struct ChainTipRestorer
+{
+    CBlockIndex* m_pindex_best;
+    CBlockIndex* m_pindex_genesis;
+    uint256 m_hash_best;
+    int m_best_height;
+    //! Whatever an earlier suite left in mapBlockIndex, held aside for the
+    //! fixture's lifetime. LoadBlockIndex() only creates genesis into an empty
+    //! map, and which suites leave entries behind depends on link order: the
+    //! Windows cross-compile leg runs a suite before this one that does. Moving
+    //! the map keeps every node where it is, which matters because each
+    //! CBlockIndex::phashBlock aliases its map key.
+    decltype(mapBlockIndex) m_preexisting_index;
+
+    ChainTipRestorer()
+    {
+        LOCK(cs_main);
+
+        m_pindex_best = pindexBest;
+        m_pindex_genesis = pindexGenesisBlock;
+        m_hash_best = hashBestChain;
+        m_best_height = nBestHeight;
+        m_preexisting_index = std::move(mapBlockIndex);
+        mapBlockIndex.clear();
+
+        pindexBest = nullptr;
+        pindexGenesisBlock = nullptr;
+        hashBestChain = uint256();
+        nBestHeight = -1;
+    }
+
+    ~ChainTipRestorer()
+    {
+        LOCK(cs_main);
+
+        // The block index entries this fixture created are pool-allocated and
+        // never freed (BlockIndexPool), and phashBlock aliases the map key, so
+        // the map is erased and the objects are left behind. The map was
+        // emptied at construction, so everything in it now is ours; then the
+        // earlier suites' entries go back exactly as they were.
+        mapBlockIndex.clear();
+        mapBlockIndex = std::move(m_preexisting_index);
+
+        pindexBest = m_pindex_best;
+        pindexGenesisBlock = m_pindex_genesis;
+        hashBestChain = m_hash_best;
+        nBestHeight = m_best_height;
+    }
+};
+
+//! Removes the CWalletTx entries the fixture added to the process-global
+//! wallet. The planted key is left behind -- leaking keys into pwalletMain is
+//! already precedented (addressbook_tests, qt_wallettxstore_chain_tests) -- but
+//! wallet transactions are not: accounting_tests pins absolute nOrderPosNext
+//! values that CWalletDB::ReorderTransactions recomputes over the whole
+//! mapWallet.
+struct WalletTxRestorer
+{
+    std::set<uint256> m_preexisting;
+
+    WalletTxRestorer()
+    {
+        if (!pwalletMain) return;
+
+        LOCK(pwalletMain->cs_wallet);
+
+        for (const auto& entry : pwalletMain->mapWallet) {
+            m_preexisting.insert(entry.first);
+        }
+    }
+
+    ~WalletTxRestorer()
+    {
+        if (!pwalletMain) return;
+
+        std::vector<uint256> added;
+
+        {
+            LOCK(pwalletMain->cs_wallet);
+
+            for (const auto& entry : pwalletMain->mapWallet) {
+                if (!m_preexisting.count(entry.first)) added.push_back(entry.first);
+            }
+        }
+
+        for (const uint256& hash : added) {
+            pwalletMain->EraseFromWallet(hash);
+        }
+    }
+};
+
+//! The fixture's state. Members are declared so that every restorer is fully
+//! constructed before any mutation happens: a throw later in the constructor
+//! then unwinds them, which a destructor could not do for a partially
+//! constructed object.
+struct ChainState
+{
+    ParamsRestorer m_params;
+    ConsensusGlobalsRestorer m_consensus;
+    WalletTxRestorer m_wallet;
+    ChainTipRestorer m_tip;
+
+    CKey m_key;
+    CBasicKeyStore m_keystore;
+    CTransaction m_premine_coinbase;
+
+    ChainState();
+    ~ChainState();
+};
+
+std::unique_ptr<ChainState> g_state;
+
+ChainState& State()
+{
+    BOOST_REQUIRE_MESSAGE(g_state, "no RegtestChainSetup is alive");
+    return *g_state;
+}
+
+ChainState::ChainState()
+{
+    // Regtest, and the datadir must follow it: GetDataDir() appends a
+    // network-specific component, and the global TestingSetup points -datadir
+    // at a temp path it never creates, so GetDataDir() resolves empty until it
+    // does exist. The block flat files are not mocked -- only LevelDB is -- so
+    // blk0001.dat and CheckDiskSpace both need a real directory.
+    SelectParams(CBaseChainParams::REGTEST);
+    gArgs.ClearPathCache();
+
+    const std::string datadir = gArgs.GetArg("-datadir", "");
+    BOOST_REQUIRE_MESSAGE(!datadir.empty(), "TestingSetup did not set -datadir");
+
+    // Create the network subdirectory too, not just the base. GetDataDir() appends
+    // BaseParams().DataDir() and hands the result to CreateOwnerOnlyDirectory, which
+    // restricts only a directory it created itself and leaves a pre-existing one
+    // alone. Creating it here therefore keeps the fixture out of that path -- which
+    // matters because it is not always available: under Wine, where the Windows
+    // cross-compile CI leg runs this suite, applying an owner-only DACL fails, the
+    // helper withdraws the directory it just made, and GetDataDir() resolves empty.
+    fs::create_directories(fs::path(datadir) / BaseParams().DataDir());
+    gArgs.ClearPathCache();
+    BOOST_REQUIRE_MESSAGE(!GetDataDir().empty(), "datadir still resolves empty");
+
+    {
+        LOCK(cs_main);
+        // ChainTipRestorer moved any earlier suite's entries aside; if this
+        // fires, a restorer was reordered after the mutating work.
+        BOOST_REQUIRE_MESSAGE(mapBlockIndex.empty(),
+            "mapBlockIndex is not empty after ChainTipRestorer set it aside");
+    }
+
+    // Takes cs_main itself, so it must not be held here.
+    BOOST_REQUIRE_MESSAGE(LoadBlockIndex(/*fAllowNew=*/true), "LoadBlockIndex failed");
+
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(pindexGenesisBlock != nullptr);
+        BOOST_REQUIRE(pindexBest != nullptr);
+        BOOST_REQUIRE_EQUAL(nBestHeight, 0);
+    }
+
+    // The premine key, and the coins it owns. The genesis block is
+    // deterministic, so its coinbase can be recomputed rather than read back.
+    m_key = GetRegtestPremineKey();
+    BOOST_REQUIRE(m_key.IsValid());
+    m_keystore.AddKey(m_key);
+
+    const CBlock genesis = CreateGenesisBlock();
+    BOOST_REQUIRE(!genesis.vtx.empty());
+    m_premine_coinbase = genesis.vtx[0];
+    BOOST_REQUIRE_MESSAGE(!m_premine_coinbase.vout.empty(),
+                          "regtest genesis coinbase has no premine outputs");
+
+    // LoadBlockIndex writes this one index entry itself, because genesis
+    // bypasses ConnectBlock. Without it nothing can spend the premine, and the
+    // selection loop would never see a resolvable input.
+    {
+        LOCK(cs_main);
+        CTxDB txdb("r");
+        CTxIndex txindex;
+        BOOST_REQUIRE_MESSAGE(txdb.ReadTxIndex(m_premine_coinbase.GetHash(), txindex),
+                              "regtest genesis coinbase is not in the transaction index");
+    }
+
+    // Give the wallet the premine key and let it see the genesis outputs, so
+    // CreateAndProcessBlock() has something to stake.
+    if (pwalletMain) PlantRegtestPremineKey(pwalletMain);
+}
+
+ChainState::~ChainState()
+{
+    // AppendBlockFile caches a FILE* and the current block file number; both
+    // are process-global and must not outlive the datadir this fixture used.
+    {
+        LOCK(cs_main);
+        CloseBlockFile();
+    }
+
+    mempool.clear();
+
+    // The restorers unwind in reverse declaration order from here.
+}
+
+} // anonymous namespace
+
+RegtestChainSetup::RegtestChainSetup()
+{
+    BOOST_REQUIRE_MESSAGE(!g_state,
+        "a RegtestChainSetup is already alive: it is a suite-level fixture "
+        "(*boost::unit_test::fixture<RegtestChainSetup>()), not a per-case one");
+
+    g_state = std::make_unique<ChainState>();
+}
+
+RegtestChainSetup::~RegtestChainSetup()
+{
+    g_state.reset();
+}
+
+const CKey& PremineKey() { return State().m_key; }
+
+const CBasicKeyStore& PremineKeystore() { return State().m_keystore; }
+
+const CTransaction& PremineCoinbase() { return State().m_premine_coinbase; }
+
+CScript PremineScript() { return psgt_test::P2PKH(PremineKey().GetPubKey().GetID()); }
+
+int64_t FixtureTxTime() { return FIXTURE_TX_TIME; }
+
+std::vector<COutPoint> SpendablePremineOutputs()
+{
+    const CTransaction& coinbase = PremineCoinbase();
+    const uint256 hash = coinbase.GetHash();
+
+    std::vector<COutPoint> out;
+
+    LOCK(cs_main);
+
+    CTxDB txdb("r");
+    CTxIndex txindex;
+
+    if (!txdb.ReadTxIndex(hash, txindex)) return out;
+
+    for (unsigned int i = 0; i < coinbase.vout.size(); ++i) {
+        if (i >= txindex.vSpent.size()) break;
+        if (!txindex.vSpent[i].IsNull()) continue;
+        if (coinbase.vout[i].IsEmpty()) continue;
+
+        out.emplace_back(hash, i);
+    }
+
+    return out;
+}
+
+CTransaction CreateSpendToScript(const CTransaction& txFrom, uint32_t n, CAmount fee,
+                                 const CScript& script_pub_key, int n_outputs, int64_t tx_time)
+{
+    BOOST_REQUIRE(n < txFrom.vout.size());
+    BOOST_REQUIRE(n_outputs >= 1);
+
+    const CAmount value_in = txFrom.vout[n].nValue;
+    const CAmount value_out = value_in - fee;
+    BOOST_REQUIRE_MESSAGE(value_out > 0, "fee exceeds the value of the input");
+
+    CMutableTransaction mtx;
+    mtx.nTime = static_cast<unsigned int>(tx_time != 0 ? tx_time : FIXTURE_TX_TIME);
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(txFrom.GetHash(), n);
+    mtx.vout.resize(n_outputs);
+
+    const CAmount each = value_out / n_outputs;
+    BOOST_REQUIRE_MESSAGE(each > 0, "too many outputs for the value being spent");
+
+    for (int i = 0; i < n_outputs; ++i) {
+        mtx.vout[i].nValue = each;
+        mtx.vout[i].scriptPubKey = script_pub_key;
+    }
+
+    // Any rounding remainder goes to the fee rather than to an output, so the
+    // fee a test asks for is the fee the miner will compute.
+    mtx.vout[0].nValue += value_out - each * n_outputs;
+
+    BOOST_REQUIRE_MESSAGE(SignSignature(PremineKeystore(), txFrom, mtx, 0),
+                          "failed to sign the fixture spend");
+
+    return CTransaction(mtx);
+}
+
+CTransaction CreateSpend(const CTransaction& txFrom, uint32_t n, CAmount fee, int n_outputs,
+                         int64_t tx_time)
+{
+    return CreateSpendToScript(txFrom, n, fee, PremineScript(), n_outputs, tx_time);
+}
+
+CTransaction CreateCoinstakeShaped(const CTransaction& txFrom, uint32_t n, CAmount fee)
+{
+    BOOST_REQUIRE(n < txFrom.vout.size());
+
+    const CAmount value_in = txFrom.vout[n].nValue;
+    BOOST_REQUIRE_MESSAGE(value_in > fee, "fee exceeds the value of the input");
+
+    CMutableTransaction mtx;
+    mtx.nTime = static_cast<unsigned int>(FIXTURE_TX_TIME);
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(txFrom.GetHash(), n);
+    mtx.vout.resize(2);
+    mtx.vout[0].SetEmpty();
+    mtx.vout[1].nValue = value_in - fee;
+    mtx.vout[1].scriptPubKey = PremineScript();
+
+    BOOST_REQUIRE_MESSAGE(SignSignature(PremineKeystore(), txFrom, mtx, 0),
+                          "failed to sign the fixture coinstake");
+
+    const CTransaction tx(mtx);
+    BOOST_REQUIRE_MESSAGE(tx.IsCoinStake(), "fixture coinstake is not shaped like one");
+
+    return tx;
+}
+
+void AddToMempool(const CTransaction& tx, CAmount fee)
+{
+    LOCK(mempool.cs);
+
+    mempool.addUnchecked(
+        tx.GetHash(),
+        CTxMemPoolEntry(tx, fee, tx.nTime, nBestHeight,
+                        ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION)));
+}
+
+void MakeBlockAndCoinstake(CBlock& block, CMutableTransaction& coinbase,
+                           CMutableTransaction& coinstake)
+{
+    block.SetNull();
+
+    // Regtest activates every fork at height 0 except V15, so this is the block
+    // version the chain actually runs, and it is >= 12, which is what makes
+    // CreateRestOfTheBlock compute the coinstake size reserve rather than
+    // starting from a flat 1000 bytes.
+    block.nVersion = ComputeBlockVersion(nBestHeight + 1);
+    block.nTime = static_cast<unsigned int>(FIXTURE_TX_TIME + 1000);
+    block.vtx.resize(2);
+
+    coinbase = CMutableTransaction();
+    coinbase.nTime = block.nTime;
+
+    // The prologue reads vout[1] for its size reserve, and CreateCoinStake
+    // leaves exactly these two outputs before splitting and MRC binding.
+    coinstake = CMutableTransaction();
+    coinstake.nTime = block.nTime;
+    coinstake.vin.resize(1);
+    coinstake.vout.resize(2);
+    coinstake.vout[0].SetEmpty();
+    coinstake.vout[1].nValue = 0;
+    coinstake.vout[1].scriptPubKey = PremineScript();
+}
+
+bool CreateAndProcessBlock(CBlock& block_out, std::string& err)
+{
+    if (!pwalletMain) {
+        err = "no wallet";
+        return false;
+    }
+
+    // The kernel is evaluated at one 16-second-masked timestamp with no time
+    // search, so a retry only helps if it steps to a fresh slot. This mirrors
+    // the loop in generatetoaddress.
+    bool ok = false;
+
+    for (int attempt = 0; attempt < 5 && !ok; ++attempt) {
+        err.clear();
+        ok = TryMineRegtestBlock(pwalletMain, block_out, err, attempt);
+    }
+
+    if (!ok) return false;
+
+    // RegisterValidationInterface() is a silent no-op in this binary --
+    // registration is gated on a MainSignalsInstance that only
+    // RegisterBackgroundSignalScheduler creates, and TestingSetup builds no
+    // scheduler -- so CWallet::BlockConnected never fires. Rescan instead,
+    // which reaches AddToWalletIfInvolvingMe without the signal layer.
+    {
+        LOCK(cs_main);
+
+        if (pindexGenesisBlock) {
+            pwalletMain->ScanForWalletTransactions(pindexGenesisBlock, /*fUpdate=*/true);
+        }
+    }
+
+    return true;
+}
+
+} // namespace grc_test

--- a/src/test/chain_setup.h
+++ b/src/test/chain_setup.h
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_TEST_CHAIN_SETUP_H
+#define GRIDCOIN_TEST_CHAIN_SETUP_H
+
+#include "amount.h"
+#include "key.h"
+#include "keystore.h"
+#include "primitives/transaction.h"
+
+#include <string>
+#include <vector>
+
+class CBlock;
+
+namespace grc_test {
+
+//!
+//! \brief A real regtest chain, with spendable coins, inside the unit-test binary.
+//!
+//! The global TestingSetup (test_gridcoin.cpp) already supplies ECC, a mocked
+//! Berkeley DB wallet and an in-memory LevelDB behind the process-global txdb
+//! handle. What it does not supply is a chain: mapBlockIndex is empty, there is
+//! no genesis, no block file, and no transaction index. Anything that resolves
+//! an input through CTxDB is therefore untestable, which is why the mempool
+//! selection loop in CreateRestOfTheBlock has never executed an iteration under
+//! a unit test (see issue #3290).
+//!
+//! This fixture selects regtest, creates the datadir, and calls the production
+//! LoadBlockIndex(), which writes the deterministic regtest genesis to a real
+//! blk0001.dat and its coinbase to the transaction index. That coinbase pays ten
+//! spendable outputs to the premine key, and regtest skips ConnectInputs'
+//! coinbase maturity walk (validation.cpp), so those outputs are spendable at
+//! height 1 with no mining at all.
+//!
+//! LIFETIME. Use it as a SUITE-level fixture:
+//!
+//!     BOOST_AUTO_TEST_SUITE(my_tests, *boost::unit_test::fixture<grc_test::RegtestChainSetup>())
+//!
+//! and NOT with BOOST_FIXTURE_TEST_SUITE, which constructs a fixture once per
+//! test case. A per-case rebuild does not work here: the genesis block index,
+//! hashBestChain and the transaction index all persist in the LevelDB memenv,
+//! which is opened once for the whole binary and must never be closed (doing so
+//! destroys the global fixture's handle), so a second LoadBlockIndex() takes the
+//! disk-reload path instead of creating genesis. Constructing a second one while
+//! the first is alive asserts.
+//!
+//! Because it is not a base class under that decorator, the helpers below are
+//! free functions. They are valid only while a RegtestChainSetup is alive.
+//!
+//! GLOBAL STATE. Construction flips the whole process to regtest and mutates
+//! consensus globals shared with every other suite in this binary. Every
+//! restore lives in an RAII sub-object constructed before the mutating work, so
+//! a throw out of the constructor still unwinds it -- no destructor runs for a
+//! partially constructed object. One residue is irreversible and accepted: the
+//! genesis block-index record, hashBestChain and the tx-index entries stay in
+//! the memenv LevelDB. They are inert for other suites (nothing else calls
+//! LoadBlockIndex, and lookups are by hash), which is precisely why the lifetime
+//! is once per suite.
+//!
+struct RegtestChainSetup
+{
+    RegtestChainSetup();
+    ~RegtestChainSetup();
+
+    RegtestChainSetup(const RegtestChainSetup&) = delete;
+    RegtestChainSetup& operator=(const RegtestChainSetup&) = delete;
+};
+
+//! \brief The key the regtest genesis premine pays to.
+const CKey& PremineKey();
+
+//! \brief A keystore holding PremineKey(), for SignSignature().
+const CBasicKeyStore& PremineKeystore();
+
+//! \brief The regtest genesis coinbase. Its outputs are the fixture's coins.
+const CTransaction& PremineCoinbase();
+
+//! \brief Premine outputs the transaction index still records as unspent.
+std::vector<COutPoint> SpendablePremineOutputs();
+
+//! \brief A P2PKH scriptPubKey paying the premine key.
+CScript PremineScript();
+
+//! \brief Timestamp shared by every fixture-built transaction.
+//!
+//! Fixed rather than wall-clock so tests are reproducible. It is after the
+//! genesis timestamp, which ConnectInputs requires (txPrev.nTime <= tx.nTime).
+int64_t FixtureTxTime();
+
+//!
+//! \brief Sign a spend of \p txFrom output \p n, paying \p fee.
+//!
+//! \p n_outputs is the size knob: a 1-in/N-out P2PKH transaction is roughly
+//! 163 + 34N bytes, which is how a test varies fee RATE independently of
+//! absolute fee. The signature is real -- ConnectInputs verifies it on the
+//! miner path.
+//!
+//!
+//! \p tx_time overrides the transaction timestamp; 0 means FixtureTxTime().
+//! ConnectInputs rejects a transaction older than the input it spends, so a
+//! value below the genesis timestamp will not connect.
+//!
+CTransaction CreateSpend(const CTransaction& txFrom, uint32_t n, CAmount fee, int n_outputs = 1,
+                         int64_t tx_time = 0);
+
+//! \brief As CreateSpend, but every output carries \p script_pub_key.
+CTransaction CreateSpendToScript(const CTransaction& txFrom, uint32_t n, CAmount fee,
+                                 const CScript& script_pub_key, int n_outputs = 1,
+                                 int64_t tx_time = 0);
+
+//!
+//! \brief A signed transaction that satisfies CTransaction::IsCoinStake().
+//!
+//! Empty vout[0], a real signed input, and vout[1] paying the remainder, so the
+//! transaction carries a POSITIVE fee. That matters: a realistic minting
+//! coinstake pays a negative fee and is excluded by the nTxFees < nMinFee
+//! handler whether or not the loop's IsCoinStake() guard is there, so it would
+//! prove nothing about the guard.
+//!
+CTransaction CreateCoinstakeShaped(const CTransaction& txFrom, uint32_t n, CAmount fee);
+
+//! \brief Put \p tx in the global mempool with \p fee, bypassing all validation.
+void AddToMempool(const CTransaction& tx, CAmount fee);
+
+//!
+//! \brief Fill in CreateRestOfTheBlock's preconditions.
+//!
+//! Sets a block version that reaches the nBlockSize reserve arithmetic, sizes
+//! block.vtx and the coinstake outputs (the prologue indexes vout[1]), and puts
+//! block.nTime after FixtureTxTime() so the timestamp guard does not silently
+//! drop every candidate.
+//!
+void MakeBlockAndCoinstake(CBlock& block, CMutableTransaction& coinbase,
+                           CMutableTransaction& coinstake);
+
+//!
+//! \brief Mine one real regtest block, retrying across stake time slots.
+//!
+//! Mirrors the retry loop in generatetoaddress (rpc/mining.cpp): the kernel is
+//! evaluated at a single 16-second-masked timestamp, so each attempt steps to a
+//! fresh slot. Rescans the wallet afterwards -- RegisterValidationInterface is a
+//! silent no-op in this binary, so the wallet has no other way to learn about the
+//! block. Returns false and sets \p err on failure.
+//!
+//! Only tests that genuinely need a mined output (a confirmed P2SH funding
+//! output, say) should call this; the premine alone needs no mining.
+//!
+bool CreateAndProcessBlock(CBlock& block_out, std::string& err);
+
+} // namespace grc_test
+
+#endif // GRIDCOIN_TEST_CHAIN_SETUP_H

--- a/src/test/chain_setup.h
+++ b/src/test/chain_setup.h
@@ -54,11 +54,15 @@ namespace grc_test {
 //! consensus globals shared with every other suite in this binary. Every
 //! restore lives in an RAII sub-object constructed before the mutating work, so
 //! a throw out of the constructor still unwinds it -- no destructor runs for a
-//! partially constructed object. One residue is irreversible and accepted: the
-//! genesis block-index record, hashBestChain and the tx-index entries stay in
-//! the memenv LevelDB. They are inert for other suites (nothing else calls
-//! LoadBlockIndex, and lookups are by hash), which is precisely why the lifetime
-//! is once per suite.
+//! partially constructed object. Residue that is irreversible and accepted:
+//! the genesis block-index record, hashBestChain and the tx-index entries stay
+//! in the memenv LevelDB; LoadBlockIndex also initializes g_chain_trust (which
+//! retains a pointer to the fixture's leaked genesis index entry) and refills
+//! g_seen_stakes, and neither is set aside and restored. All of it is inert for
+//! other suites (nothing else calls LoadBlockIndex, nothing reads g_chain_trust
+//! or g_seen_stakes in this binary, lookups are by hash, and each fixture
+//! construction re-initializes both globals), which is precisely why the
+//! lifetime is once per suite.
 //!
 struct RegtestChainSetup
 {

--- a/src/test/miner_block_assembly_tests.cpp
+++ b/src/test/miner_block_assembly_tests.cpp
@@ -1,0 +1,441 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+//!
+//! Block assembly: the mempool selection loop in CreateRestOfTheBlock.
+//!
+//! Until issue #3290 these lines had no unit coverage at all. The two existing
+//! drivers of CreateRestOfTheBlock -- coinstake_construction_tests.cpp and
+//! gridcoin/mrc_tests.cpp -- run against a MOCK chain with an EMPTY mempool, so
+//! the loop body never executes a single iteration; they cover the prologue and
+//! the epilogue around it. Everything about which transactions reach a block was
+//! therefore reachable only from test/functional/, where observing it costs a
+//! real staked block.
+//!
+//! What makes this testable is RegtestChainSetup (test/chain_setup.h): a real
+//! regtest chain with the genesis premine spendable. Note that the assertions
+//! here never mine -- they populate the mempool and call CreateRestOfTheBlock
+//! directly -- so none of them inherits the regtest stake lottery that put
+//! mining_fee_policy.py in EXTENDED_SCRIPTS.
+//!
+//! FEE RULE FOR EVERY CANDIDATE HERE. Any transaction that is meant to be
+//! evaluated past the size guard is funded at >= 100 satoshi per serialized
+//! byte. On this branch the miner's only floor is ABSOLUTE (GetMinFee with
+//! nBytes = 0 is size-independent, so a flat 100,000), but PR #3291 adds a
+//! fee-RATE floor defaulting to the same 100,000 per KILOBYTE. The two coincide
+//! at exactly 1000 bytes and diverge above it, and AddToMempool uses
+//! addUnchecked, which bypasses the size-scaled relay floor that makes the rate
+//! floor inert for real traffic. Funding by rate keeps these cases valid across
+//! that merge instead of quietly emptying the block.
+//!
+
+#include "amount.h"
+#include "chain.h"
+#include "consensus/consensus.h"
+#include "consensus/tx_verify.h"
+#include "gridcoin/cpid.h"
+#include "gridcoin/mrc.h"
+#include "miner.h"
+#include "policy/fees.h"
+#include "primitives/block.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "test/chain_setup.h"
+#include "txmempool.h"
+#include "validation.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <map>
+#include <vector>
+
+using grc_test::AddToMempool;
+using grc_test::CreateSpend;
+using grc_test::MakeBlockAndCoinstake;
+using grc_test::PremineCoinbase;
+using grc_test::SpendablePremineOutputs;
+
+namespace {
+
+using MrcMap = std::map<GRC::Cpid, std::pair<uint256, GRC::MRC>>;
+
+//! Serialized size the miner measures a candidate by.
+unsigned int TxSize(const CTransaction& tx)
+{
+    return ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+}
+
+//! The miner's dFeePerKb for a transaction paying `fee`.
+double FeePerKb(const CTransaction& tx, CAmount fee)
+{
+    return (double)fee / (double(TxSize(tx)) / 1000.0);
+}
+
+//! Fund a candidate at `sat_per_byte`, which is how every case here stays above
+//! both the absolute floor on this branch and the fee-rate floor #3291 adds.
+CAmount FeeAtRate(const CTransaction& probe, CAmount sat_per_byte)
+{
+    return (CAmount)TxSize(probe) * sat_per_byte;
+}
+
+//! Build one candidate spending premine output `index`, sized by `n_outputs`
+//! and funded at `sat_per_byte`. The fee is derived from the transaction's real
+//! serialized size rather than an estimate: a one-byte DER drift would
+//! otherwise move the rate.
+CTransaction MakeCandidate(size_t index, int n_outputs, CAmount sat_per_byte, CAmount& fee_out)
+{
+    const std::vector<COutPoint> coins = SpendablePremineOutputs();
+    BOOST_REQUIRE_MESSAGE(index < coins.size(), "not enough spendable premine outputs");
+
+    // Size first, with a placeholder fee, then re-derive the fee from the
+    // measured size and rebuild. The size does not depend on the fee.
+    const CTransaction probe = CreateSpend(PremineCoinbase(), coins[index].n, COIN, n_outputs);
+    fee_out = FeeAtRate(probe, sat_per_byte);
+
+    const CTransaction tx = CreateSpend(PremineCoinbase(), coins[index].n, fee_out, n_outputs);
+    BOOST_REQUIRE_EQUAL(TxSize(tx), TxSize(probe));
+
+    // The rate floor is not the only one. The miner also compares the ABSOLUTE
+    // fee against GetMinFee(tx, nBlockSize, GMF_BLOCK), which passes nBytes = 0
+    // and is therefore a flat MIN_TX_FEE * 10 regardless of size, and
+    // ConnectInputs applies the same flat floor a second time. A candidate that
+    // misses it is not merely excluded -- on this branch it aborts the whole
+    // selection loop -- so a case that funds too thinly must fail here as bad
+    // setup rather than silently assert on an empty block.
+    BOOST_REQUIRE_MESSAGE(fee_out >= GetMinFee(tx),
+        "candidate underfunded for the miner's absolute floor: a small transaction "
+        "needs roughly 520 satoshi per byte to clear a flat 100000");
+
+    return tx;
+}
+
+//! As MakeCandidate, but every output carries `script`. Used to reach the sigop
+//! guard, which counts signature operations in the output scripts.
+CTransaction MakeCandidateToScript(size_t index, const CScript& script, int n_outputs,
+                                   CAmount sat_per_byte, CAmount& fee_out)
+{
+    const std::vector<COutPoint> coins = SpendablePremineOutputs();
+    BOOST_REQUIRE_MESSAGE(index < coins.size(), "not enough spendable premine outputs");
+
+    const CTransaction probe =
+        grc_test::CreateSpendToScript(PremineCoinbase(), coins[index].n, COIN, script, n_outputs);
+    fee_out = FeeAtRate(probe, sat_per_byte);
+
+    const CTransaction tx =
+        grc_test::CreateSpendToScript(PremineCoinbase(), coins[index].n, fee_out, script, n_outputs);
+    BOOST_REQUIRE_EQUAL(TxSize(tx), TxSize(probe));
+
+    return tx;
+}
+
+//! Run block assembly over whatever is in the mempool, returning the selected
+//! transactions in selection order. block.vtx is filled by push_back after the
+//! coinbase/coinstake pair, so vtx[2:] IS the order the loop chose.
+std::vector<CTransaction> AssembleBlock(CAmount& fees_out)
+{
+    CBlock block;
+    CMutableTransaction coinbase;
+    CMutableTransaction coinstake;
+    MakeBlockAndCoinstake(block, coinbase, coinstake);
+
+    MrcMap mrc_map;
+
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(pindexBest != nullptr);
+        BOOST_REQUIRE(CreateRestOfTheBlock(block, coinbase, coinstake, pindexBest, mrc_map));
+    }
+
+    // The epilogue parks the accumulated fees on the coinbase's only output.
+    fees_out = coinbase.vout[0].nValue;
+
+    BOOST_REQUIRE(block.vtx.size() >= 2);
+
+    return std::vector<CTransaction>(block.vtx.begin() + 2, block.vtx.end());
+}
+
+bool Contains(const std::vector<CTransaction>& txs, const CTransaction& tx)
+{
+    const uint256 hash = tx.GetHash();
+
+    for (const CTransaction& candidate : txs) {
+        if (candidate.GetHash() == hash) return true;
+    }
+
+    return false;
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(miner_block_assembly_tests,
+                      *boost::unit_test::fixture<grc_test::RegtestChainSetup>())
+
+//!
+//! The fixture's own precondition: a real chain, and premine coins that the
+//! transaction index can resolve. Everything below is meaningless without it,
+//! so it is asserted separately rather than left implicit in a failure
+//! elsewhere.
+//!
+BOOST_AUTO_TEST_CASE(the_fixture_provides_spendable_coins)
+{
+    LOCK(cs_main);
+
+    BOOST_CHECK(pindexGenesisBlock != nullptr);
+    BOOST_CHECK(pindexBest != nullptr);
+    BOOST_CHECK_EQUAL(nBestHeight, 0);
+
+    BOOST_CHECK_EQUAL(PremineCoinbase().vout.size(), 10u);
+    BOOST_CHECK_EQUAL(SpendablePremineOutputs().size(), 10u);
+}
+
+//!
+//! The loop executes. This is the assertion that has never held: with a mock
+//! chain the candidates cannot resolve their inputs, so they are diverted into
+//! vOrphan and vecPriority is empty when std::make_heap runs.
+//!
+BOOST_AUTO_TEST_CASE(mempool_transactions_are_selected_into_the_block)
+{
+    mempool.clear();
+
+    CAmount fee_a = 0, fee_b = 0, fee_c = 0;
+    const CTransaction a = MakeCandidate(0, 1, 900, fee_a);
+    const CTransaction b = MakeCandidate(1, 1, 800, fee_b);
+    const CTransaction c = MakeCandidate(2, 1, 700, fee_c);
+
+    AddToMempool(a, fee_a);
+    AddToMempool(b, fee_b);
+    AddToMempool(c, fee_c);
+
+    CAmount fees = 0;
+    const std::vector<CTransaction> selected = AssembleBlock(fees);
+
+    BOOST_CHECK_EQUAL(selected.size(), 3u);
+    BOOST_CHECK(Contains(selected, a));
+    BOOST_CHECK(Contains(selected, b));
+    BOOST_CHECK(Contains(selected, c));
+
+    mempool.clear();
+}
+
+//!
+//! Ordering is by fee RATE, not absolute fee.
+//!
+//! The heap is keyed on dFeePerKb (miner.cpp), so a large transaction paying
+//! the largest absolute fee in the block still sorts below smaller ones paying
+//! a higher rate. Gridcoin's relay schedule is (1 + bytes/1000) * 0.001 GRC, so
+//! the effective rate FALLS with size and the two orders genuinely differ.
+//!
+//! The rate relationship is asserted on the built transactions before the block
+//! is assembled: if a size or fee change ever inverted it, this would fail as a
+//! bad setup rather than silently testing nothing.
+//!
+BOOST_AUTO_TEST_CASE(selection_order_is_by_fee_rate_not_absolute_fee)
+{
+    mempool.clear();
+
+    CAmount small_fee = 0, big_fee = 0;
+    const CTransaction small = MakeCandidate(0, 1, 2000, small_fee);
+    const CTransaction big = MakeCandidate(1, 60, 300, big_fee);
+
+    // The premise of the case: the big transaction pays MORE in total and LESS
+    // per kilobyte.
+    BOOST_REQUIRE_GT(big_fee, small_fee);
+    BOOST_REQUIRE_GT(FeePerKb(small, small_fee), FeePerKb(big, big_fee));
+
+    // Added in the "wrong" order, so a loop that merely preserved insertion
+    // order would fail.
+    AddToMempool(big, big_fee);
+    AddToMempool(small, small_fee);
+
+    CAmount fees = 0;
+    const std::vector<CTransaction> selected = AssembleBlock(fees);
+
+    BOOST_REQUIRE_EQUAL(selected.size(), 2u);
+    BOOST_CHECK_EQUAL(selected[0].GetHash().ToString(), small.GetHash().ToString());
+    BOOST_CHECK_EQUAL(selected[1].GetHash().ToString(), big.GetHash().ToString());
+
+    mempool.clear();
+}
+
+//!
+//! The fees the loop accumulates reach the coinbase, and they agree with what
+//! the mempool entries already recorded.
+//!
+//! The agreement is worth pinning because the loop recomputes everything: it
+//! re-reads the inputs through FetchInputs and recomputes the fee with
+//! GetValueIn, ignoring CTxMemPoolEntry::GetFee() entirely. The two are
+//! independent paths to the same number.
+//!
+BOOST_AUTO_TEST_CASE(accumulated_fees_reach_the_coinbase)
+{
+    mempool.clear();
+
+    CAmount fee_a = 0, fee_b = 0;
+    const CTransaction a = MakeCandidate(0, 1, 700, fee_a);
+    const CTransaction b = MakeCandidate(1, 4, 700, fee_b);
+
+    AddToMempool(a, fee_a);
+    AddToMempool(b, fee_b);
+
+    CAmount fees = 0;
+    const std::vector<CTransaction> selected = AssembleBlock(fees);
+
+    BOOST_REQUIRE_EQUAL(selected.size(), 2u);
+    BOOST_CHECK_EQUAL(fees, fee_a + fee_b);
+
+    mempool.clear();
+}
+
+
+//!
+//! An oversized candidate is SKIPPED, not treated as the end of the block.
+//!
+//! The guard is a continue, and the difference is observable only when the
+//! oversized transaction sorts FIRST: it pays the higher rate here, so a break
+//! would end selection before the affordable one is ever popped. Asserting that
+//! the small transaction is still in the block is therefore the assertion that
+//! distinguishes the two.
+//!
+//! No -blockmaxsize override is used. Setting it would mean restoring it for
+//! every later suite in this binary, and ForceSetArg to the empty string does
+//! not restore the default -- it parses as 0, which the miner then clamps to
+//! 1000. The transaction is simply built past the real 250000 default instead.
+//!
+BOOST_AUTO_TEST_CASE(an_oversized_transaction_is_skipped_and_selection_continues)
+{
+    mempool.clear();
+
+    // A P2PKH output serializes to 34 bytes, so this lands around 251 KB.
+    CAmount big_fee = 0, small_fee = 0;
+    const CTransaction oversized = MakeCandidate(0, 7400, 800, big_fee);
+    const CTransaction small = MakeCandidate(1, 1, 700, small_fee);
+
+    BOOST_REQUIRE_GE(TxSize(oversized), (unsigned int)(MAX_BLOCK_SIZE_GEN / 2));
+    BOOST_REQUIRE_GT(FeePerKb(oversized, big_fee), FeePerKb(small, small_fee));
+
+    AddToMempool(oversized, big_fee);
+    AddToMempool(small, small_fee);
+
+    CAmount fees = 0;
+    const std::vector<CTransaction> selected = AssembleBlock(fees);
+
+    BOOST_CHECK(!Contains(selected, oversized));
+    BOOST_CHECK(Contains(selected, small));
+    BOOST_CHECK_EQUAL(fees, small_fee);
+
+    mempool.clear();
+}
+
+//!
+//! The legacy sigop guard skips its candidate and selection continues.
+//!
+//! Reaching it needs raw scripts rather than more outputs. Legacy sigops for a
+//! P2PKH spend equal the output count, and the size guard runs first at a
+//! default -blockmaxsize of 250000, which caps the reachable count near 7350 --
+//! well under MAX_BLOCK_SIGOPS. A bare OP_CHECKMULTISIG counts 20 in
+//! non-accurate mode, so a kilobyte of them carries about 19900, and the
+//! running total starts at 100.
+//!
+BOOST_AUTO_TEST_CASE(a_sigop_heavy_transaction_is_skipped_and_selection_continues)
+{
+    mempool.clear();
+
+    CScript sigop_script;
+    for (int i = 0; i < 995; ++i) sigop_script << OP_CHECKMULTISIG;
+
+    CAmount heavy_fee = 0, small_fee = 0;
+    const CTransaction heavy = MakeCandidateToScript(0, sigop_script, 1, 800, heavy_fee);
+    const CTransaction small = MakeCandidate(1, 1, 700, small_fee);
+
+    BOOST_REQUIRE_GE(GetLegacySigOpCount(heavy) + 100u, (unsigned int)MAX_BLOCK_SIGOPS);
+    BOOST_REQUIRE_LT(TxSize(heavy), (unsigned int)(MAX_BLOCK_SIZE_GEN / 2));
+    BOOST_REQUIRE_GT(FeePerKb(heavy, heavy_fee), FeePerKb(small, small_fee));
+
+    AddToMempool(heavy, heavy_fee);
+    AddToMempool(small, small_fee);
+
+    CAmount fees = 0;
+    const std::vector<CTransaction> selected = AssembleBlock(fees);
+
+    BOOST_CHECK(!Contains(selected, heavy));
+    BOOST_CHECK(Contains(selected, small));
+
+    mempool.clear();
+}
+
+//!
+//! A candidate stamped after the block it would go into is skipped.
+//!
+BOOST_AUTO_TEST_CASE(a_transaction_newer_than_the_block_is_skipped)
+{
+    mempool.clear();
+
+    const std::vector<COutPoint> coins = SpendablePremineOutputs();
+    BOOST_REQUIRE_GE(coins.size(), 2u);
+
+    // MakeBlockAndCoinstake stamps the block at FixtureTxTime() + 1000.
+    const CTransaction late =
+        CreateSpend(PremineCoinbase(), coins[0].n, 200000, 1, grc_test::FixtureTxTime() + 5000);
+    const CTransaction ontime = CreateSpend(PremineCoinbase(), coins[1].n, 150000, 1);
+
+    BOOST_REQUIRE_GT(FeePerKb(late, 200000), FeePerKb(ontime, 150000));
+
+    AddToMempool(late, 200000);
+    AddToMempool(ontime, 150000);
+
+    CAmount fees = 0;
+    const std::vector<CTransaction> selected = AssembleBlock(fees);
+
+    BOOST_CHECK(!Contains(selected, late));
+    BOOST_CHECK(Contains(selected, ontime));
+
+    mempool.clear();
+}
+
+//!
+//! A coinstake sitting in the mempool is never selected.
+//!
+//! The candidate pays a POSITIVE fee above the miner's flat floor, which is
+//! what makes the case discriminate: delete the IsCoinStake() term from the
+//! enumeration guard and this transaction really does land in the block,
+//! because ConnectInputs skips the value and fee tally for coinstakes. A
+//! realistic minting coinstake would be excluded by the fee handler either way
+//! and would prove nothing.
+//!
+//! Its coinbase sibling is deliberately not tested. IsCoinBase() implies a null
+//! prevout, so with the guard removed the input cannot be fetched, the
+//! candidate is dropped as missing inputs before it ever reaches the priority
+//! heap, and no fixture state can change that -- the coinbase half of the guard
+//! has no reachable behaviour to pin.
+//!
+BOOST_AUTO_TEST_CASE(a_coinstake_in_the_mempool_is_never_selected)
+{
+    mempool.clear();
+
+    const std::vector<COutPoint> coins = SpendablePremineOutputs();
+    BOOST_REQUIRE_GE(coins.size(), 2u);
+
+    const CAmount coinstake_fee = 200000;
+    const CTransaction coinstake =
+        grc_test::CreateCoinstakeShaped(PremineCoinbase(), coins[0].n, coinstake_fee);
+    const CTransaction ordinary = CreateSpend(PremineCoinbase(), coins[1].n, 150000, 1);
+
+    // Above the flat GMF_BLOCK floor, so the fee handler is not what excludes it.
+    BOOST_REQUIRE_GE(coinstake_fee, GetMinFee(coinstake));
+    BOOST_REQUIRE(coinstake.IsCoinStake());
+
+    AddToMempool(coinstake, coinstake_fee);
+    AddToMempool(ordinary, 150000);
+
+    CAmount fees = 0;
+    const std::vector<CTransaction> selected = AssembleBlock(fees);
+
+    BOOST_CHECK(!Contains(selected, coinstake));
+    BOOST_CHECK(Contains(selected, ordinary));
+    BOOST_CHECK_EQUAL(fees, 150000);
+
+    mempool.clear();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_block_assembly_tests.cpp
+++ b/src/test/miner_block_assembly_tests.cpp
@@ -21,13 +21,12 @@
 //!
 //! FEE RULE FOR EVERY CANDIDATE HERE. Any transaction that is meant to be
 //! evaluated past the size guard is funded at >= 100 satoshi per serialized
-//! byte. On this branch the miner's only floor is ABSOLUTE (GetMinFee with
-//! nBytes = 0 is size-independent, so a flat 100,000), but PR #3291 adds a
-//! fee-RATE floor defaulting to the same 100,000 per KILOBYTE. The two coincide
-//! at exactly 1000 bytes and diverge above it, and AddToMempool uses
-//! addUnchecked, which bypasses the size-scaled relay floor that makes the rate
-//! floor inert for real traffic. Funding by rate keeps these cases valid across
-//! that merge instead of quietly emptying the block.
+//! byte. The miner applies two floors: the ABSOLUTE GetMinFee floor (nBytes = 0
+//! is size-independent, a flat 100,000) and, since #3291, a fee-RATE floor
+//! defaulting to the same 100,000 per KILOBYTE. The two coincide at exactly
+//! 1000 bytes and diverge above it, and AddToMempool uses addUnchecked, which
+//! bypasses the size-scaled relay floor that makes the rate floor inert for
+//! real traffic. Funding by rate keeps every candidate above both floors.
 //!
 
 #include "amount.h"
@@ -100,9 +99,9 @@ CTransaction MakeCandidate(size_t index, int n_outputs, CAmount sat_per_byte, CA
     // fee against GetMinFee(tx, nBlockSize, GMF_BLOCK), which passes nBytes = 0
     // and is therefore a flat MIN_TX_FEE * 10 regardless of size, and
     // ConnectInputs applies the same flat floor a second time. A candidate that
-    // misses it is not merely excluded -- on this branch it aborts the whole
-    // selection loop -- so a case that funds too thinly must fail here as bad
-    // setup rather than silently assert on an empty block.
+    // misses it is skipped (the selection loop continues past it since #3291),
+    // so a case that funds too thinly would surface as a confusing assertion
+    // on the block's contents; fail it here as bad setup instead.
     BOOST_REQUIRE_MESSAGE(fee_out >= GetMinFee(tx),
         "candidate underfunded for the miner's absolute floor: a small transaction "
         "needs roughly 520 satoshi per byte to clear a flat 100000");


### PR DESCRIPTION
Closes #3290 (its line that the `nTxFees < nMinFee` handler has "no route to coverage at all" was
too strong; #3326 reaches it functionally, and this fixture is the unit route). Seven commits: a
small lift in `init.cpp` so a test can plant the regtest premine key the way the daemon does, the
fixture with its first consumer, and five fixups pushed since the first push. Three of the five are
cross-suite state the fixture was not restoring, and a fourth is the mirror image, all of it found
by adding a second fixture consumer; they are listed at the end. The maintainer's review commit
(`a69a5d597`) then rewrote the two fee-floor comment blocks against the post-#3291 base and locked
the fixture's `nBestHeight` reads.

### Why a fixture, and why this shape

The mempool selection loop in `CreateRestOfTheBlock` had never executed one iteration under a
unit test. `coinstake_construction_tests` and `gridcoin/mrc_tests` build a mock chain with an
empty mempool, so they cover the code around the loop and never the loop.

A mempool-only fixture cannot fix that, and this is the fact that decided the design: the
enumeration pass resolves each candidate's parent through the `ReadTxFromDisk(tx, txdb, prevout,
txindex)` overload, which has no `CDiskTxPos(1,1,1)` mempool sentinel branch (unlike
`FetchInputs`). A candidate whose parent is not readable from a block file goes to `vOrphan` and
only reaches the heap once a parent is selected, so with nothing on disk `vecPriority` is empty
at `make_heap` and the loop body runs zero times.

So `RegtestChainSetup` builds a real chain. It selects regtest, creates the datadir
(`TestingSetup` sets `-datadir` but never creates it, and the block flat files are not mocked),
and calls the production `LoadBlockIndex()`, which writes the deterministic genesis to a real
`blk0001.dat` and its coinbase to the tx index. That coinbase pays ten outputs to the premine key,
and regtest skips the coinbase maturity walk in `ConnectInputs`, so they are spendable at height 1
and the cases here never mine (the fixture offers `CreateAndProcessBlock` for consumers that
need to). The cases populate the mempool and call `CreateRestOfTheBlock` directly, so nothing here
inherits the regtest stake lottery that keeps `mining_fee_policy.py` in `EXTENDED_SCRIPTS`.

### What the test binary forced

- **Suite-level, not per-case.** The genesis index, `hashBestChain` and the tx index live in the
  LevelDB memenv, which is opened once for the binary and must never be closed, so a second
  `LoadBlockIndex()` takes the reload path and never creates genesis. Hence
  `BOOST_AUTO_TEST_SUITE(name, *boost::unit_test::fixture<RegtestChainSetup>())` and free-function
  helpers in `grc_test`.
- **Tip globals are saved and nulled in the constructor.** `CTxDB::LoadBlockIndex` returns
  "hashBestChain not found" whenever `pindexGenesisBlock` is non-null and no record exists, and
  earlier suites leave it non-null, several dangling (`project_tests.cpp`'s `TestStateGuard`
  records the Wine wild-pointer fault). Every restore of pre-existing global state is an RAII
  sub-object declared before the mutating work, because a throwing constructor runs no destructor;
  the fixture's own teardown actions (rewind, block-file close, mempool clear) live in the
  destructor body.
- **`mapBlockIndex` is moved aside, not asserted empty.** Which earlier suites leave entries
  behind depends on link order, and the Windows cross-compile leg runs one that does; the first
  push of this branch failed there on exactly that assertion. Moving the map keeps every node
  where it is, which matters because `CBlockIndex::phashBlock` aliases its map key.
- **Wallet transactions are erased on teardown.** `accounting_tests` pins absolute
  `nOrderPosNext` values recomputed over the whole `mapWallet`.
- **`RegisterValidationInterface` is not used.** It is a silent no-op in this binary: gated on a
  `MainSignalsInstance` that only `RegisterBackgroundSignalScheduler` creates, whose sole caller is
  in `init.cpp`. `CreateAndProcessBlock` rescans instead.

### The cases

Eight: a fixture precondition (`the_fixture_provides_spendable_coins`), then seven each
mutation-tested to fail only for its own mutation: the loop runs at all; ordering is by fee rate,
not absolute fee; the size, legacy-sigop and timestamp guards each skip their candidate and let
selection continue; fees reach the coinbase; a coinstake in the mempool is never selected. The
coinbase half of that last guard is deliberately uncovered: `IsCoinBase()` implies a null prevout,
so with the guard removed the candidate is dropped as missing inputs before the heap and no fixture
state can make it discriminate.

Every candidate meant to survive the size guard is funded between 300 and 2000 sat/byte, well
above both floors: the flat absolute floor (`GetMinFee` with `nBytes = 0` is `MIN_TX_FEE * 10`,
applied in the loop and again inside `ConnectInputs`) and the `-mintxfee` rate floor #3291
restored. 100 sat/byte would only match the rate floor; the flat floor needs about 520 sat/byte on
a minimal spend, and `MakeCandidate` asserts it. `addUnchecked` bypasses the size-scaled relay
floor that makes the rate floor inert for real traffic.

Not covered: the P2SH sigop leg, which needs a mined P2SH funding output because `FetchInputs`
with `fMiner` returns false for a mempool-only parent. The `-mintxfee` floor and the
`nTxFees < nMinFee` handler are covered at the functional level by `mining_fee_policy.py` (#3291)
and #3326.

### Consumers waiting on it

The trust-regression revert leg deferred on #3182 (the `reorganize` RPC bypasses `SetBestChain`),
and a chain-level reorg for the pool lifecycle tests, which today drive Apply/Revert against a
synthetic `CBlockIndex` stack. Both are follow-ups, not in this PR.

### Fixups since the first push

The first push was two commits. The five since, in order:

- **`7e9922a9f`** rescans the premine on every fixture construction, not only the first. This one
  is the mirror image of the others: the fixture did put its state back (the wallet restorer erases
  the coinbase entry), and the plant helper's rescan-on-first-add failed to rebuild it.
- **`13e112bd3`** restores `g_previous_block_time` with the rest of the chain tip. A suite that
  mines otherwise leaves it at a fresh block's time and every later suite believes the node is in
  sync.
- **`9c5ea55c0`** clears the miner status the fixture's mining leaves behind, which
  `interfaces_tests` pins false.
- **`02e75261e`** turns the premine helper's `assert(pwallet)` into `Assert()`. The bare assert
  tripped `test/lint/lint-assertions.sh`; worth knowing that check cannot fire on a fork push: the
  workflow sets `COMMIT_RANGE` from the pull-request event, which on a push expands to a bare
  `..`, and the script skips on that, so it only shows up here.
- **`a004cb4fb`** rewinds the fixture's committed blocks on teardown. `ChainTipRestorer` restored
  the in-memory chain but not what `SetBestChain` had written through `CTxDB` and
  `WriteHashBestChain`, so the next construction's `LoadBlockIndex()` read the previous suite's
  chain back and the fixture's own `nBestHeight == 0` precondition fired on it.

Every one of those except the assert fix is the same shape: state the fixture mutated and did not
put back (or, for the first, put back too well), harmless while it was the only consumer in the
binary and not harmless once a second suite ran either side of it. Link order decides whether
anything reads the leftovers, which is why the last one showed on the Windows cross-compile leg
and not under GCC. Its commit message carries a Boost `--random` seed that reproduces it on Linux
at the same line as that leg; that recipe names `chainman_reorg_tests`, the second consumer, which
lives on the follow-up branch rather than here, since from this PR's binary alone there is nothing
to read the leftovers.

**Testing.** Unit suite (including the new `miner_block_assembly_tests`) and the full functional
suite pass locally on the current head (the functional run with a local `boincdatadir=` conf
workaround for this machine's distro BOINC client, pending #3327).

https://claude.ai/code/session_01GtjiCGE4qYMeyrMgjt3QQc
