### PR TITLE
test, tally: cover the researcher's own research reward on regtest; stop the newbie correction dereferencing a missing accrual baseline

### DIFF
--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1275,6 +1275,12 @@ CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const Supe
     }
 
     const CBlockIndex* pindex_baseline = GRC::Tally::GetBaseline();
+    // GetBaseline() is null until snapshot accrual has a baseline, which on a
+    // fresh chain (regtest) it never gets; there is no history to correct then.
+    if (!pindex_baseline) {
+        LogPrint(BCLog::LogFlags::ACCRUAL, "INFO %s: no accrual baseline; no correction.", __func__);
+        return accrual;
+    }
 
     // Start at the tip.
     const CBlockIndex* pindex_high = mapBlockIndex[hashBestChain];
@@ -1291,7 +1297,9 @@ CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const Supe
     SuperblockPtr superblock;
     unsigned int period_num = 0;
 
-    while (pindex->nHeight >= pindex_baseline->nHeight)
+    // The walk steps pprev and re-tests the height, so it must also stop at the
+    // end of the chain: with the baseline at genesis, the step past genesis is null.
+    while (pindex && pindex->nHeight >= pindex_baseline->nHeight)
     {
         if (pindex->IsSuperblock())
         {

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -116,13 +116,21 @@ this table mirrors it.
 | `feature_stakelimit.py` | background staker honors + resumes the `stakelimit` height ceiling | wall-clock bound (~16s/block via `STAKE_TIMESTAMP_MASK`) |
 | `feature_reorg.py` | two-node divergent chains + reorg on connect | flaky on shared-premine regtest (duplicate coinstake kernel); see note in `test_runner.py` |
 
-### Deferred to Phase 4B (need the synthetic beacon + RSA trust anchor, 2B.3/2B.4)
+### Researcher flows (Phase 4B)
 
-`feature_beacon_inject.py`, `feature_superblock_inject.py` (also needs
-`generatesuperblock` un-stubbed), `feature_mrc.py`, and the beacon flavor of
-`feature_contract_replay.py`. These require an active regtest beacon/CPID, which
-investor-mode staking does not (see the staking path: `TrySignClaim` skips the
-beacon signature for non-crunchers).
+No RSA trust anchor is needed: a beacon advertised under `-forcecpid` is
+activated by a `generatesuperblock` call that names its public key (see
+`doc/regtest.md`). Landed so far, all in the default suite:
+
+| Test | Exercises |
+|---|---|
+| `feature_generatesuperblock.py` | explicit superblock attach (the former `feature_superblock_inject.py`) |
+| `feature_beacon_activation.py` | beacon advertisement -> pending -> activated by a superblock (the former `feature_beacon_inject.py`) |
+| `feature_research_reward.py` | the activated CPID's own coinstake pays its accrued research subsidy; a pending beacon pays none |
+
+Still to write: `feature_mrc.py` (an MRC request paid by another node's
+coinstake) and the beacon flavor of `feature_contract_replay.py` (beacon state
+across a `reorganize`).
 
 ## Cherry-pick log (post-v0.21.2 utilities)
 

--- a/test/functional/feature_research_reward.py
+++ b/test/functional/feature_research_reward.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""A researcher's own coinstake pays its accrued research reward, on regtest.
+
+Continues where feature_beacon_activation.py stops. The claim in a staked block
+carries a research subsidy only when the staker's CPID has an ACTIVE beacon and
+positive accrual at the block's time (CreateGridcoinReward in miner.cpp: the
+subsidy is Tally::GetAccrual at block time, and a zero subsidy makes the miner
+stake the block as a non-cruncher). Accrual for a CPID that has never staked
+runs from the superblock that first carries it, at the superblock magnitude.
+
+Two blocks are staked by the -forcecpid node and their claims compared:
+
+  * with the beacon still PENDING (the superblock omitted it), the claim has no
+    CPID and a zero research subsidy -- the negative control;
+  * after a superblock activates the beacon at magnitude 100 and a day passes,
+    the claim names the CPID, its research subsidy is positive, and the
+    coinstake pays block subsidy plus research subsidy.
+
+Without the reward path the second block would look like the first, so the
+comparison is what discriminates.
+"""
+
+import os
+from decimal import Decimal
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal, assert_greater_than
+
+CPID = "00010203040506070809101112131415"
+
+# See feature_beacon_activation.py for both constants.
+STAKE_TIMESTAMP_MASK = 15
+SUPERBLOCK_SPACING = 43200
+
+# How long the activated CPID accrues before it stakes. Accrual is magnitude x
+# magnitude unit x time, so any positive span works; a day keeps the amount
+# comfortably above the coinstake's rounding.
+ACCRUAL_SPAN = 86400
+
+
+class ResearchRewardTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        self.extra_args = [[
+            "-staking=0",
+            "-devbuild=override",
+            "-connect=0",
+            "-listen=0",
+            f"-forcecpid={CPID}",
+        ]]
+
+    def setup_network(self):
+        # Same BOINC stub as feature_beacon_activation.py: the CPID comes from
+        # -forcecpid, and an empty client_state.xml keeps the host's BOINC out.
+        boinc_dir = os.path.join(self.options.tmpdir, "boinc")
+        os.makedirs(boinc_dir, exist_ok=True)
+        client_state_path = os.path.join(boinc_dir, "client_state.xml")
+        with open(client_state_path, "w", encoding="utf-8") as client_state:
+            client_state.write("<client_state>\n</client_state>\n")
+        self.extra_args[0].append(f"-boincdatadir={boinc_dir}")
+
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+
+    def advance_to_slot(self, node, seconds=64):
+        """Move mocktime forward onto a stake-timestamp boundary."""
+        tip_time = node.getblock(node.getbestblockhash())["time"]
+        slot = (tip_time + seconds) & ~STAKE_TIMESTAMP_MASK
+        node.setmocktime(slot)
+        return slot
+
+    def stake_one(self, node):
+        """Stake one block on the current slot and return its verbose getblock."""
+        node.generatetoaddress(1, node.getnewaddress())
+        return node.getblock(node.getbestblockhash(), True)
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        node.generatetoaddress(5, node.getnewaddress())
+
+        self.log.info("advertise the beacon and carry it in a block")
+        self.advance_to_slot(node)
+        advertised = node.advertisebeacon()
+        assert_equal(advertised["result"], "SUCCESS")
+        public_key = advertised["public_key"]
+        node.generatetoaddress(1, node.getnewaddress())
+        assert_equal(node.beaconstatus(CPID)["active"], [])
+
+        self.log.info("a superblock that omits the beacon leaves it pending")
+        self.advance_to_slot(node)
+        node.generatesuperblock({CPID: 100})
+        assert_equal(node.beaconstatus(CPID)["active"], [])
+
+        self.log.info("control: staking with a pending beacon pays no research reward")
+        self.advance_to_slot(node, ACCRUAL_SPAN)
+        control = self.stake_one(node)
+        control_claim = control["claim"]
+        assert control_claim["mining_id"] != CPID, control_claim
+        assert_equal(Decimal(control_claim["research_subsidy"]), Decimal(0))
+        block_subsidy = Decimal(control_claim["block_subsidy"])
+        assert_greater_than(block_subsidy, 0)
+
+        self.log.info("a superblock naming the beacon activates it")
+        self.advance_to_slot(node, SUPERBLOCK_SPACING + 600)
+        node.generatesuperblock({CPID: 100}, None, [public_key])
+        active = node.beaconstatus(CPID)["active"]
+        assert_equal(len(active), 1)
+        assert_equal(active[0]["magnitude"], 100)
+
+        # A day of accrual at magnitude 100 before the CPID stakes.
+        self.advance_to_slot(node, ACCRUAL_SPAN)
+
+        self.log.info("auditsnapshotaccrual survives a CPID with no accrual baseline")
+        # The RPC's newbie correction used to dereference a null tally baseline
+        # here (regtest never gets one) and take the node down with it. The
+        # return value is not inspected: on a chain this short the audit's
+        # history walk reports an empty object, which is the RPC's own gap.
+        node.auditsnapshotaccrual(CPID, False)
+        assert_greater_than(node.getblockcount(), 0)
+
+        self.log.info("the researcher's coinstake pays block subsidy plus research subsidy")
+        rewarded = self.stake_one(node)
+        claim = rewarded["claim"]
+        assert_equal(claim["mining_id"], CPID)
+        research_subsidy = Decimal(claim["research_subsidy"])
+        assert_greater_than(research_subsidy, 0)
+        assert_equal(Decimal(claim["block_subsidy"]), block_subsidy)
+
+        # getblock's "mint" is what the coinstake created beyond its input: with
+        # an empty mempool that is the block subsidy plus the research subsidy.
+        minted = Decimal(str(rewarded["mint"]))
+        assert_equal(minted, block_subsidy + research_subsidy)
+        assert_equal(Decimal(str(control["mint"])), block_subsidy)
+        self.log.info("coinstake minted %s = %s block + %s research",
+                      minted, block_subsidy, research_subsidy)
+
+
+if __name__ == "__main__":
+    ResearchRewardTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -198,6 +198,7 @@ BASE_SCRIPTS = [
     # in EXTENDED_SCRIPTS while it raced two stakers on the shared premine.
     'feature_reorg.py',
     'feature_beacon_activation.py',
+    'feature_research_reward.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since longer tests benefit from being scheduled


### PR DESCRIPTION
**Branch:** `test/research-reward-claim` @ `f7850207e`, stacked on #3334 (`test/beacon-activation`);
the first commits here are that PR and the last commit is this one.

Stacked on #3334 (beacon activation). The last commit is one of the remaining Phase 4B
researcher-flow tests (#2932 listed four; two had landed, and this one sits between them rather
than on that list), plus a crash it found on the way.

### The test

`feature_research_reward.py` picks up where `feature_beacon_activation.py` stops. The `-forcecpid`
node stakes twice:

1. with its beacon still **pending** (a superblock that omitted it): the claim carries no CPID
   and a zero research subsidy, and `getblock`'s `mint` is the block subsidy alone;
2. a day after a superblock **activates** it at magnitude 100: the claim names the CPID, the
   research subsidy is positive, and `mint` equals block subsidy plus research subsidy (10 + 25 GRC
   on the regtest parameters; the test pins the sum and the positivity, not the split).

Block 1 is the negative control. Without the reward path block 2 would look exactly like it, so
the comparison is what discriminates, not either block alone.

### The crash it found

`Tally::GetNewbieSuperblockAccrualCorrection` dereferences `Tally::GetBaseline()` without
checking it. On regtest snapshot accrual never gets a baseline (it is written only at
`BlockV11Height - 1`, and regtest's `BlockV11Height` is 0), so `auditsnapshotaccrual` for a CPID
with an active beacon was a null dereference: the node died with `SIGSEGV` (exit -11 from the
framework). The existing `rpc_audit_snapshot_accrual.py` never hit it because it only audits
unknown CPIDs.

Staking and validation are not affected on regtest. The correction has four callers and the
miner is not one of them: `BlockRewardRules::Check` and `ValidateMRC` (`validation.cpp`) call it
only from `GetOrigNewbieSnapshotFixHeight()` upward (mainnet 2104000, testnet 1393000),
`TallySuperblockAccrual` (`tally.cpp`) from `GetNewbieSnapshotFixHeight()` upward (2197000 /
1480000), and the RPC unconditionally. Regtest never reaches those heights. I checked that
directly: with the guard stashed, the reward blocks stake and validate; only the audit call
crashes. The dereference the crash reached is now guarded: with no baseline there is no history
to correct and the function returns the uncorrected accrual. A second, defensive guard on the
`pprev` walk is a no-op on every network (it would need `BlockV11Height == 1`). The same function
still indexes `mapBlockIndex[hashBestChain]` and rewinds `pindex_high->pprev` unguarded; neither
is on this path.

The test pins it with one `auditsnapshotaccrual` call for the activated CPID, result not
inspected: against the unguarded tree the call takes the node down, with the guard it returns.

### Not asserted, and why

`auditsnapshotaccrual` for that CPID returns an empty object on a chain this short: the RPC
already degrades to no result on a missing baseline (the guard #3084 added in `CaptureAuditPass`),
which is the same null baseline this crash is about, one function away. The test says so in a
comment rather than asserting on the shape.

### README

The Phase 4B section is rewritten: no RSA trust anchor is needed (the beacon PR established
that), `feature_generatesuperblock.py` and `feature_beacon_activation.py` are the former
`superblock_inject` / `beacon_inject` entries, this test is listed, and the two still to write
(`feature_mrc.py` and the beacon flavour of `feature_contract_replay.py`) are named.

**Testing.** Unit suite and the full functional suite pass locally on the head, with the new test
in the default suite. (The host has a distro BOINC install, so the rest of the suite ran with the
#3327 fix cherry-picked on top for the run, as on #3334; the new test sets `-boincdatadir` and
does not need it.)

https://claude.ai/code/session_01GtjiCGE4qYMeyrMgjt3QQc
