### PR TITLE
wallet, validation: tell the wallet when the mempool evicts its transaction

### DIFF
--- a/src/test/miner_block_assembly_tests.cpp
+++ b/src/test/miner_block_assembly_tests.cpp
@@ -503,6 +503,81 @@ BOOST_AUTO_TEST_CASE(a_size_limit_eviction_reaches_the_wallet)
     mempool.clear();
 }
 
+BOOST_AUTO_TEST_CASE(a_size_limit_eviction_signals_the_victims_descendants_too)
+{
+    mempool.clear();
+
+    struct SignalsForThisCase {
+        CScheduler m_scheduler;
+        SignalsForThisCase()
+        {
+            GetMainSignals().RegisterBackgroundSignalScheduler(m_scheduler);
+            RegisterValidationInterface(pwalletMain);
+        }
+        ~SignalsForThisCase()
+        {
+            UnregisterValidationInterface(pwalletMain);
+            GetMainSignals().UnregisterBackgroundSignalScheduler();
+        }
+    } signals;
+
+    struct MaxSizeRestorer {
+        size_t m_saved{mempool.GetMaxSize()};
+        ~MaxSizeRestorer() { mempool.SetMaxSize(m_saved); }
+    } max_size;
+
+    std::vector<std::pair<uint256, ChangeType>> seen;
+    boost::signals2::scoped_connection watch = pwalletMain->NotifyTransactionChanged.connect(
+        [&seen](CWallet*, const uint256& hash, ChangeType status) { seen.emplace_back(hash, status); });
+
+    // The parent takes the LOWEST feerate in the pool so the trim selects it as
+    // the primary victim; the child (spending the parent's in-pool output)
+    // rides a higher rate and is erased only through remove()'s recursive
+    // descendant branch -- the path whose signal this case pins.
+    const std::vector<COutPoint> coins = SpendablePremineOutputs();
+    BOOST_REQUIRE_GE(coins.size(), 2u);
+    CTransaction parent = CreateSpend(PremineCoinbase(), coins[0].n, 100000, 1);
+    CTransaction child = CreateSpend(parent, 0, 300000, 1);
+    BOOST_REQUIRE_GE(CAmount{100000}, GetMinFee(parent));
+    const uint256 parent_hash = parent.GetHash();
+    const uint256 child_hash = child.GetHash();
+
+    LOCK(cs_main);
+
+    CValidationState state_parent, state_child;
+    BOOST_REQUIRE_MESSAGE(AcceptToMemoryPool(mempool, parent, state_parent, nullptr),
+                          "parent rejected: " + state_parent.GetRejectReason());
+    BOOST_REQUIRE_MESSAGE(AcceptToMemoryPool(mempool, child, state_child, nullptr),
+                          "child rejected: " + state_child.GetRejectReason());
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE(pwalletMain->mapWallet.count(parent_hash));
+        BOOST_REQUIRE(pwalletMain->mapWallet.count(child_hash));
+    }
+
+    // Room for exactly what is in the pool now, so the next accept has to evict.
+    mempool.SetMaxSize(mempool.DynamicMemoryUsage());
+    const size_t seen_before = seen.size();
+
+    CAmount fee_third = 0;
+    CTransaction third = MakeCandidate(1, 1, 2000, fee_third);
+    CValidationState state_third;
+    BOOST_REQUIRE_MESSAGE(AcceptToMemoryPool(mempool, third, state_third, nullptr),
+                          "third spend rejected: " + state_third.GetRejectReason());
+    BOOST_REQUIRE_MESSAGE(!mempool.exists(parent_hash), "the size limit did not evict the parent");
+    BOOST_REQUIRE_MESSAGE(!mempool.exists(child_hash),
+                          "the recursive removal did not take the child with the parent");
+
+    for (const uint256& hash : {parent_hash, child_hash}) {
+        const auto notices = std::count_if(seen.begin() + seen_before, seen.end(),
+            [&](const std::pair<uint256, ChangeType>& e) { return e.first == hash && e.second == CT_UPDATED; });
+        BOOST_CHECK_MESSAGE(notices == 1,
+            "expected exactly one CT_UPDATED for " + hash.GetHex() + ", saw " + std::to_string(notices));
+    }
+
+    mempool.clear();
+}
+
 BOOST_AUTO_TEST_CASE(a_coinstake_in_the_mempool_is_never_selected)
 {
     mempool.clear();

--- a/src/test/miner_block_assembly_tests.cpp
+++ b/src/test/miner_block_assembly_tests.cpp
@@ -35,16 +35,24 @@
 #include "consensus/tx_verify.h"
 #include "gridcoin/cpid.h"
 #include "gridcoin/mrc.h"
+#include "init.h"
 #include "miner.h"
 #include "policy/fees.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
+#include "scheduler.h"
 #include "script/script.h"
 #include "test/chain_setup.h"
 #include "txmempool.h"
 #include "validation.h"
+#include "validationinterface.h"
+#include "wallet/wallet.h"
 
+#include <boost/signals2/connection.hpp>
 #include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <string>
 
 #include <map>
 #include <vector>
@@ -408,6 +416,93 @@ BOOST_AUTO_TEST_CASE(a_transaction_newer_than_the_block_is_skipped)
 //! heap, and no fixture state can change that -- the coinbase half of the guard
 //! has no reachable behaviour to pin.
 //!
+//!
+//! A size-limit eviction inside AcceptToMemoryPool reaches the wallet.
+//!
+//! Lives in this suite because it needs the same chain: AcceptToMemoryPool
+//! resolves inputs through the tx index, which only the fixture provides.
+//! The validation signals are inert in this binary until a scheduler is
+//! registered (chain_setup.cpp explains why), so the case registers one for
+//! its own duration; every signal used here is invoked synchronously, so the
+//! scheduler never has to run.
+//!
+//! Discriminates on the wallet's NotifyTransactionChanged for the EVICTED
+//! transaction after the second accept. Without the emission in
+//! AcceptToMemoryPool the wallet never hears about the eviction and no such
+//! notification exists; depth alone would not do, since it is derived live
+//! from mempool.exists() and reads -1 either way.
+//!
+BOOST_AUTO_TEST_CASE(a_size_limit_eviction_reaches_the_wallet)
+{
+    mempool.clear();
+
+    struct SignalsForThisCase {
+        CScheduler m_scheduler;
+        SignalsForThisCase()
+        {
+            GetMainSignals().RegisterBackgroundSignalScheduler(m_scheduler);
+            RegisterValidationInterface(pwalletMain);
+        }
+        ~SignalsForThisCase()
+        {
+            UnregisterValidationInterface(pwalletMain);
+            GetMainSignals().UnregisterBackgroundSignalScheduler();
+        }
+    } signals;
+
+    struct MaxSizeRestorer {
+        size_t m_saved{mempool.GetMaxSize()};
+        ~MaxSizeRestorer() { mempool.SetMaxSize(m_saved); }
+    } max_size;
+
+    std::vector<std::pair<uint256, ChangeType>> seen;
+    boost::signals2::scoped_connection watch = pwalletMain->NotifyTransactionChanged.connect(
+        [&seen](CWallet*, const uint256& hash, ChangeType status) { seen.emplace_back(hash, status); });
+
+    CAmount fee_first = 0, fee_second = 0;
+    CTransaction first = MakeCandidate(0, 1, 2000, fee_first);
+    CTransaction second = MakeCandidate(1, 1, 2000, fee_second);
+    const uint256 first_hash = first.GetHash();
+
+    LOCK(cs_main);
+
+    CValidationState state_first;
+    BOOST_REQUIRE_MESSAGE(AcceptToMemoryPool(mempool, first, state_first, nullptr),
+                          "first spend rejected: " + state_first.GetRejectReason());
+    BOOST_REQUIRE(mempool.exists(first_hash));
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE_MESSAGE(pwalletMain->mapWallet.count(first_hash),
+                              "the wallet did not pick up its own spend from the add signal");
+    }
+
+    // Room for exactly what is in the pool now, so the next accept has to evict.
+    mempool.SetMaxSize(mempool.DynamicMemoryUsage());
+    const size_t seen_before = seen.size();
+
+    CValidationState state_second;
+    BOOST_REQUIRE_MESSAGE(AcceptToMemoryPool(mempool, second, state_second, nullptr),
+                          "second spend rejected: " + state_second.GetRejectReason());
+    BOOST_REQUIRE(mempool.exists(second.GetHash()));
+    BOOST_REQUIRE_MESSAGE(!mempool.exists(first_hash), "the size limit did not evict the first spend");
+
+    const auto evicted_notice = std::count_if(seen.begin() + seen_before, seen.end(),
+        [&](const std::pair<uint256, ChangeType>& e) { return e.first == first_hash && e.second == CT_UPDATED; });
+    BOOST_CHECK_MESSAGE(evicted_notice == 1,
+        "expected exactly one CT_UPDATED for the evicted tx, saw " + std::to_string(evicted_notice));
+
+    // Eviction is not a conflict: the state is untouched and depth reads -1 live.
+    {
+        LOCK(pwalletMain->cs_wallet);
+        const CWalletTx& wtx = pwalletMain->mapWallet.at(first_hash);
+        BOOST_CHECK(wtx.isInMempool());
+        BOOST_CHECK(!wtx.isInactive());
+        BOOST_CHECK_EQUAL(wtx.GetDepthInMainChain(), -1);
+    }
+
+    mempool.clear();
+}
+
 BOOST_AUTO_TEST_CASE(a_coinstake_in_the_mempool_is_never_selected)
 {
     mempool.clear();

--- a/src/test/miner_block_assembly_tests.cpp
+++ b/src/test/miner_block_assembly_tests.cpp
@@ -575,6 +575,15 @@ BOOST_AUTO_TEST_CASE(a_size_limit_eviction_signals_the_victims_descendants_too)
             "expected exactly one CT_UPDATED for " + hash.GetHex() + ", saw " + std::to_string(notices));
     }
 
+    // Leave no wallet residue: later cases in this suite assert preconditions
+    // on the wallet's resend-candidate set, and the evicted entries here are
+    // exactly that shape (in-mempool tag, absent from the pool).
+    {
+        LOCK(pwalletMain->cs_wallet);
+        pwalletMain->EraseFromWallet(parent_hash);
+        pwalletMain->EraseFromWallet(child_hash);
+        pwalletMain->EraseFromWallet(third.GetHash());
+    }
     mempool.clear();
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -137,7 +137,8 @@ void CTxMemPool::eraseIndexes(const CTxMemPoolEntry& entry)
 }
 
 
-bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive, MemPoolRemovalReason reason)
+bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive, MemPoolRemovalReason reason,
+                        std::vector<CTransaction>* removed_out)
 {
     // NOTE: `reason` is threaded through (including into the recursive call below)
     // as groundwork for a future TransactionRemovedFromMempool validation signal.
@@ -159,9 +160,11 @@ bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive, MemPoolRemovalR
                 for (unsigned int i = 0; i < tx.vout.size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
                     if (it != mapNextTx.end())
-                        remove(*it->second.ptx, true, reason);
+                        remove(*it->second.ptx, true, reason, removed_out);
                 }
             }
+            // Copy before the erase below invalidates the entry's storage.
+            if (removed_out) removed_out->push_back(entry_it->second.GetTx());
             // Tear down the secondary indexes before erasing the entry.
             eraseIndexes(entry_it->second);
             for (auto const& txin : tx.vin)
@@ -226,11 +229,12 @@ void CTxMemPool::TrimToSize(size_t limit, std::vector<CTransaction>* removed,
         }
 
         const CTransaction victim = it->second.GetTx();
-        if (removed) removed->push_back(victim);
 
         // Route through remove() so every index (and the running size total)
-        // stays consistent. Recursive so dependents go too.
-        remove(victim, /*fRecursive=*/true, MemPoolRemovalReason::SIZELIMIT);
+        // stays consistent. Recursive so dependents go too, and the collector
+        // is threaded through so descendants are reported alongside the
+        // victim -- their removal signals must not be silently dropped.
+        remove(victim, /*fRecursive=*/true, MemPoolRemovalReason::SIZELIMIT, removed);
     }
 }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -194,8 +194,13 @@ public:
     //! every other mutator here; "unchecked" refers to transaction validation,
     //! which the caller must have done (see AcceptToMemoryPool), not to locking.
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry);
+    //! \p removed_out, when non-null, receives a copy of every transaction this
+    //! call erases -- the named transaction and, with \p fRecursive, its in-pool
+    //! descendants -- so callers that emit removal signals can cover the whole
+    //! set instead of only the entry they named.
     bool remove(const CTransaction &tx, bool fRecursive = false,
-                MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
+                MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN,
+                std::vector<CTransaction>* removed_out = nullptr);
     bool removeConflicts(const CTransaction &tx);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
@@ -217,8 +222,10 @@ public:
     //! self-evicted (which, given Gridcoin's flat feerate and the newest-first
     //! tie-break, it otherwise always would be), while the pool still stays bounded.
     //!
-    //! \p removed, when non-null, receives the primary victims chosen here; it does
-    //! NOT include transactions dropped as recursive descendants of a victim.
+    //! \p removed, when non-null, receives every transaction the trim erases:
+    //! the victims chosen here AND their in-pool descendants, which remove()
+    //! drops recursively -- a wallet child spending an evicted parent's change
+    //! must see the same removal signal as the parent.
     void TrimToSize(size_t limit, std::vector<CTransaction>* removed = nullptr,
                     const uint256* protect = nullptr);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2339,8 +2339,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
         // entry_time is non-zero only when reloading from unbroadcast.dat: preserve
         // the original pool-entry time so tx age and eviction ordering survive a
         // restart. In practice this only affects the node's non-wallet reloaded txs;
-        // a wallet tx is re-pooled with a fresh time by ReacceptWalletTransactions
-        // before LoadUnbroadcast runs, so its persisted time is not applied.
+        // a wallet tx is re-pooled with a fresh time during the startup re-accept
+        // pass (ReacceptWalletTransactions resolves the reloaded state through a
+        // re-accept that reaches this function with entry_time 0), which init runs
+        // before LoadUnbroadcast, so its persisted time is not applied.
         CTxMemPoolEntry entry(tx, nFees, entry_time != 0 ? entry_time : GetAdjustedTime(),
                               nBestHeight, nSize);
         pool.addUnchecked(hash, entry);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2324,6 +2324,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
 
     // Store transaction in memory
     CTransactionRef replaced_tx; // copy of the replaced tx, captured before remove() frees it
+    std::vector<CTransaction> evicted; // what TrimToSize removed to make room, signalled below
     {
         LOCK(pool.cs);
         if (ptxOld)
@@ -2352,7 +2353,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
         // this transaction alone exceeds it -- only possible with an unreasonably
         // small -maxmempool, which the init-time floor already rejects; treat that
         // as a "mempool full" rejection.
-        pool.TrimToSize(pool.GetMaxSize(), /*removed=*/nullptr, /*protect=*/&hash);
+        pool.TrimToSize(pool.GetMaxSize(), &evicted, /*protect=*/&hash);
         if (!pool.exists(hash)) {
             return state.Invalid(error("AcceptToMemoryPool : transaction %s rejected, mempool full",
                                        hash.ToString()),
@@ -2365,6 +2366,16 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
     // 0 confirmations. Emitted synchronously under cs_main (held on entry),
     // preserving the cs_main -> signals -> cs_wallet order.
     GetMainSignals().TransactionAddedToMempool(MakeTransactionRef(tx));
+
+    // Then the transactions TrimToSize evicted to make room for it. Emitted from
+    // here, like the add above, rather than from CTxMemPool::remove(): the pool
+    // lock is released, so the wallet slot can take cs_wallet in the usual
+    // cs_main -> signals -> cs_wallet order, and remove()'s other callers (block
+    // connection, conflicts) keep their own, narrower notifications.
+    for (const CTransaction& victim : evicted) {
+        GetMainSignals().TransactionRemovedFromMempool(MakeTransactionRef(victim),
+                                                       MemPoolRemovalReason::SIZELIMIT);
+    }
 
     ///// are we sure this is ok when loading transactions or restoring block txes
     // If updated, erase old tx from wallet

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1473,8 +1473,9 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef& tx,
 
     // Handle removal based on the reason
     // Only mark as inactive/conflicted for genuine conflicts and replacements.
-    // Transactions evicted for size limits or expiry are still valid and can be
-    // retried — they will be picked up by ReacceptWalletTransactions.
+    // Transactions evicted for size limits or expiry are still valid and keep
+    // their in-mempool tag, which makes them resend candidates (depth reads -1
+    // live once the pool no longer holds them).
     switch (reason) {
         case MemPoolRemovalReason::CONFLICT:
         case MemPoolRemovalReason::REPLACED:

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1489,13 +1489,17 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef& tx,
 
         case MemPoolRemovalReason::EXPIRY:
         case MemPoolRemovalReason::SIZELIMIT:
-            // Transaction is still valid, just evicted from mempool.
-            // Don't mark as conflicted — ReacceptWalletTransactions will
-            // attempt to re-accept it on the next pass.
+            // Still valid, just evicted: the state stays TxStateInMempool. Depth
+            // is derived live from mempool.exists(), so it already reads -1, and
+            // that is exactly the state the scheduled ResendWalletTransactions()
+            // re-announces. Only the GUI needs telling now rather than at the
+            // next tip refresh: a row that has aged into Offline is a terminal
+            // status in WalletTxStore and is not re-derived on its own.
             LogPrint(BCLog::LogFlags::VERBOSE,
                     "CWallet::TransactionRemovedFromMempool: tx %s evicted (reason: %d), "
-                    "not marking conflicted - eligible for re-acceptance\n",
+                    "not marking conflicted - left for rebroadcast\n",
                     hash.ToString(), static_cast<int>(reason));
+            NotifyTransactionChanged(this, hash, CT_UPDATED);
             break;
 
         case MemPoolRemovalReason::REORG:

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1498,7 +1498,7 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef& tx,
             // status in WalletTxStore and is not re-derived on its own.
             LogPrint(BCLog::LogFlags::VERBOSE,
                     "CWallet::TransactionRemovedFromMempool: tx %s evicted (reason: %d), "
-                    "not marking conflicted - left for rebroadcast\n",
+                    "not marking conflicted; in-mempool state kept",
                     hash.ToString(), static_cast<int>(reason));
             NotifyTransactionChanged(this, hash, CT_UPDATED);
             break;

--- a/src/wallet/wallet_tx_source.cpp
+++ b/src/wallet/wallet_tx_source.cpp
@@ -199,7 +199,9 @@ void WalletTxSourceImpl::onTransactionChanged(CWallet* wallet, const uint256& ha
     // Invoked via the weak_ptr-locking lambda in subscribe(), on the emitting
     // core thread, under the cs_main + cs_wallet the emitter already holds (all
     // CT_NEW/CT_UPDATED callsites: AddToWallet / CommitTransaction /
-    // WalletUpdateSpent). The analyzer cannot see those locks across the signals2
+    // WalletUpdateSpent / TransactionRemovedFromMempool's SIZELIMIT arm, which
+    // takes cs_wallet itself under ATMP's cs_main). The analyzer cannot see
+    // those locks across the signals2
     // dispatch, hence NO_THREAD_SAFETY_ANALYSIS; the AssertLockHeld() calls below
     // enforce the contract at runtime under DEBUG_LOCKORDER, exactly as the prior
     // EXCLUSIVE_LOCKS_REQUIRED annotation did for the analyzer.


### PR DESCRIPTION
Stacked on #3333 (the #3290 chain fixture); the first commits here are that PR. The last three
commits are this change: mine, then the two maintainer review commits (`31c9ef35a`, which signals
a size-limit victim's in-pool descendants too, and `4daaa4b00`, test cleanup plus the switch-header
comment).

`CWallet::TransactionRemovedFromMempool` exists, is registered, and handles every
`MemPoolRemovalReason`. Exactly one thing in the tree emits the signal: the
`cancelunbroadcasttransaction` RPC (`wallet/rpcwallet.cpp`, added in #3252). A transaction
evicted by `CTxMemPool::TrimToSize` (size limit) leaves the pool without the wallet hearing about
it. #3220 recorded the gap as out of scope (it merged after #3252 had added that one emission, so
the sentence was already one site out of date):

> Mempool ejection flipping depth 0 → −1 has no wallet signal anywhere (`TransactionRemovedFromMempool` has no emission site in the tree) — pre-existing blind spot, out of scope here.

### Why not emit from `remove()`

The note in `txmempool.cpp` (mine, from #3252) rejects that:

> Emitting from here instead would fire on every caller -- block connection, conflicts, reorgs -- which is a far broader behavioural change than that RPC needed, so it was deliberately left to the caller.

That reasoning still holds, and there is a lock-order reason on top of it: the wallet slot takes
`cs_wallet`, and `remove()` runs under `mempool.cs`. So the emission happens where
`TransactionAddedToMempool` and `TransactionReplacedInMempool` already happen, in
`AcceptToMemoryPool` under `cs_main` after the pool scope closes.

### The change

- `AcceptToMemoryPool` passes `TrimToSize` its optional `removed` vector and, after the pool scope
  closes, emits `TransactionRemovedFromMempool(SIZELIMIT)` for each victim, right after the
  existing `TransactionAddedToMempool` emission. That is the only eviction path today:
  `TrimToSize` is the sole caller of `remove()` with `SIZELIMIT`, and nothing removes with
  `EXPIRY` (no expiry sweep) or `REORG` (reorgs go through `BlockDisconnected`), so those arms stay
  unemitted and untouched. Since `31c9ef35a` the vector carries every transaction `remove()`
  erased for a victim, its in-pool descendants included, not only the victim itself.
- The wallet's `SIZELIMIT` / `EXPIRY` arm keeps the state as it is and now calls
  `NotifyTransactionChanged(this, hash, CT_UPDATED)`, the way `WalletUpdateSpent` does for a
  spent-flag change. Emitting into the arm as it was would have changed nothing observable.
- The arm's comment is corrected. It said "ReacceptWalletTransactions will attempt to re-accept
  it on the next pass"; that runs at startup and on the import/rescan RPCs, never re-pools an
  entry already tagged in-mempool, and on development today marks such a transaction conflicted
  (#3331 changes that for the import paths). The real recovery path is the scheduled
  `ResendWalletTransactions`, which handles exactly this state: unconfirmed and not in the
  mempool, depth -1, derived live from `mempool.exists()`. The switch-header comment above the
  arm said the same wrong thing and `4daaa4b00` finishes it.

### What it changes, honestly

Not much on the wallet side, which is why it is written down. An evicted own transaction was
already recoverable without any signal: depth reads -1 the moment it is evicted, and rebroadcast
picks that up. What the signal adds:

- the GUI hears about the eviction at eviction time rather than at the next tip advance, which
  is the one case it cannot self-correct today: a row that has already aged into `Offline`
  (`wallet/transactionrecord.cpp`: older than two minutes with no request count) is a terminal
  status in `WalletTxStore` and stops being re-derived on tip refresh;
- the eviction log line the handler already had starts appearing (under `-debug=verbose`), so a
  "stuck unconfirmed" send has a log to point at;
- the `SIZELIMIT` arm stops being dead code. `EXPIRY` still has no emitter, and the two existing
  unit cases for these arms set the state by hand and assert it rather than going through the
  signal, so they pin nothing about emission; routing them through the signal is a follow-up.

### The pin

`a_size_limit_eviction_reaches_the_wallet`, in `miner_block_assembly_tests` because it needs the
#3290 chain: `AcceptToMemoryPool` resolves inputs through the tx index. The validation signals
are inert in the test binary until a scheduler is registered, so the case registers one for its
own duration (every signal it uses is invoked synchronously, so the scheduler never runs). It
accepts one premine spend, requires the wallet picked it up from the add signal, caps the pool at
its current size, accepts a second, and requires exactly one `CT_UPDATED` for the evicted
transaction, with its state still `TxStateInMempool` at depth -1.

Run against the tree with the two source changes stashed, the whole suite file fails at that one
case and nowhere else. Depth alone would not discriminate: it reads -1 either way. `31c9ef35a`
adds the descendant case beside it, pinned the same way (without the threading, exactly its
assertion fails with "saw 0").

**Testing.** Unit suite (including the fixture suite) and the full functional suite pass locally
on the head.

https://claude.ai/code/session_01GtjiCGE4qYMeyrMgjt3QQc
