### PR TITLE
test, tally: cover beacon contract state across a reorganize; survive disconnecting the first superblock on a fresh chain

### DIFF
--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -1509,6 +1509,18 @@ public:
     //!
     bool ApplyLatest(ResearchAccountMap& accounts) const
     {
+        // No snapshot left to apply. That is the state of a fresh chain whose
+        // first superblock was just disconnected: nothing was ever stored
+        // before it, and there is no baseline to fall back to. The
+        // pre-superblock state is no snapshot accrual for anyone, so restore
+        // that rather than trying to open a snapshot at height 0.
+        if (m_registry.LatestHeight() == 0) {
+            LogPrint(LogFlags::TALLY, "Tally: no accrual snapshot to apply; clearing snapshot accrual.");
+            for (auto& account_pair : accounts) {
+                account_pair.second.m_accrual = 0;
+            }
+            return true;
+        }
         return Apply(m_registry.LatestHeight(), accounts);
     }
 

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -128,9 +128,7 @@ activated by a `generatesuperblock` call that names its public key (see
 | `feature_beacon_activation.py` | beacon advertisement -> pending -> activated by a superblock (the former `feature_beacon_inject.py`) |
 | `feature_research_reward.py` | the activated CPID's own coinstake pays its accrued research subsidy; a pending beacon pays none |
 | `feature_mrc.py` | two nodes: the researcher's MRC request is paid by the investor node's coinstake to the beacon address |
-
-Still to write: the beacon flavor of `feature_contract_replay.py` (beacon state
-across a `reorganize`).
+| `feature_contract_replay.py` | beacon contract state across `reorganize`: activation reverted, advertisement reverted and resurrected, replayed and re-activated |
 
 ## Cherry-pick log (post-v0.21.2 utilities)
 

--- a/test/functional/feature_contract_replay.py
+++ b/test/functional/feature_contract_replay.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""Beacon contract state across a reorganization, on regtest.
+
+The beacon registry is driven by two kinds of block event: a beacon
+advertisement contract (ADD) carried by an ordinary block, and a superblock
+whose verified-beacon list activates a pending beacon. Both have inverses that
+BlockDisconnect runs (BeaconRegistry::Revert for the contract,
+BeaconRegistry::Deactivate for the superblock), and the disconnected
+advertisement is resurrected into the mempool like any other transaction.
+
+The regtest `reorganize` RPC rolls the chain back to a given hash, so the
+sequence advertise -> activate -> roll back one block -> roll back another ->
+mine again -> activate again walks every one of those transitions:
+
+  * rolling back the superblock returns the beacon to PENDING;
+  * rolling back the advertisement removes it entirely;
+  * the identical advertisement transaction is accepted again, the next block
+    replays it (same public key), and a new superblock activates it again.
+
+Each step asserts the state that only its inverse (or its replay) produces, so
+a missing Revert, a missing Deactivate, or a registry that refuses the replayed
+contract each fails a different line.
+
+Observed and not asserted either way: the disconnected advertisement does not
+come back into the mempool on its own (the mempool is empty after the second
+roll-back), so the replay resubmits the transaction's own bytes.
+"""
+
+import os
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+CPID = "00010203040506070809101112131415"
+
+# See feature_beacon_activation.py.
+STAKE_TIMESTAMP_MASK = 15
+
+
+class ContractReplayTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        self.extra_args = [[
+            "-staking=0",
+            "-devbuild=override",
+            "-connect=0",
+            "-listen=0",
+            f"-forcecpid={CPID}",
+        ]]
+
+    def setup_network(self):
+        boinc_dir = os.path.join(self.options.tmpdir, "boinc")
+        os.makedirs(boinc_dir, exist_ok=True)
+        client_state_path = os.path.join(boinc_dir, "client_state.xml")
+        with open(client_state_path, "w", encoding="utf-8") as client_state:
+            client_state.write("<client_state>\n</client_state>\n")
+        self.extra_args[0].append(f"-boincdatadir={boinc_dir}")
+
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+
+    def advance_to_slot(self, node, seconds=128):
+        """Move mocktime forward onto a stake-timestamp boundary past the tip.
+
+        After a roll-back the tip is older than the clock, so the slot is
+        taken from the tip rather than from the clock, and far enough ahead
+        that a resurrected transaction built at an earlier slot is not newer
+        than the block that carries it back.
+        """
+        tip_time = node.getblock(node.getbestblockhash())["time"]
+        slot = (tip_time + seconds) & ~STAKE_TIMESTAMP_MASK
+        node.setmocktime(slot)
+        return slot
+
+    def beacon_status(self, node):
+        status = node.beaconstatus(CPID)
+        return status["active"], status["pending"]
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        node.generatetoaddress(5, node.getnewaddress())
+        base_hash = node.getbestblockhash()
+        base_height = node.getblockcount()
+
+        self.log.info("advertise the beacon; a block carries it (pending)")
+        self.advance_to_slot(node)
+        advertised = node.advertisebeacon()
+        assert_equal(advertised["result"], "SUCCESS")
+        public_key = advertised["public_key"]
+        assert_equal(len(node.getrawmempool()), 1)
+        advert_txid = node.getrawmempool()[0]
+        advert_hex = node.getrawtransaction(advert_txid)
+        node.generatetoaddress(1, node.getnewaddress())
+        advert_hash = node.getbestblockhash()
+        active, pending = self.beacon_status(node)
+        assert_equal(active, [])
+        assert_equal([p["public_key"] for p in pending], [public_key])
+
+        self.log.info("a superblock naming the beacon activates it")
+        self.advance_to_slot(node)
+        node.generatesuperblock({CPID: 100}, None, [public_key])
+        assert_equal(node.getblockcount(), base_height + 2)
+        active, pending = self.beacon_status(node)
+        assert_equal(pending, [])
+        assert_equal([a["public_key"] for a in active], [public_key])
+
+        self.log.info("roll back the superblock: the beacon is pending again")
+        assert_equal(node.reorganize(advert_hash)["RollbackChain"], True)
+        assert_equal(node.getbestblockhash(), advert_hash)
+        active, pending = self.beacon_status(node)
+        assert_equal(active, [])
+        assert_equal([p["public_key"] for p in pending], [public_key])
+
+        self.log.info("roll back the advertisement: the beacon is gone")
+        assert_equal(node.reorganize(base_hash)["RollbackChain"], True)
+        assert_equal(node.getbestblockhash(), base_hash)
+        active, pending = self.beacon_status(node)
+        assert_equal(active, [])
+        assert_equal(pending, [])
+        assert_equal(node.getrawmempool(), [])
+
+        self.log.info("the identical advertisement is accepted again and replayed by the next block")
+        assert_equal(node.sendrawtransaction(advert_hex), advert_txid)
+        assert_equal(node.getrawmempool(), [advert_txid])
+        self.advance_to_slot(node)
+        node.generatetoaddress(1, node.getnewaddress())
+        assert_equal(node.getrawmempool(), [])
+        assert_equal(node.getblockcount(), base_height + 1)
+        assert node.getbestblockhash() != advert_hash
+        active, pending = self.beacon_status(node)
+        assert_equal(active, [])
+        assert_equal([p["public_key"] for p in pending], [public_key])
+
+        self.log.info("a new superblock activates the replayed beacon")
+        self.advance_to_slot(node)
+        node.generatesuperblock({CPID: 100}, None, [public_key])
+        active, pending = self.beacon_status(node)
+        assert_equal(pending, [])
+        assert_equal([a["public_key"] for a in active], [public_key])
+        assert_equal(active[0]["magnitude"], 100)
+
+
+if __name__ == "__main__":
+    ContractReplayTest().main()

--- a/test/functional/feature_contract_replay.py
+++ b/test/functional/feature_contract_replay.py
@@ -24,9 +24,12 @@ Each step asserts the state that only its inverse (or its replay) produces, so
 a missing Revert, a missing Deactivate, or a registry that refuses the replayed
 contract each fails a different line.
 
-Observed and not asserted either way: the disconnected advertisement does not
-come back into the mempool on its own (the mempool is empty after the second
-roll-back), so the replay resubmits the transaction's own bytes.
+Whether the disconnected advertisement comes back into the mempool on its own
+is not asserted either way: DisconnectBlocksBatch resurrects it once its
+re-acceptance runs after the disconnect batch commits, and before that fix
+the mempool is empty here. The replay resubmits the transaction's own bytes
+only when it has to; either way the identical transaction is what the next
+block carries.
 """
 
 import os
@@ -123,10 +126,10 @@ class ContractReplayTest(GridcoinTestFramework):
         active, pending = self.beacon_status(node)
         assert_equal(active, [])
         assert_equal(pending, [])
-        assert_equal(node.getrawmempool(), [])
 
         self.log.info("the identical advertisement is accepted again and replayed by the next block")
-        assert_equal(node.sendrawtransaction(advert_hex), advert_txid)
+        if advert_txid not in node.getrawmempool():
+            assert_equal(node.sendrawtransaction(advert_hex), advert_txid)
         assert_equal(node.getrawmempool(), [advert_txid])
         self.advance_to_slot(node)
         node.generatetoaddress(1, node.getnewaddress())

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -200,6 +200,7 @@ BASE_SCRIPTS = [
     'feature_beacon_activation.py',
     'feature_research_reward.py',
     'feature_mrc.py',
+    'feature_contract_replay.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since longer tests benefit from being scheduled


### PR DESCRIPTION
Stacked on #3337; the last two commits are this PR. The last of the three remaining Phase 4B
researcher-flow tests, and with it nothing from the former "Deferred to Phase 4B" list is left to
write.

### The test

`feature_contract_replay.py`, one `-forcecpid` node, using the regtest `reorganize` RPC:

1. advertise a beacon; a block carries it (pending);
2. a superblock naming its key activates it;
3. roll back the superblock: the beacon is **pending** again (`BeaconRegistry::Deactivate`);
4. roll back the advertisement: the beacon is **gone** (`BeaconRegistry::Revert`);
5. put the advertisement's own bytes back in the mempool — resubmitted with `sendrawtransaction`
   when the roll-back did not resurrect it — and assert it is accepted, the next block carries
   it, pending with the **same public key** (acceptance consults only *active* beacons, so the
   pending-revert itself is pinned by step 4's assertion, not by this acceptance);
6. a new superblock activates it again, magnitude 100.

Each step asserts the state that only its inverse or its replay produces, so a missing
`Deactivate`, a missing `Revert`, or a registry that refuses the replayed contract each fails a
different line.

### The fatal path it found

Step 3 killed the node on the unfixed tree. `RevertSuperblock` drops the superblock's accrual
snapshot and then applies the latest remaining one. On a fresh chain there is none, and there is
no baseline snapshot either, so `ApplyLatest` tried to open a snapshot at height 0, failed, and
`DisconnectBlocksBatch` treated that as chain corruption: "This is a fatal error. The chain index
may be corrupt. Aborting." The `reorganize` call hung past the RPC timeout and the node was gone
when the test looked for it (`ReorganizeChain` calls `exit(1)` on that path). Any reorganization
across the first superblock of a regtest chain was therefore fatal, which is also a wall in front
of the `feature_reorg.py` rewrite.

`ApplyLatest` now recognises an empty registry as the pre-superblock state and clears snapshot
accrual for every account instead of opening a file that cannot exist. The test pins that the
beacon survives the roll-back, not the clearing itself. On mainnet and testnet the registry holds
the baseline snapshot written at the V11 threshold below every superblock, and
`RevertSuperblock`'s `Drop` removes only the reverted superblock's own snapshot, so `ApplyLatest`
always finds one there and the branch is never taken.

Run against the tree with that change stashed, step 3 fails exactly as described; with it, the
test passes. Unit suite and full functional suite pass on the fixed tree.

### Step 5 does not assert either behaviour

This section previously recorded that the disconnected advertisement is **not** in the mempool
after the roll-back in step 4, with nothing in the log to say why the re-acceptance had not landed.
Chasing that turned into #3339: `DisconnectBlocksBatch` ran the resurrect loop before the
disconnect batch was committed, so `AcceptToMemoryPool` — which opens its own `CTxDB` and therefore
sees only committed state — refused every transaction, silently.

Step 5 has since been made tolerant of both behaviours (`e5862e8a7`): it takes the advertisement
from the mempool when it is there and resubmits its bytes when it is not, and either way the
identical transaction is what the next block carries. So this PR passes whether or not #3339 is in
the tree, and neither PR has to merge first.

**Testing.** Unit suite and the full functional suite pass locally on the head, with the new test
in the default suite. (The host has a distro BOINC install, so the rest of the suite ran with the
#3327 `boincdatadir` workaround; both new tests plant their own stub and do not need it.)

https://claude.ai/code/session_01GtjiCGE4qYMeyrMgjt3QQc

