### PR TITLE
node: resurrect disconnected transactions after the disconnect batch commits

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -175,9 +175,12 @@ protected:
         std::string unused;
 
         if (activeBatch) {
+            // A pending Delete for this key has to answer "absent" without
+            // falling through to the disk copy, which is still there until
+            // the batch commits. Read() below already treats it that way.
             bool deleted;
-            if (ScanBatch(ssKey, &unused, &deleted) && !deleted) {
-                return true;
+            if (ScanBatch(ssKey, &unused, &deleted)) {
+                return !deleted;
             }
         }
 

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -191,7 +191,16 @@ static bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, u
     /* fix up after disconnecting, prepare for new blocks */
     if (cnt_dis > 0)
     {
+        if (!txdb.TxnCommit())
+            return error("DisconnectBlocksBatch: TxnCommit failed"); /*fatal*/
+
         // Resurrect memory transactions that were in the disconnected branch.
+        //
+        // This must run after the commit above. AcceptToMemoryPool opens its own
+        // read-only CTxDB, which sees only committed state: with the disconnect
+        // batch still pending, the transaction's own index entry is still on
+        // disk (so ContainsTx refuses it) and its inputs are still marked spent.
+        // Every resurrection was silently refused that way.
         // Note: these are re-accepted but NOT re-added to the unbroadcast set --
         // provenance ("was this ours?") is not tracked here. A locally-originated
         // non-wallet tx (e.g. sendrawtransaction/HTLC) that had briefly confirmed
@@ -200,11 +209,14 @@ static bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, u
         // ResendWalletTransactions. Acceptable given how rare a same-tx reorg is.
         for( CTransaction& tx : vResurrect) {
             CValidationState resurrect_state;
-            AcceptToMemoryPool(mempool, tx, resurrect_state, nullptr);
+            bool missing_inputs = false;
+            if (!AcceptToMemoryPool(mempool, tx, resurrect_state, &missing_inputs)) {
+                LogPrint(BCLog::LogFlags::MEMPOOL, "%s: transaction %s not resurrected%s%s",
+                         __func__, tx.GetHash().ToString(),
+                         missing_inputs ? ": missing inputs" : "",
+                         resurrect_state.GetRejectReason().empty() ? "" : ": " + resurrect_state.GetRejectReason());
+            }
         }
-
-        if (!txdb.TxnCommit())
-            return error("DisconnectBlocksBatch: TxnCommit failed"); /*fatal*/
 
         // Record new best height (the common block) in the registries that have a backing DB. This is important
         // to ensure that if the wallet is shutdown, on the next start, the contract replay (if any) is done from
@@ -454,16 +466,6 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                 }
             }
 
-            // Clean up spent outputs in wallet that are now not spent if mempool transactions erased above. This
-            // is ugly and heavyweight and should be replaced when the upstream wallet code is ported. Unlike the
-            // repairwallet rpc, this is silent.
-            if (!to_be_erased.empty()) {
-                int nMisMatchFound = 0;
-                CAmount nBalanceInQuestion = 0;
-
-                pwalletMain->FixSpentCoins(nMisMatchFound, nBalanceInQuestion);
-            }
-
             if (!txdb.WriteHashBestChain(pindex->GetBlockHash())) {
                 txdb.TxnAbort();
                 return error("%s: WriteHashBestChain failed", __func__);
@@ -472,6 +474,20 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_main)
             // Make sure it's successfully written to disk before changing memory structure
             if (!txdb.TxnCommit()) {
                 return error("%s: TxnCommit failed", __func__);
+            }
+
+            // Clean up spent outputs in wallet that are now not spent if mempool transactions erased above. This
+            // is ugly and heavyweight and should be replaced when the upstream wallet code is ported. Unlike the
+            // repairwallet rpc, this is silent.
+            //
+            // After the commit, deliberately: FixSpentCoins reads the tx index through its own CTxDB, which sees
+            // only committed state. Run before the commit it would not see this block's spends and would hand
+            // back every wallet output the block just consumed.
+            if (!to_be_erased.empty()) {
+                int nMisMatchFound = 0;
+                CAmount nBalanceInQuestion = 0;
+
+                pwalletMain->FixSpentCoins(nMisMatchFound, nBalanceInQuestion);
             }
 
             LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: cs_tx_val_commit_to_disk unlocked", __func__);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -135,6 +135,8 @@ add_executable(test_gridcoin
     # test binary alongside the sources above.
     ${CMAKE_SOURCE_DIR}/src/ipc/peercred.cpp
     ipc_peercred_tests.cpp
+    # CTxDB batch-consistent reads: Exists() against a pending Delete.
+    dbwrapper_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     rpchelpman_tests.cpp

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "dbwrapper.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <utility>
+
+// CTxDB reads inside an open batch are documented as consistent with the
+// batch: Read() consults the pending writes first and answers "absent" for a
+// key the batch deletes. Exists() has the same contract, and these cases hold
+// it to that in the one shape that matters: a key whose committed copy is
+// still on disk while the batch holds a Delete for it. That is exactly the
+// state of a transaction's index entry midway through DisconnectBlocksBatch.
+
+BOOST_AUTO_TEST_SUITE(dbwrapper_tests)
+
+BOOST_AUTO_TEST_CASE(exists_honours_a_batched_delete_of_a_committed_key)
+{
+    CTxDB txdb("r+");
+    std::pair<std::string, int> key("dbwrapper_tests", 1);
+    const int value = 42;
+
+    // Committed copy on disk.
+    BOOST_REQUIRE(txdb.WriteGenericSerializable(key, value));
+    BOOST_REQUIRE(txdb.ExistsGenericSerializable(key));
+
+    // Delete it inside a batch: the disk copy is still there, and Exists()
+    // used to fall through to it and report the key present.
+    BOOST_REQUIRE(txdb.TxnBegin());
+    BOOST_REQUIRE(txdb.EraseGenericSerializable(key));
+    BOOST_CHECK(!txdb.ExistsGenericSerializable(key));
+
+    int read_back = 0;
+    BOOST_CHECK(!txdb.ReadGenericSerializable(key, read_back));
+
+    // Abandoning the batch brings the committed copy back into view.
+    BOOST_REQUIRE(txdb.TxnAbort());
+    BOOST_CHECK(txdb.ExistsGenericSerializable(key));
+
+    BOOST_REQUIRE(txdb.EraseGenericSerializable(key));
+    BOOST_CHECK(!txdb.ExistsGenericSerializable(key));
+}
+
+// Pins the scanner's last-entry-wins order rather than the fix above: the old
+// fall-through also answered "absent" here, because nothing was on disk.
+BOOST_AUTO_TEST_CASE(exists_follows_a_key_written_then_deleted_in_one_batch)
+{
+    CTxDB txdb("r+");
+    std::pair<std::string, int> key("dbwrapper_tests", 2);
+    const int value = 7;
+
+    BOOST_REQUIRE(!txdb.ExistsGenericSerializable(key));
+
+    BOOST_REQUIRE(txdb.TxnBegin());
+    BOOST_REQUIRE(txdb.WriteGenericSerializable(key, value));
+    BOOST_CHECK(txdb.ExistsGenericSerializable(key));
+
+    // The scanner walks the whole batch, so the later Delete wins.
+    BOOST_REQUIRE(txdb.EraseGenericSerializable(key));
+    BOOST_CHECK(!txdb.ExistsGenericSerializable(key));
+    BOOST_REQUIRE(txdb.TxnAbort());
+
+    BOOST_CHECK(!txdb.ExistsGenericSerializable(key));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4566,6 +4566,21 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, bo
     // repairwallet RPC).
     std::set<uint256> repaired;
 
+    // An output consumed by a mempool transaction is spent whatever the tx
+    // index says: a mempool spend has no index entry, so the chain has no
+    // opinion to defer to. Without this, every own transaction sitting in the
+    // mempool -- one resurrected by a reorganize, or simply unconfirmed when
+    // repairwallet runs -- has its inputs handed back as spendable, and the
+    // wallet can build a transaction, or a coinstake, that double-spends its
+    // own pending transaction.
+    std::set<COutPoint> spent_in_mempool;
+    {
+        LOCK(mempool.cs);
+        for (const auto& [outpoint, inpoint] : mempool.mapNextTx) {
+            spent_in_mempool.insert(outpoint);
+        }
+    }
+
     CTxDB txdb("r");
     for (auto const& pcoin : vCoins)
     {
@@ -4576,7 +4591,8 @@ void CWallet::FixSpentCoins(int& nMismatchFound, int64_t& nBalanceInQuestion, bo
         }
         for (unsigned int n=0; n < pcoin->vout.size(); n++)
         {
-            if ((IsMine(pcoin->vout[n]) != ISMINE_NO) && pcoin->IsSpent(n) && (txindex.vSpent.size() <= n || txindex.vSpent[n].IsNull()))
+            if ((IsMine(pcoin->vout[n]) != ISMINE_NO) && pcoin->IsSpent(n) && (txindex.vSpent.size() <= n || txindex.vSpent[n].IsNull())
+                && !spent_in_mempool.count(COutPoint(pcoin->GetHash(), n)))
             {
                 LogPrintf("FixSpentCoins found lost coin %s gC %s[%d], %s",
                     FormatMoney(pcoin->vout[n].nValue).c_str(), pcoin->GetHash().ToString().c_str(), n, fCheckOnly? "repair not attempted" : "repairing");

--- a/test/functional/feature_reorg_resurrect.py
+++ b/test/functional/feature_reorg_resurrect.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""A wallet transaction survives its block being disconnected.
+
+DisconnectBlocksBatch queues every ordinary transaction of a disconnected
+block and re-submits it to the mempool, so a transaction that was mined and
+then reorganized away is still pending afterwards unless it is independently
+invalid at the new tip: the next block picks it up again, and the wallet keeps
+reporting it at zero confirmations.
+
+The regtest `reorganize` RPC rolls the chain back to a given hash, so one node
+walks the whole path: spend a mature coinstake output to an own address, mine
+the transaction, roll the chain back one block, and mine again.
+
+Each step asserts the state only a working resurrection produces:
+
+  * after the roll-back the transaction is in the mempool, gettransaction
+    reports it at zero confirmations (a transaction that is in neither a block
+    nor the mempool reports -1), and the output it spends is not offered as
+    unspent;
+  * the next block mines it again and the mempool is empty.
+
+The re-acceptance used to be refused for every transaction: it ran before the
+disconnect batch was committed to the transaction index, so the mempool still
+saw the transaction as confirmed and its inputs as spent. Nothing was logged
+and the mempool stayed empty. And once it did land, FixSpentCoins, which runs
+right after the disconnect and consulted only the tx index, handed the
+transaction's input back as spendable.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+FEE = Decimal("1.0")
+
+
+class ReorgResurrectTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-staking=0", "-connect=0", "-listen=0"]]
+
+    def setup_network(self):
+        # Single isolated regtest node; bypass the base regtest createwallet
+        # path (Gridcoin has one default BDB wallet, no multiwallet).
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+
+    def oldest_coinstake_utxo(self, node):
+        """The coinstake output with the most confirmations.
+
+        The height-0 premine coinbase outputs carry one more confirmation than
+        the chain height, so the filter keeps every post-genesis output. All of
+        those are coinstakes here, and the oldest one is the furthest from any
+        maturity rule.
+        """
+        height = node.getblockcount()
+        coinstakes = [u for u in node.listunspent(0) if u["confirmations"] <= height]
+        assert coinstakes, "no coinstake output to spend"
+        return max(coinstakes, key=lambda u: u["confirmations"])
+
+    def unspent_outpoints(self, node):
+        return {(u["txid"], u["vout"]) for u in node.listunspent(0)}
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        node.generatetoaddress(10, node.getnewaddress())
+
+        self.log.info("spend a mature coinstake output to an own address")
+        utxo = self.oldest_coinstake_utxo(node)
+        dest = node.getnewaddress()
+        raw = node.createrawtransaction(
+            [{"txid": utxo["txid"], "vout": utxo["vout"]}], {dest: utxo["amount"] - FEE})
+        signed = node.signrawtransactionwithwallet(raw)
+        assert_equal(signed["complete"], True)
+        txid = node.sendrawtransaction(signed["hex"])
+        assert_equal(node.getrawmempool(), [txid])
+        assert_equal(node.gettransaction(txid)["confirmations"], 0)
+
+        self.log.info("mine it")
+        self.advance_to_next_stake_slot()
+        base_hash = node.getbestblockhash()
+        base_height = node.getblockcount()
+        node.generatetoaddress(1, node.getnewaddress())
+        mined_hash = node.getbestblockhash()
+        assert_equal(node.getrawmempool(), [])
+        assert_equal(node.gettransaction(txid)["confirmations"], 1)
+        assert_equal(node.gettransaction(txid)["blockhash"], mined_hash)
+
+        self.log.info("roll the chain back one block: the transaction is pending again")
+        assert_equal(node.reorganize(base_hash)["RollbackChain"], True)
+        assert_equal(node.getbestblockhash(), base_hash)
+        assert_equal(node.getrawmempool(), [txid])
+        assert_equal(node.gettransaction(txid)["confirmations"], 0)
+        # The input is spent by a pending transaction, so it must not be
+        # offered for spending or staking again.
+        assert (utxo["txid"], utxo["vout"]) not in self.unspent_outpoints(node)
+
+        self.log.info("the next block mines it again")
+        self.advance_to_next_stake_slot()
+        node.generatetoaddress(1, node.getnewaddress())
+        assert_equal(node.getblockcount(), base_height + 1)
+        assert node.getbestblockhash() != mined_hash
+        assert_equal(node.getrawmempool(), [])
+        assert_equal(node.gettransaction(txid)["confirmations"], 1)
+        assert_equal(node.gettransaction(txid)["blockhash"], node.getbestblockhash())
+
+
+if __name__ == "__main__":
+    ReorgResurrectTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -195,6 +195,10 @@ BASE_SCRIPTS = [
     'rpc_net_connman.py',
     'feature_sidestake.py',
     'feature_generatesuperblock.py',
+    # feature_reorg_resurrect.py: a wallet transaction whose block is
+    # disconnected returns to the mempool and stays unconfirmed, not
+    # conflicted, and is mined again by the next block.
+    'feature_reorg_resurrect.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since longer tests benefit from being scheduled


### PR DESCRIPTION
Found by `feature_contract_replay.py` on #3338, which had recorded that the disconnected beacon
advertisement did not come back into the mempool on its own and worked around it by resubmitting
the transaction's own bytes. Chasing why turned up this. (That test has since been made tolerant of
both behaviours, so the wording it carried when this was found is no longer on its head.)

### The defect

`DisconnectBlocksBatch` queues every ordinary transaction of each disconnected block above the
last checkpoint and hands each one to `AcceptToMemoryPool`, so a transaction whose block is
reorganized away stays pending, unless it is independently invalid at the new tip, and the next
block can carry it again. The loop ran before `txdb.TxnCommit()`.

`AcceptToMemoryPool` opens its own `CTxDB txdb("r")`. The batch is a per-instance member of
`CTxDB`, so that handle sees only committed LevelDB state: the disconnected transaction's own
index entry is still on disk, `ContainsTx()` answers true, and the call returns `false` before
any check that would set a reject reason or log. Had it got past that, `ConnectInputs` would have
rejected it for the same reason, its inputs still marked spent in the committed index ("prev tx
already used", itself logged only under VERBOSE). Instrumenting the loop on regtest confirmed it
directly: `ok=0`, no missing inputs, empty reject reason, and both a fresh handle and the batched
handle reporting the transaction present.

So every resurrection has been refused, silently, since the chain reorganize rewrite
(`af5ff9f1e`) placed the loop ahead of the commit. The `Reorganize()` it replaced committed first.

The wallet turns the silence into a visible symptom. `CWallet::BlockDisconnected` runs inside
`DisconnectBlock`, before the resurrect loop, finds the transaction absent from the mempool and
marks it `TxStateInactive`, relying on `TransactionAddedToMempool` to move it back to
`TxStateInMempool` when the re-acceptance lands. With the re-acceptance refused, the wallet's own
still-valid transaction is shown as *Conflicted* (`gettransaction` depth -1),
`RelayWalletTransaction` refuses to rebroadcast it, and it never returns to the chain unless
something resubmits its bytes.

### The fix

Commit the disconnect batch, then resurrect. A commit failure now returns before anything has
been re-accepted rather than after. Nothing between the two positions reads the resurrected
transactions. A refused resurrection is now logged under the mempool category, with its reason
where it has one (the `ContainsTx` refusal that motivated this carries none), so the next silent
refusal is not silent.

### What the working resurrection then exposed

With the transaction really back in the mempool, the test's next assertion failed: the output it
spends was listed as unspent again. `ReorganizeChain` calls `FixSpentCoins` right after the
disconnect batch, and `FixSpentCoins` compares wallet spent flags with the tx index alone. A
mempool spend has no index entry, so the input the wallet had just re-marked spent read as a
"lost coin" and was handed back, with one `FixSpentCoins found lost coin` line in the log. From
there `listunspent` and coin control offer it, `CreateTransaction` can select it, and
`AvailableCoinsForStaking` can stake it, producing a transaction or coinstake that double-spends
the wallet's own pending transaction. The same branch is reachable from every other caller for
any unconfirmed own transaction at the time it runs: startup calls `FixSpentCoins` right after
`ReacceptWalletTransactions`, so every start with an own transaction in the mempool hits the
repair; `repairwallet` repairs the same way; `checkwallet` reports the coin as lost without
handing it back.

`FixSpentCoins` now skips an output that a mempool transaction spends, whatever the index says.
The mempool outpoints are collected once under `mempool.cs`, in the `cs_main -> cs_wallet ->
mempool.cs` order `BlockDisconnected` already uses. This is the same guard the release pass one
function up already carries for the abandoned-versus-active case, and its comment explains why
the index cannot cover a mempool spend.

### Same shape, one site over

The connect side calls `FixSpentCoins` inside its own batch window when a stale MRC was erased.
Through its own `CTxDB` it would not see the block's spends and would hand back every wallet
output the block just consumed. That call is moved after the commit as well.

### The same bug one layer down

The batched handle itself also reported the transaction present: `CTxDB::Exists()` scans the
open batch, but on finding a pending `Delete` it fell through to `pdb->Get`, which still holds the
committed copy, and returned true. `Read()` already answers "absent" in that case. The second
commit makes `Exists()` do the same. No in-tree caller invokes `Exists()` on a batched handle
today, so this is a consistency fix for the primitive with no production behaviour change; the
iterator-based readers still walk the disk alone, as before.

### What changes on a live reorg

Disconnected ordinary transactions now really land in the mempool during a reorg. The connect
side already handles them: `ConnectBlock` is followed by `mempool.remove` for every transaction
in the new branch and `mempool.removeConflicts` for anything spending the same inputs, and the
stale-MRC sweep runs after. The wallet ends in `TxStateInMempool` through the ordinary
`TransactionAddedToMempool` path. The transient inactive state between the two notifications is
written to the wallet and signalled `CT_UPDATED` (only `-walletnotify` is skipped for it), so a
GUI can show one Conflicted-to-pending flicker across the reorg.

Two consequences worth naming. An MRC from the first disconnected block re-validates against the
new tip, is resurrected, fires `MRCChanged`, and is then erased as stale by the connect side's
sweep at the next block, from the mempool and the wallet; before, it stayed in the wallet as
conflicted. MRCs from deeper disconnected blocks fail their anchor check and now log the refusal.
`AcceptToMemoryPool` does not relay, so nothing is announced from inside the reorg.

### Tests

`feature_reorg_resurrect.py` (added to the default suite) spends a mature coinstake output to an
own address, mines it, rolls back one block with the `reorganize` RPC, and asserts the
transaction is in the mempool, that `gettransaction` reports zero confirmations, that its input
is not listed as unspent, and that the next block mines it again. On the unfixed daemon it fails
at the mempool assertion after the roll-back (`[]` instead of the transaction). With only the
resurrect fix applied it fails at the unspent-input assertion, with the "lost coin" repair in the
log. With all three commits it passes.

`dbwrapper_tests` pins `Exists()` for a committed key deleted inside a batch and for a key
written then deleted inside one batch. The first case fails on the unfixed header at the
`!ExistsGenericSerializable` check; both pass fixed.

**Interaction with #3338.** Its step 5 used to assert the mempool is empty after the second
roll-back, which this PR inverts. That is already handled: #3338 was adjusted at `e5862e8a7` to
take the advertisement from the mempool when it is there and resubmit its bytes when it is not, so
it passes either way and neither PR has to merge first.

**Testing.** Unit suite and the full functional suite (32 scripts, including the new one) pass
locally on the head. (The host has a distro BOINC install, so the functional run used the #3327
`boincdatadir` workaround; nothing in this PR depends on it.)

https://claude.ai/code/session_01WPz3aTvz2vsNYGbnqqwzti
