### PR TITLE
wallet, test: cover rebroadcast of an own transaction the mempool evicted

### DIFF
--- a/src/test/miner_block_assembly_tests.cpp
+++ b/src/test/miner_block_assembly_tests.cpp
@@ -416,6 +416,34 @@ BOOST_AUTO_TEST_CASE(a_transaction_newer_than_the_block_is_skipped)
 //! heap, and no fixture state can change that -- the coinbase half of the guard
 //! has no reachable behaviour to pin.
 //!
+namespace {
+
+//! Registers the wallet with the validation signals for one case. The
+//! signals are inert in this binary until a scheduler is registered
+//! (chain_setup.cpp explains why); every signal used here is invoked
+//! synchronously, so the scheduler never has to run.
+struct SignalsForThisCase {
+    CScheduler m_scheduler;
+    SignalsForThisCase()
+    {
+        GetMainSignals().RegisterBackgroundSignalScheduler(m_scheduler);
+        RegisterValidationInterface(pwalletMain);
+    }
+    ~SignalsForThisCase()
+    {
+        UnregisterValidationInterface(pwalletMain);
+        GetMainSignals().UnregisterBackgroundSignalScheduler();
+    }
+};
+
+//! Puts the -maxmempool cap back however the case exits.
+struct MaxSizeRestorer {
+    size_t m_saved{mempool.GetMaxSize()};
+    ~MaxSizeRestorer() { mempool.SetMaxSize(m_saved); }
+};
+
+} // anonymous namespace
+
 //!
 //! A size-limit eviction inside AcceptToMemoryPool reaches the wallet.
 //!
@@ -436,24 +464,8 @@ BOOST_AUTO_TEST_CASE(a_size_limit_eviction_reaches_the_wallet)
 {
     mempool.clear();
 
-    struct SignalsForThisCase {
-        CScheduler m_scheduler;
-        SignalsForThisCase()
-        {
-            GetMainSignals().RegisterBackgroundSignalScheduler(m_scheduler);
-            RegisterValidationInterface(pwalletMain);
-        }
-        ~SignalsForThisCase()
-        {
-            UnregisterValidationInterface(pwalletMain);
-            GetMainSignals().UnregisterBackgroundSignalScheduler();
-        }
-    } signals;
-
-    struct MaxSizeRestorer {
-        size_t m_saved{mempool.GetMaxSize()};
-        ~MaxSizeRestorer() { mempool.SetMaxSize(m_saved); }
-    } max_size;
+    const SignalsForThisCase signals;
+    const MaxSizeRestorer max_size;
 
     std::vector<std::pair<uint256, ChangeType>> seen;
     boost::signals2::scoped_connection watch = pwalletMain->NotifyTransactionChanged.connect(
@@ -501,6 +513,76 @@ BOOST_AUTO_TEST_CASE(a_size_limit_eviction_reaches_the_wallet)
     }
 
     mempool.clear();
+
+    // The spends are deterministic, so the next case builds the same two
+    // transactions; leave it a wallet that has never seen them.
+    pwalletMain->EraseFromWallet(first_hash);
+    pwalletMain->EraseFromWallet(second.GetHash());
+}
+
+//!
+//! An evicted own spend is the input ResendWalletTransactions exists for:
+//! unconfirmed, no longer in the mempool, and not conflicted. The forced
+//! resend must relay exactly that spend, and nothing while it is still pooled
+//! or once it is marked inactive.
+//!
+//! Discriminates on the relayed count. While the spend is in the pool it reads
+//! depth 0 and is skipped; after the eviction it reads -1 and is revalidated
+//! against the tx index and relayed; marked conflicted it is refused by
+//! RelayWalletTransaction. Had the eviction handler marked it conflicted, the
+//! count after the eviction would be 0. The wallet must have nothing to
+//! re-announce before the case starts, or the counts would not be this case's.
+//!
+BOOST_AUTO_TEST_CASE(a_size_limit_evicted_own_spend_is_rebroadcast)
+{
+    mempool.clear();
+
+    const SignalsForThisCase signals;
+    const MaxSizeRestorer max_size;
+
+    CAmount fee_first = 0, fee_second = 0;
+    CTransaction first = MakeCandidate(0, 1, 2000, fee_first);
+    CTransaction second = MakeCandidate(1, 1, 2000, fee_second);
+    const uint256 first_hash = first.GetHash();
+
+    LOCK(cs_main);
+
+    BOOST_REQUIRE_EQUAL(pwalletMain->ResendWalletTransactions(/*fForce=*/true), 0u);
+
+    CValidationState state_first;
+    BOOST_REQUIRE_MESSAGE(AcceptToMemoryPool(mempool, first, state_first, nullptr),
+                          "first spend rejected: " + state_first.GetRejectReason());
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE(pwalletMain->mapWallet.count(first_hash));
+    }
+
+    // Still in the pool: nothing to re-announce.
+    BOOST_CHECK_EQUAL(pwalletMain->ResendWalletTransactions(/*fForce=*/true), 0u);
+
+    mempool.SetMaxSize(mempool.DynamicMemoryUsage());
+    CValidationState state_second;
+    BOOST_REQUIRE_MESSAGE(AcceptToMemoryPool(mempool, second, state_second, nullptr),
+                          "second spend rejected: " + state_second.GetRejectReason());
+    BOOST_REQUIRE_MESSAGE(!mempool.exists(first_hash), "the size limit did not evict the first spend");
+
+    // Evicted: exactly the first spend is relayed; the second is still pooled.
+    BOOST_CHECK_EQUAL(pwalletMain->ResendWalletTransactions(/*fForce=*/true), 1u);
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_CHECK(pwalletMain->mapWallet.count(first_hash));
+    }
+
+    // Conflicted: refused, whatever depth says.
+    {
+        LOCK(pwalletMain->cs_wallet);
+        pwalletMain->mapWallet.at(first_hash).SetTxState(TxStateInactive{false});
+    }
+    BOOST_CHECK_EQUAL(pwalletMain->ResendWalletTransactions(/*fForce=*/true), 0u);
+
+    mempool.clear();
+    pwalletMain->EraseFromWallet(first_hash);
+    pwalletMain->EraseFromWallet(second.GetHash());
 }
 
 BOOST_AUTO_TEST_CASE(a_size_limit_eviction_signals_the_victims_descendants_too)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2534,13 +2534,13 @@ void CWallet::ReacceptWalletTransactions()
 }
 
 
-void CWalletTx::RelayWalletTransaction(CTxDB& txdb)
+bool CWalletTx::RelayWalletTransaction(CTxDB& txdb)
 {
     // Don't relay inactive (abandoned/conflicted) transactions
     if (isInactive()) {
         LogPrint(BCLog::LogFlags::VERBOSE, "RelayWalletTransaction: skipping inactive tx %s\n",
                  GetHash().ToString().substr(0,10));
-        return;
+        return false;
     }
 
     for (auto const& tx : vtxPrev)
@@ -2562,15 +2562,17 @@ void CWalletTx::RelayWalletTransaction(CTxDB& txdb)
             RelayTransaction((CTransaction)*this, hash);
         }
     }
+
+    return true;
 }
 
-void CWalletTx::RelayWalletTransaction()
+bool CWalletTx::RelayWalletTransaction()
 {
     CTxDB txdb("r");
-    RelayWalletTransaction(txdb);
+    return RelayWalletTransaction(txdb);
 }
 
-void CWallet::ResendWalletTransactions(bool fForce) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+unsigned int CWallet::ResendWalletTransactions(bool fForce) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!fForce)
     {
@@ -2579,23 +2581,23 @@ void CWallet::ResendWalletTransactions(bool fForce) EXCLUSIVE_LOCKS_REQUIRED(cs_
         // is in sync. During initial block loads, etc. using a transferred
         // wallet.dat file, the unconfirmed status of the transactions may not be correct.
         if (IsInitialBlockDownload() || OutOfSyncByAge()) {
-            return;
+            return 0;
         }
 
         static int64_t nNextTime;
         if ( GetAdjustedTime() < nNextTime)
-            return;
+            return 0;
         bool fFirst = (nNextTime == 0);
 
         // Choose a random time up to about 10 blocks at target spacing.
         nNextTime =  GetAdjustedTime() + GetRand(GetTargetSpacing(nBestHeight) * 10);
         if (fFirst)
-            return;
+            return 0;
 
         // Only do it if there's been a new block since last time
         static int64_t nLastTime;
         if (g_nTimeBestReceived < nLastTime)
-            return;
+            return 0;
         nLastTime =  GetAdjustedTime();
     }
 
@@ -2637,10 +2639,11 @@ void CWallet::ResendWalletTransactions(bool fForce) EXCLUSIVE_LOCKS_REQUIRED(cs_
             CWalletTx& wtx = *item.second;
 
             if (wtx.RevalidateTransaction(txdb)) {
-                // Transaction is valid for relaying.
-                wtx.RelayWalletTransaction(txdb);
-
-                ++txns_relayed;
+                // Transaction is valid for relaying; an inactive one is still
+                // refused by RelayWalletTransaction and does not count.
+                if (wtx.RelayWalletTransaction(txdb)) {
+                    ++txns_relayed;
+                }
             } else {
                 LogPrintf("WARNING: %s: CheckTransaction failed for transaction %s. Transaction will be "
                           "erased.",
@@ -2680,6 +2683,8 @@ void CWallet::ResendWalletTransactions(bool fForce) EXCLUSIVE_LOCKS_REQUIRED(cs_
              txns_relayed,
              txns_failed_validation,
              txns_erased_from_wallet);
+
+    return txns_relayed;
 }
 
 bool CWalletTx::RevalidateTransaction(CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -412,7 +412,10 @@ public:
     //!
     //! \param fForce
     //!
-    void ResendWalletTransactions(bool fForce = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    //! Re-announce own transactions that are unconfirmed and no longer in the
+    //! mempool. Returns how many were relayed; the rate-limit and sync guards
+    //! that fForce bypasses return 0 without looking at the wallet.
+    unsigned int ResendWalletTransactions(bool fForce = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     int64_t GetBalance() const;
     int64_t GetUnconfirmedBalance() const;
     int64_t GetImmatureBalance() const;
@@ -1288,8 +1291,10 @@ public:
     bool AcceptWalletTransaction(CTxDB& txdb);
     bool AcceptWalletTransaction();
 
-    void RelayWalletTransaction(CTxDB& txdb);
-    void RelayWalletTransaction();
+    //! Announce this transaction (and its unindexed parents) to peers. Returns
+    //! false when the transaction is inactive and nothing was relayed.
+    bool RelayWalletTransaction(CTxDB& txdb);
+    bool RelayWalletTransaction();
 
     bool RevalidateTransaction(CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 


### PR DESCRIPTION
Stacked on #3336, which stacks on #3333; only the last commit is new here. Closes the wallet half
of the coverage gap #3112 noted when it moved `ResendWalletTransactions` onto the scheduler; the
re-INV assertion #3112 asked for still needs a functional test.

### Why there was no test

`ResendWalletTransactions` considers a wallet transaction only when it is unconfirmed and at depth
-1, which means not in the mempool. The obvious test, submit a transaction and call `resendtx`,
asserts nothing: a fresh transaction is at depth 0 and skipped. Reaching depth -1 needs the
transaction out of the mempool while the wallet still holds it and has not marked it conflicted. A
restart does not do it on regtest, where the wallet is rebuilt on every start, and a reorganize
puts the transaction straight back into the mempool. The one route is a mempool eviction, and until
#3336 the wallet was never told about one. #3336 keeps the evicted transaction in `TxStateInMempool`
precisely so that rebroadcast has an input; this PR is the test that proves the two fit.

### The seam

`ResendWalletTransactions` returns the number of transactions it relayed, a count it already kept
for its log line. `RelayWalletTransaction` now reports whether it relayed or refused an inactive
transaction, so an inactive entry, refused one call down, no longer counts: before this the loop
incremented on every revalidated candidate, and a conflicted entry at depth -1 was counted while
being refused. (A candidate the tx index already holds still counts true, as the `wallet.h`
comment says; only the inactive refusal is excluded.) The RPC and the scheduled job ignore the
value; `resendtx`'s output and heritage fingerprint are unchanged.

The relay itself is not observable in the unit binary: `RelayTransaction` writes into a file-static
map and announces to `g_connman`'s peers, and the fixture's connection manager has no way to
register a `CNode` without a real socket. The count is the nearest honest observable; the P2P half
stays with the existing relay tests.

### The case

Follows #3336's eviction case on the chain fixture, sharing its signal registration and
`-maxmempool` restorer, now hoisted to file scope. A forced resend relays nothing while the spend
is pooled, exactly one transaction once the size limit has evicted it, and nothing again once the
entry is marked conflicted. It requires the wallet to have nothing to re-announce before it starts,
so a future case leaving entries behind fails loudly instead of skewing the counts (which is
exactly how the review caught #3336's descendant case leaving three behind; fixed there in
`4daaa4b00`).

**Mutation.** With the eviction arm changed to mark the evicted spend conflicted, the case fails at
the middle count (0 instead of 1) and the eviction case fails its state checks. Restored, the unit
suite passes.

**A cleanup that the determinism forced.** The fixture's spends are deterministic (fixed timestamp,
RFC 6979 signatures), so this case builds byte-identical transactions to the eviction case's. Both
cases erase their wallet entries at the end of each case (trailing statements, not RAII, so a
failed `REQUIRE` skips them and the next case's opening precondition is what reports it); before
that, the second case inherited the first's evicted spend and its counts were not its own.

**Not covered.** The 60-second scheduler cadence #3112 introduced runs on `CScheduler`'s
`system_clock`, which `setmocktime` does not move (only `MockForward` does), so it is not pinned
here.

**Testing.** The unit suite passes locally on this head; the functional suite is green on it
in CI. The head was rebased onto #3336 after its own rebase, so both were re-run rather than
carried over from the pre-rebase build.

https://claude.ai/code/session_01WPz3aTvz2vsNYGbnqqwzti
