### PR TITLE
packaging: hdiutil retries and framework-root sealing in macdeployqtplus

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -383,6 +383,35 @@ def copyFramework(framework: FrameworkInfo, path: str, verbose: int) -> Optional
         if os.path.exists(headers_dir):
             shutil.rmtree(headers_dir)
 
+        # Seal the framework root: codesign refuses a framework whose root
+        # holds real entries other than Versions ("unsealed contents present
+        # in the root directory of an embedded framework"). Bottled Qt kegs
+        # ship clean roots, but source-built kegs -- what Homebrew now
+        # produces on Intel under its Tier 3 fallback -- can leave real
+        # files or directories (build artifacts such as .prl files) at the
+        # root. Re-home them under the versioned directory and leave the
+        # symlink the sealed layout expects.
+        versions_dir = os.path.join(to_dir, "Versions")
+        if os.path.isdir(versions_dir):
+            versioned_root = os.path.join(versions_dir, framework.version)
+            for entry in os.listdir(to_dir):
+                if entry == "Versions":
+                    continue
+                entry_path = os.path.join(to_dir, entry)
+                if os.path.islink(entry_path):
+                    continue
+                versioned_path = os.path.join(versioned_root, entry)
+                if os.path.exists(versioned_path):
+                    if os.path.isdir(entry_path):
+                        shutil.rmtree(entry_path)
+                    else:
+                        os.remove(entry_path)
+                else:
+                    shutil.move(entry_path, versioned_path)
+                os.symlink(os.path.join("Versions", framework.version, entry), entry_path)
+                if verbose:
+                    print("Sealed framework root entry:", entry)
+
     permissions = os.stat(toPath)
     if not permissions.st_mode & stat.S_IWRITE:
       os.chmod(toPath, permissions.st_mode | stat.S_IWRITE)

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import sys, re, os, platform, shutil, stat, subprocess, os.path
+import sys, re, os, platform, shutil, stat, subprocess, os.path, time
 from argparse import ArgumentParser
 try:
     from ds_store import DSStore
@@ -804,11 +804,27 @@ if config.dmg is not None:
 
     tempname: str = dmg_basename + ".temp.dmg"
 
-    run(["hdiutil", "create", tempname, "-srcfolder", "dist", "-format", "UDRW", "-size", str(size), "-volname", appname], check=True, universal_newlines=True)
+    def run_hdiutil_with_retry(args, attempts=4, delay=15, **kwargs):
+        # hdiutil races against Spotlight/fseventsd still indexing freshly
+        # written files on CI runners and fails transiently with "Resource
+        # busy" or "Resource temporarily unavailable"; a short pause and a
+        # retry clears it. The final attempt raises like check=True would.
+        for attempt in range(1, attempts + 1):
+            result = run(["hdiutil"] + args, universal_newlines=True, **kwargs)
+            if result.returncode == 0:
+                return result
+            if attempt < attempts:
+                print(f"hdiutil {args[0]} failed (attempt {attempt}/{attempts}), retrying in {delay}s...")
+                time.sleep(delay)
+        result.check_returncode()
+
+    # -ov: a failed attempt can leave a partial temp image behind; overwrite
+    # it so the retry does not die on "File exists".
+    run_hdiutil_with_retry(["create", tempname, "-ov", "-srcfolder", "dist", "-format", "UDRW", "-size", str(size), "-volname", appname])
 
     if verbose:
         print("Attaching temp image...")
-    output = run(["hdiutil", "attach", tempname, "-readwrite"], check=True, universal_newlines=True, stdout=PIPE).stdout
+    output = run_hdiutil_with_retry(["attach", tempname, "-readwrite"], stdout=PIPE).stdout
 
     m = re.search(r"/Volumes/(.+$)", output)
     disk_root = m.group(0)
@@ -831,7 +847,7 @@ if config.dmg is not None:
 
     run(["hdiutil", "detach", f"/Volumes/{appname}"], universal_newlines=True)
 
-    run(["hdiutil", "convert", tempname, "-format", "UDZO", "-o", dmg_basename, "-imagekey", "zlib-level=9"], check=True, universal_newlines=True)
+    run_hdiutil_with_retry(["convert", tempname, "-format", "UDZO", "-o", dmg_basename, "-imagekey", "zlib-level=9"])
 
     os.unlink(tempname)
 

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -809,8 +809,12 @@ if config.dmg is not None:
         # written files on CI runners and fails transiently with "Resource
         # busy" or "Resource temporarily unavailable"; a short pause and a
         # retry clears it. The final attempt raises like check=True would.
+        # check must not sneak in through kwargs: it would raise on the
+        # first failure and silently bypass the retry this helper exists for.
+        kwargs.pop("check", None)
+        kwargs.setdefault("universal_newlines", True)
         for attempt in range(1, attempts + 1):
-            result = run(["hdiutil"] + args, universal_newlines=True, **kwargs)
+            result = run(["hdiutil"] + args, **kwargs)
             if result.returncode == 0:
                 return result
             if attempt < attempts:


### PR DESCRIPTION
Two macdeployqtplus robustness fixes, one commit each, both surfaced by the macOS packaging path and the second specifically by Homebrew's Intel Tier 3 fallback producing source-built Qt kegs:

**1. Retry transient hdiutil failures (7d98ba40b + 6a74ec745).** The DMG step dies intermittently with `Resource busy` / `Resource temporarily unavailable` — a race against Spotlight/fseventsd indexing the freshly written `dist` folder on the runner. Three manual reruns to date, each now waiting hours behind the Intel source builds sharing the workflow run. The three checked hdiutil invocations (`create`, `attach`, `convert`) get a bounded retry — 4 attempts, 15 s apart — with the final failure raising exactly as `check=True` did. `create` gains `-ov` so a partial temp image cannot make the retry die on `File exists`; `check=` is stripped inside the helper so it cannot silently bypass the retry; `detach` was already tolerant.

**2. Seal framework roots before codesign (4e1034202).** The first source-built Qt satellite kegs on the Intel job produced `codesign: unsealed contents present in the root directory of an embedded framework` on QtSvg.framework — source-built kegs leave real entries (build artifacts such as `.prl` files) in the framework root where bottles ship clean symlinked roots. After the existing Headers cleanup, any real root entry is re-homed under the versioned directory (or dropped if a versioned copy exists) and replaced with the symlink the sealed layout expects. Bottled frameworks, whose roots are already clean, pass through untouched — the ARM job's behavior is unchanged.

Both fixes are exercised by the two macOS DMG jobs on this PR's own CI; #3342's Intel job needs fix 2 to deploy at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
