### PR TITLE
qt, gridcoin, interfaces: drive the researcher wizard's pool list from the registry

### DIFF
--- a/doc/multiprocess_interface_spec.md
+++ b/doc/multiprocess_interface_spec.md
@@ -209,7 +209,7 @@ handshake (`ipc/handshake.h`):
 
 ```cpp
 constexpr uint32_t IPC_SCHEMA_MAJOR   = 3;
-constexpr uint32_t IPC_SCHEMA_MINOR   = 1;
+constexpr uint32_t IPC_SCHEMA_MINOR   = 2;
 constexpr uint32_t IPC_PROTOCOL_VERSION = 1;
 ```
 
@@ -234,6 +234,11 @@ Rules a client must honor (from `ClientHandshake` and design §4.2):
   signature-request toast damp keys on; an older node would send it empty and
   the damp would silence every request after the first, which the minor turns
   into the "update the node" hard fail.
+  **Minor 2** (under major 3) adds `ResearcherContext.activePools @19`, the
+  registry-driven pool list behind the researcher wizard's pool page; a GUI
+  carrying it against an older node would otherwise call a method that node does
+  not serve, which the minor turns into the "update the node" hard fail at
+  connect.
 - **`protocol_version`** — the transport/handshake shape. Must match exactly.
 - **`git_commit`** / **`built_at`** — not compatibility gates; a `git_commit`
   mismatch is a soft mixed-build warning, `built_at` is informational.
@@ -376,7 +381,9 @@ voting types cross.
 Beacon / magnitude / accrual. `snapshot() -> ResearcherSnapshot` (blocking) and
 `trySnapshot()` (non-blocking); `outOfSync`; the fused `projects(extended) ->
 vector<ResearcherProjectRow>` (whitelist + local projects + scraper magnitude in
-one node-side pass); `whitelistProjects`, `v3CapableProjects`, `hasV3CapableProjects`,
+one node-side pass); `whitelistProjects`, `activePools` (the pool registry's
+ACTIVE entries reduced to one row per operator site, for the wizard's pool
+page), `v3CapableProjects`, `hasV3CapableProjects`,
 `maxProjectNameLength` / `maxProjectUrlLength`; commands `switchMode`,
 `advertiseBeacon`, `generateBeaconKeyForV3`, `advertiseBeaconV3`, `reload`; and
 the `handleResearcherChanged` / `handleBeaconChanged` / `handleAccrualChanged` /

--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -18,6 +18,7 @@
 #include "gridcoin/contract/message.h"
 #include "gridcoin/magnitude.h"
 #include "gridcoin/mrc.h"
+#include "gridcoin/pool.h"
 #include "gridcoin/project.h"
 #include "gridcoin/quorum.h"
 #include "gridcoin/researcher.h"
@@ -1175,6 +1176,21 @@ public:
         // so the committed-superblock state is the matching source.
         for (const auto& project : GRC::GetWhitelist().Snapshot(GRC::GreylistState::AUTHORITATIVE).Sorted()) {
             result.push_back({project.m_name, project.m_url});
+        }
+
+        return result;
+    }
+
+    std::vector<PoolRow> activePools() override
+    {
+        // ActivePoolsByOperator collapses the CPIDs an operator holds into the
+        // one site a researcher joins, so the four grandfathered grcpool.com
+        // seeds present as a single row. The registry is seeded at construction
+        // and re-seeded by Reset(), so this is never empty.
+        std::vector<PoolRow> result;
+
+        for (const auto& pool : GRC::GetPoolRegistry().ActivePoolsByOperator()) {
+            result.push_back({pool.m_name, pool.m_url});
         }
 
         return result;

--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -1186,7 +1186,8 @@ public:
         // ActivePoolsByOperator collapses the CPIDs an operator holds into the
         // one site a researcher joins, so the four grandfathered grcpool.com
         // seeds present as a single row. The registry is seeded at construction
-        // and re-seeded by Reset(), so this is never empty.
+        // and re-seeded by Reset(), so there are rows from genesis; this is
+        // empty only if every ACTIVE pool has been de-listed on chain.
         std::vector<PoolRow> result;
 
         for (const auto& pool : GRC::GetPoolRegistry().ActivePoolsByOperator()) {

--- a/src/gridcoin/pool.cpp
+++ b/src/gridcoin/pool.cpp
@@ -11,7 +11,10 @@
 #include "sync.h"
 #include "chain.h"
 
+#include <algorithm>
 #include <cassert>
+#include <set>
+#include <string>
 
 using namespace GRC;
 using LogFlags = BCLog::LogFlags;
@@ -395,6 +398,27 @@ std::vector<Pool> PoolRegistry::ActivePools() const
             out.push_back(*iter.second);
         }
     }
+
+    return out;
+}
+
+std::vector<Pool> PoolRegistry::ActivePoolsByOperator() const
+{
+    std::vector<Pool> out = ActivePools();
+
+    // Sort by name first so the surviving entry of each URL group is the
+    // lowest-named one, and so the result order does not depend on the CPID
+    // map's iteration order.
+    std::sort(out.begin(), out.end(), [](const Pool& lhs, const Pool& rhs) {
+        return lhs.m_name < rhs.m_name;
+    });
+
+    std::set<std::string> seen_urls;
+
+    out.erase(std::remove_if(out.begin(), out.end(), [&seen_urls](const Pool& pool) {
+                  return !seen_urls.insert(pool.m_url).second;
+              }),
+              out.end());
 
     return out;
 }

--- a/src/gridcoin/pool.cpp
+++ b/src/gridcoin/pool.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <set>
 #include <string>
+#include <tuple>
 
 using namespace GRC;
 using LogFlags = BCLog::LogFlags;
@@ -408,15 +409,20 @@ std::vector<Pool> PoolRegistry::ActivePoolsByOperator() const
 
     // Sort by name first so the surviving entry of each URL group is the
     // lowest-named one, and so the result order does not depend on the CPID
-    // map's iteration order.
+    // map's iteration order. The URL breaks a tie between equal names.
     std::sort(out.begin(), out.end(), [](const Pool& lhs, const Pool& rhs) {
-        return lhs.m_name < rhs.m_name;
+        return std::tie(lhs.m_name, lhs.m_url) < std::tie(rhs.m_name, rhs.m_url);
     });
 
     std::set<std::string> seen_urls;
 
+    // An ACTIVE entry with no URL has nothing a researcher can join. It is
+    // reachable: an operator's POOL_REGISTER REMOVE may carry an empty URL,
+    // and a later Foundation POOL_APPROVE ADD flips that entry back to ACTIVE
+    // as it stands. Drop it rather than render a blank row (and collapse every
+    // such entry into one).
     out.erase(std::remove_if(out.begin(), out.end(), [&seen_urls](const Pool& pool) {
-                  return !seen_urls.insert(pool.m_url).second;
+                  return pool.m_url.empty() || !seen_urls.insert(pool.m_url).second;
               }),
               out.end());
 

--- a/src/gridcoin/pool.cpp
+++ b/src/gridcoin/pool.cpp
@@ -414,19 +414,26 @@ std::vector<Pool> PoolRegistry::ActivePoolsByOperator() const
         return std::tie(lhs.m_name, lhs.m_url) < std::tie(rhs.m_name, rhs.m_url);
     });
 
-    std::set<std::string> seen_urls;
-
+    // One explicit pass over the sorted list: keep the first entry seen for
+    // each URL, which the sort above made the lowest-named one.
+    //
     // An ACTIVE entry with no URL has nothing a researcher can join. It is
     // reachable: an operator's POOL_REGISTER REMOVE may carry an empty URL,
     // and a later Foundation POOL_APPROVE ADD flips that entry back to ACTIVE
     // as it stands. Drop it rather than render a blank row (and collapse every
     // such entry into one).
-    out.erase(std::remove_if(out.begin(), out.end(), [&seen_urls](const Pool& pool) {
-                  return pool.m_url.empty() || !seen_urls.insert(pool.m_url).second;
-              }),
-              out.end());
+    std::vector<Pool> result;
+    std::set<std::string> seen_urls;
 
-    return out;
+    for (Pool& pool : out) {
+        if (pool.m_url.empty() || !seen_urls.insert(pool.m_url).second) {
+            continue;
+        }
+
+        result.push_back(std::move(pool));
+    }
+
+    return result;
 }
 
 std::vector<Pool> PoolRegistry::ActivePoolsAtHeight(int height) const

--- a/src/gridcoin/pool.h
+++ b/src/gridcoin/pool.h
@@ -447,6 +447,25 @@ public:
     std::vector<Pool> ActivePools() const;
 
     //!
+    //! \brief Get the ACTIVE pools reduced to one entry per operator site.
+    //!
+    //! ActivePools() answers per CPID, and one operator can hold several: four
+    //! of the five grandfathered seeds are grcpool.com. A UI that offers pools
+    //! to a researcher wants the sites, not the CPIDs, so this collapses
+    //! entries that share a URL and keeps the first name in sorted order as the
+    //! group's label (grcpool.com over grcpool.com-2/-3/-5).
+    //!
+    //! The URL is the grouping key rather than m_operator_key because the
+    //! grandfathered seeds all carry a deliberately invalid CPubKey{} -- see
+    //! SeedBuiltinPools -- so keying on the operator key would collapse every
+    //! builtin into one row.
+    //!
+    //! Result is sorted by name, so the order does not depend on the CPID map's
+    //! iteration order.
+    //!
+    std::vector<Pool> ActivePoolsByOperator() const;
+
+    //!
     //! \brief Get all pools that were ACTIVE as of the supplied block
     //! height — the consensus-critical view used by voting AVW
     //! (voting/registry.cpp and voting/result.cpp).

--- a/src/gridcoin/pool.h
+++ b/src/gridcoin/pool.h
@@ -441,8 +441,8 @@ public:
     std::vector<Pool> Entries() const;
 
     //!
-    //! \brief Get all pools currently in the ACTIVE state. Used by the wizard
-    //! and the listpools RPC.
+    //! \brief Get all pools currently in the ACTIVE state. Backs
+    //! ActivePoolsByOperator(); the listpools RPC reads Entries().
     //!
     std::vector<Pool> ActivePools() const;
 
@@ -460,8 +460,14 @@ public:
     //! SeedBuiltinPools -- so keying on the operator key would collapse every
     //! builtin into one row.
     //!
-    //! Result is sorted by name, so the order does not depend on the CPID map's
-    //! iteration order.
+    //! Result is sorted by name (URL breaks a tie), so the order does not
+    //! depend on the CPID map's iteration order. ACTIVE entries whose URL is
+    //! empty are dropped: there is nothing to join.
+    //!
+    //! The collapse keys on the exact URL string, and only ACTIVE entries take
+    //! part. So an operator claiming several builtin CPIDs should register the
+    //! same URL byte-for-byte for each, or the site shows as more than one row;
+    //! and a CPID mid-claim (PENDING) drops out of its row until approved.
     //!
     std::vector<Pool> ActivePoolsByOperator() const;
 

--- a/src/interfaces/researcher.h
+++ b/src/interfaces/researcher.h
@@ -169,6 +169,15 @@ struct WhitelistProject
     std::string url;
 };
 
+//! One row of the researcher wizard's pool table: the pool registry's ACTIVE
+//! entries reduced to one per operator site, so the four grandfathered
+//! grcpool.com CPIDs present as the one pool a researcher can join.
+struct PoolRow
+{
+    std::string name;
+    std::string url;
+};
+
 //! Called when the researcher context changes (uiInterface.ResearcherChanged).
 //! Payload-free (decision B): the consumer refetches snapshot() on its own thread,
 //! which drops the former cross-thread marshal of a GRC::ResearcherPtr.
@@ -222,6 +231,11 @@ public:
 
     //! The whitelisted projects (name + url) for the poll-wizard pickers.
     virtual std::vector<WhitelistProject> whitelistProjects() = 0;
+
+    //! The pools a researcher can join (name + url), one row per operator site.
+    //! Replaces the researcher wizard's hardcoded pool table; the registry is
+    //! never empty, since PoolRegistry seeds the grandfathered pools at boot.
+    virtual std::vector<PoolRow> activePools() = 0;
 
     //! Maximum on-chain project name / URL lengths (GRC::Project::MAX_NAME_SIZE /
     //! MAX_URL_SIZE). The poll wizard's project-entry fields cap their Qt input at

--- a/src/interfaces/researcher.h
+++ b/src/interfaces/researcher.h
@@ -233,8 +233,9 @@ public:
     virtual std::vector<WhitelistProject> whitelistProjects() = 0;
 
     //! The pools a researcher can join (name + url), one row per operator site.
-    //! Replaces the researcher wizard's hardcoded pool table; the registry is
-    //! never empty, since PoolRegistry seeds the grandfathered pools at boot.
+    //! Replaces the researcher wizard's hardcoded pool table. PoolRegistry seeds
+    //! the grandfathered pools at boot, so there are rows from genesis; the
+    //! result is empty only if every ACTIVE pool is de-listed on chain.
     virtual std::vector<PoolRow> activePools() = 0;
 
     //! Maximum on-chain project name / URL lengths (GRC::Project::MAX_NAME_SIZE /
@@ -281,6 +282,7 @@ INTERFACES_ASSERT_MARSHALABLE(ResearcherSnapshot);
 INTERFACES_ASSERT_MARSHALABLE(ResearcherProjectRow);
 INTERFACES_ASSERT_MARSHALABLE(BeaconAdvertiseResult);
 INTERFACES_ASSERT_MARSHALABLE(WhitelistProject);
+INTERFACES_ASSERT_MARSHALABLE(PoolRow);
 } // namespace interfaces
 
 #endif // GRIDCOIN_INTERFACES_RESEARCHER_H

--- a/src/ipc/capnp/researcher.capnp
+++ b/src/ipc/capnp/researcher.capnp
@@ -44,6 +44,7 @@ interface ResearcherContext $Proxy.wrap("interfaces::ResearcherContext") {
     handleBeaconChanged @16 (context :Proxy.Context, callback :Node.VoidCallback) -> (result :Handler.Handler);
     handleAccrualChanged @17 (context :Proxy.Context, callback :Node.VoidCallback) -> (result :Handler.Handler);
     handleBlocksChanged @18 (context :Proxy.Context, callback :Node.NotifyBlocksChangedCallback) -> (result :Handler.Handler);
+    activePools @19 (context :Proxy.Context) -> (result :List(PoolRow));
 }
 
 struct ResearcherSnapshot $Proxy.wrap("interfaces::ResearcherSnapshot") {
@@ -102,6 +103,11 @@ struct BeaconAdvertiseResult $Proxy.wrap("interfaces::BeaconAdvertiseResult") {
 }
 
 struct WhitelistProject $Proxy.wrap("interfaces::WhitelistProject") {
+    name @0 :Text;
+    url @1 :Text;
+}
+
+struct PoolRow $Proxy.wrap("interfaces::PoolRow") {
     name @0 :Text;
     url @1 :Text;
 }

--- a/src/ipc/handshake.h
+++ b/src/ipc/handshake.h
@@ -46,8 +46,16 @@ namespace ipc {
 //! Additive, and the same silent-degradation shape: an old node sends the field
 //! empty, every row collapses onto one key, and the damp then silences every
 //! signature request after the first.
+//!
+//! Minor 2 (under major 3): ResearcherContext gained `activePools @19`
+//! (researcher.capnp), the registry-driven pool list behind the researcher
+//! wizard's pool page. Additive, so an old node still talks to a new GUI -- until
+//! that page opens and calls a method the node does not serve: the UNIMPLEMENTED
+//! reply is rethrown client-side as std::runtime_error out of initializePage(),
+//! which the GUI can only treat as a runaway exception. The minor turns that
+//! into the "Update the node" hard fail at connect.
 constexpr uint32_t IPC_SCHEMA_MAJOR = 3;
-constexpr uint32_t IPC_SCHEMA_MINOR = 1;
+constexpr uint32_t IPC_SCHEMA_MINOR = 2;
 constexpr uint32_t IPC_PROTOCOL_VERSION = 1;
 
 //! Domain-separation tag hashed into the node identity token. Bump the suffix if

--- a/src/qt/forms/researcherwizardpoolpage.ui
+++ b/src/qt/forms/researcherwizardpoolpage.ui
@@ -138,31 +138,11 @@
      <attribute name="verticalHeaderStretchLastSection">
       <bool>false</bool>
      </attribute>
-     <row>
-      <property name="text">
-       <string>grcpool</string>
-      </property>
-     </row>
-     <row>
-      <property name="text">
-       <string>Arikado Pool</string>
-      </property>
-     </row>
      <column>
       <property name="text">
        <string>Website URL</string>
       </property>
      </column>
-     <item row="0" column="0">
-      <property name="text">
-       <string notr="true">https://grcpool.com/</string>
-      </property>
-     </item>
-     <item row="1" column="0">
-      <property name="text">
-       <string notr="true">https://grc.arikado.ru/</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item>

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -545,6 +545,18 @@ std::vector<std::pair<QString, QString>> ResearcherModel::buildV3ProjectList() c
     return result;
 }
 
+std::vector<std::pair<QString, QString>> ResearcherModel::buildPoolList() const
+{
+    std::vector<std::pair<QString, QString>> result;
+
+    for (const auto& pool : m_researcher_context.activePools()) {
+        result.emplace_back(QString::fromStdString(pool.name),
+                            QString::fromStdString(pool.url));
+    }
+
+    return result;
+}
+
 QString ResearcherModel::generateBeaconKeyForV3()
 {
     const std::string public_key_hex = m_researcher_context.generateBeaconKeyForV3();

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -137,6 +137,11 @@ public:
     bool isV14Enabled() const;
     bool hasV3CapableProjects() const;
     std::vector<std::pair<QString, QString>> buildV3ProjectList() const;
+
+    //! The pools a researcher can join, as (name, website URL) pairs, one per
+    //! operator site. Backs the wizard pool page's table, which used to carry
+    //! the same two rows hardcoded in its .ui.
+    std::vector<std::pair<QString, QString>> buildPoolList() const;
     QString generateBeaconKeyForV3();
     BeaconStatus advertiseBeaconV3(const QString& ownership_proof_xml);
     QString cachedBeaconPubKeyHex() const;

--- a/src/qt/researcher/researcherwizardpoolpage.cpp
+++ b/src/qt/researcher/researcherwizardpoolpage.cpp
@@ -13,7 +13,12 @@
 #include <QClipboard>
 #include <QDesktopServices> // for opening URLs
 #include <QInputDialog>
+#include <QStringList>
+#include <QTableWidgetItem>
 #include <QUrl>
+
+#include <utility>
+#include <vector>
 
 // -----------------------------------------------------------------------------
 // Class: ResearcherWizardPoolPage
@@ -55,13 +60,7 @@ void ResearcherWizardPoolPage::initializePage()
 
     m_researcher_model->switchToPool();
 
-    // TODO (issue #1783 follow-up): populate poolTableWidget from
-    // GetPoolRegistry().ActivePools() instead of the static rows defined in
-    // researcherwizardpoolpage.ui. With the V15 rework grandfathering the
-    // 5 legacy pools into PoolRegistry's constructor, the registry is never
-    // empty, so the dynamic path can switch over at any time — the
-    // pre-activation fallback this comment used to mention is no longer
-    // needed.
+    populatePoolTable();
 
     connect(ui->poolTableWidget, &QTableWidget::cellClicked,
             this, &ResearcherWizardPoolPage::openLink);
@@ -73,9 +72,39 @@ void ResearcherWizardPoolPage::initializePage()
     connect(ui->newAddressButton, &QPushButton::clicked, this, &ResearcherWizardPoolPage::getNewAddress);
 }
 
+void ResearcherWizardPoolPage::populatePoolTable()
+{
+    // The rows come from the pool registry rather than the .ui file. The
+    // registry is seeded with the grandfathered pools in its constructor and
+    // again on Reset(), so it is never empty and needs no static fallback.
+    const std::vector<std::pair<QString, QString>> pools = m_researcher_model->buildPoolList();
+
+    ui->poolTableWidget->clearContents();
+    ui->poolTableWidget->setRowCount(static_cast<int>(pools.size()));
+
+    QStringList names;
+
+    for (int row = 0; row < static_cast<int>(pools.size()); ++row) {
+        names << pools[row].first;
+
+        // Not translated: a pool's website address is data, like the addresses
+        // the .ui rows carried with notr="true".
+        auto* url_item = new QTableWidgetItem(pools[row].second);
+        url_item->setFlags(url_item->flags() & ~Qt::ItemIsEditable);
+        ui->poolTableWidget->setItem(row, 0, url_item);
+    }
+
+    // The pool name is the row's vertical header, as it was in the .ui.
+    ui->poolTableWidget->setVerticalHeaderLabels(names);
+}
+
 void ResearcherWizardPoolPage::openLink(int row, int column) const
 {
     const QTableWidgetItem* item = ui->poolTableWidget->item(row, column);
+
+    if (!item) {
+        return;
+    }
 
     QDesktopServices::openUrl(QUrl(item->text()));
 }

--- a/src/qt/researcher/researcherwizardpoolpage.cpp
+++ b/src/qt/researcher/researcherwizardpoolpage.cpp
@@ -108,7 +108,17 @@ void ResearcherWizardPoolPage::openLink(int row, int column) const
         return;
     }
 
-    QDesktopServices::openUrl(QUrl(item->text()));
+    // The cell text is on-chain registry data now, not a string from the .ui:
+    // an operator registers the URL and the Foundation approves it. Hand the
+    // desktop only a well-formed web address; anything else (a bare host, a
+    // file: or custom scheme) is not something this page should launch.
+    const QUrl url(item->text());
+
+    if (!url.isValid() || (url.scheme() != QStringLiteral("http") && url.scheme() != QStringLiteral("https"))) {
+        return;
+    }
+
+    QDesktopServices::openUrl(url);
 }
 
 void ResearcherWizardPoolPage::getNewAddress()

--- a/src/qt/researcher/researcherwizardpoolpage.cpp
+++ b/src/qt/researcher/researcherwizardpoolpage.cpp
@@ -76,7 +76,9 @@ void ResearcherWizardPoolPage::populatePoolTable()
 {
     // The rows come from the pool registry rather than the .ui file. The
     // registry is seeded with the grandfathered pools in its constructor and
-    // again on Reset(), so it is never empty and needs no static fallback.
+    // again on Reset(), so there are rows from genesis and no static fallback
+    // is needed; were every pool de-listed on chain, the table would simply
+    // be empty.
     const std::vector<std::pair<QString, QString>> pools = m_researcher_model->buildPoolList();
 
     ui->poolTableWidget->clearContents();

--- a/src/qt/researcher/researcherwizardpoolpage.h
+++ b/src/qt/researcher/researcherwizardpoolpage.h
@@ -28,6 +28,10 @@ public:
     void initializePage() override;
 
 private:
+    //! Fills poolTableWidget from the pool registry. The .ui carries the
+    //! column and the widget's properties; the rows are data.
+    void populatePoolTable();
+
     Ui::ResearcherWizardPoolPage *ui;
     ResearcherModel* m_researcher_model;
     WalletModel* m_wallet_model;

--- a/src/test/gridcoin/pool_tests.cpp
+++ b/src/test/gridcoin/pool_tests.cpp
@@ -14,6 +14,7 @@
 #include "util/system.h"
 
 #include <boost/test/unit_test.hpp>
+#include <algorithm>
 #include <map>
 #include <set>
 #include <vector>
@@ -528,6 +529,54 @@ BOOST_AUTO_TEST_CASE(pool_registry_active_pools_contains_grandfathered_builtins)
 // -----------------------------------------------------------------------------
 // Grandfathered builtin pools (issue #1783 / plan §3, §3.5, §6, Q3, Q4)
 // -----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(active_pools_by_operator_collapses_the_shared_grcpool_site)
+{
+    GRC::PoolRegistry& registry = GRC::GetPoolRegistry();
+
+    // Four of the five seeds are grcpool.com under one URL; the fifth is
+    // arikado. A researcher joins a site, not a CPID, so the wizard wants two
+    // rows where ActivePools() answers five.
+    const std::vector<GRC::Pool> by_operator = registry.ActivePoolsByOperator();
+
+    std::set<std::string> urls;
+
+    for (const auto& seed : GRC::PoolRegistry::BuiltinPoolSeeds()) {
+        urls.insert(seed.url);
+    }
+
+    BOOST_CHECK_EQUAL(registry.ActivePools().size(), GRC::PoolRegistry::BuiltinPoolSeeds().size());
+    BOOST_CHECK_EQUAL(by_operator.size(), urls.size());
+
+    // Every surviving row carries a distinct URL.
+    std::set<std::string> seen;
+
+    for (const auto& pool : by_operator) {
+        BOOST_CHECK(seen.insert(pool.m_url).second);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(active_pools_by_operator_keeps_the_lowest_name_of_each_group)
+{
+    GRC::PoolRegistry& registry = GRC::GetPoolRegistry();
+
+    const std::vector<GRC::Pool> by_operator = registry.ActivePoolsByOperator();
+
+    // grcpool.com sorts ahead of grcpool.com-2/-3/-5, so it is the label the
+    // group keeps -- not whichever CPID the map happened to yield first.
+    auto grcpool = std::find_if(by_operator.begin(), by_operator.end(), [](const GRC::Pool& pool) {
+        return pool.m_url == "https://grcpool.com/";
+    });
+
+    BOOST_REQUIRE(grcpool != by_operator.end());
+    BOOST_CHECK_EQUAL(grcpool->m_name, "grcpool.com");
+
+    // And the result is sorted by name, so it does not depend on CPID order.
+    BOOST_CHECK(std::is_sorted(by_operator.begin(), by_operator.end(),
+                               [](const GRC::Pool& lhs, const GRC::Pool& rhs) {
+                                   return lhs.m_name < rhs.m_name;
+                               }));
+}
 
 BOOST_AUTO_TEST_CASE(builtin_pools_match_g_mining_pools_pre_v15)
 {

--- a/src/test/gridcoin/pool_tests.cpp
+++ b/src/test/gridcoin/pool_tests.cpp
@@ -578,6 +578,70 @@ BOOST_AUTO_TEST_CASE(active_pools_by_operator_keeps_the_lowest_name_of_each_grou
                                }));
 }
 
+BOOST_AUTO_TEST_CASE(active_pools_by_operator_applies_its_rules_beyond_the_seed_family)
+{
+    GRC::PoolRegistry& registry = GRC::GetPoolRegistry();
+
+    // A non-builtin ACTIVE pool sharing the grcpool site under a name that
+    // sorts ahead of every seed: the label rule is "lowest ACTIVE name wins",
+    // for any entry, not just the grcpool.com-N family.
+    GRC::Pool claimant;
+    claimant.m_cpid = GRC::Cpid::Parse("00000000000000000000000000000001");
+    claimant.m_name = "aaa-grcpool";
+    claimant.m_url = "https://grcpool.com/";
+    claimant.m_status = GRC::PoolStatus::ACTIVE;
+    registry.SeedForTests(claimant);
+
+    // A PENDING entry with an even lower name and the same URL is not ACTIVE,
+    // so it must not take the label: the reduction starts from ActivePools(),
+    // not Entries().
+    GRC::Pool pending;
+    pending.m_cpid = GRC::Cpid::Parse("00000000000000000000000000000002");
+    pending.m_name = "000-grcpool";
+    pending.m_url = "https://grcpool.com/";
+    pending.m_status = GRC::PoolStatus::PENDING;
+    registry.SeedForTests(pending);
+
+    // An ACTIVE entry whose URL is empty (reachable post-V15: the operator's
+    // POOL_REGISTER REMOVE may carry no URL, and a later Foundation
+    // POOL_APPROVE ADD flips that entry back to ACTIVE as it stands) has
+    // nothing a researcher can join, and must not become a blank row.
+    GRC::Pool blank;
+    blank.m_cpid = GRC::Cpid::Parse("00000000000000000000000000000003");
+    blank.m_name = "blank";
+    blank.m_url = "";
+    blank.m_status = GRC::PoolStatus::ACTIVE;
+    registry.SeedForTests(blank);
+
+    const std::vector<GRC::Pool> rows = registry.ActivePoolsByOperator();
+
+    std::set<std::string> seed_urls;
+
+    for (const auto& seed : GRC::PoolRegistry::BuiltinPoolSeeds()) {
+        seed_urls.insert(seed.url);
+    }
+
+    // The claimant joined an existing site and the blank entry was dropped, so
+    // the row count is still the number of distinct seed sites.
+    BOOST_CHECK_EQUAL(rows.size(), seed_urls.size());
+
+    auto grcpool = std::find_if(rows.begin(), rows.end(), [](const GRC::Pool& pool) {
+        return pool.m_url == "https://grcpool.com/";
+    });
+
+    BOOST_REQUIRE(grcpool != rows.end());
+    BOOST_CHECK_EQUAL(grcpool->m_name, "aaa-grcpool");
+
+    for (const auto& row : rows) {
+        BOOST_CHECK(!row.m_url.empty());
+        BOOST_CHECK(row.m_name != "000-grcpool");
+        BOOST_CHECK(row.m_name != "blank");
+    }
+
+    // Restore the seeded boot state for the cases that follow.
+    registry.ClearForTests();
+}
+
 BOOST_AUTO_TEST_CASE(builtin_pools_match_g_mining_pools_pre_v15)
 {
     // Q3 shadow check: pre-V15, ActivePoolsAtHeight must yield the same SET of

--- a/src/test/gridcoin/pool_tests.cpp
+++ b/src/test/gridcoin/pool_tests.cpp
@@ -578,7 +578,9 @@ BOOST_AUTO_TEST_CASE(active_pools_by_operator_keeps_the_lowest_name_of_each_grou
                                }));
 }
 
-BOOST_AUTO_TEST_CASE(active_pools_by_operator_applies_its_rules_beyond_the_seed_family)
+// PoolLifecycleFixture leaves the shared registry booted-clean before and after:
+// this case mutates it, so it must not depend on, or leak into, its neighbours.
+BOOST_FIXTURE_TEST_CASE(active_pools_by_operator_applies_its_rules_beyond_the_seed_family, PoolLifecycleFixture)
 {
     GRC::PoolRegistry& registry = GRC::GetPoolRegistry();
 
@@ -637,9 +639,6 @@ BOOST_AUTO_TEST_CASE(active_pools_by_operator_applies_its_rules_beyond_the_seed_
         BOOST_CHECK(row.m_name != "000-grcpool");
         BOOST_CHECK(row.m_name != "blank");
     }
-
-    // Restore the seeded boot state for the cases that follow.
-    registry.ClearForTests();
 }
 
 BOOST_AUTO_TEST_CASE(builtin_pools_match_g_mining_pools_pre_v15)


### PR DESCRIPTION

Resolves the TODO in `researcherwizardpoolpage.cpp`, an issue #1783 follow-up that #2955 left in
place.

### What the TODO was waiting for, and what it was not

The page's two pool rows were written into `researcherwizardpoolpage.ui`. The TODO's original
concern — an empty registry before V15 activation, needing a pre-activation fallback — was retired
inside #2955 itself: `9e7205e23` grandfathered the five legacy pools into `PoolRegistry`'s
constructor, `794bc3563` made `Reset()` re-seed them, and `da14b79fd` trimmed the TODO to say the
registry is never empty. On head `SeedBuiltinPools` runs from the constructor *and* from `Reset()`,
so `ActivePools()` is non-empty at every height, including 0.

What was actually left is a presentation problem the TODO did not mention. `ActivePools()` answers
per CPID, and one operator holds several: four of the five grandfathered seeds are `grcpool.com`
under one URL. Rendering the registry directly would turn two curated rows into five, four of them
pointing at the same site.

### The change

`PoolRegistry::ActivePoolsByOperator()` collapses entries that share a URL, keeping the
lowest-sorting name of each group as its label (`grcpool.com` over `grcpool.com-2/-3/-5`) and
returning the result sorted, so it does not depend on the CPID map's iteration order.

The grouping key is the URL rather than `m_operator_key` because the grandfathered seeds all carry
a deliberately invalid `CPubKey{}` — `SeedBuiltinPools` explains why, and `pool_tests` already
pins it — so keying on the operator key would collapse every builtin into one row.

The page reaches it the way the poll wizard reaches the project whitelist:
`interfaces::ResearcherContext::activePools()` returns a plain name/url DTO alongside the existing
`whitelistProjects()`, so no file under `src/qt` includes `gridcoin/pool.h` and the multiprocess
build carries it over the researcher capnp interface as an appended method.

The page's `openLink` slot also gains an `if (!item) return;` guard, since the table's cells are
now filled at runtime rather than from the `.ui`.

### The visible changes

Both row labels now come from the registry: `grcpool` becomes `grcpool.com` and `Arikado Pool`
becomes `grc.arikado.pool`. The arikado row also shows the registry's URL, `https://gridcoinpool.ru/`, where the `.ui` had
`https://grc.arikado.ru/`. Both serve the same live site — it self-identifies as "grc.arikado.ru
gridcoin pool" (checked 2026-09-03) — and the registry is the source this page is meant to follow,
so the seed is left alone rather than edited to match the old hardcoded string. Say the word if
you would rather the seed change instead; that is a registry data question, not a GUI one.

### Tests

`pool_tests` pins the collapse (five ACTIVE entries, one row per distinct URL in the seed table,
which is two, and every surviving row a distinct URL) and the label choice (`grcpool.com`, and the
result sorted). Returning `ActivePools()` unchanged fails both: it iterates a `std::map<Cpid, …>`,
so the rows come out in CPID byte order, which puts `grcpool.com-3` first and is not sorted by name
either. What the label case does *not* catch is a sort-but-no-dedup mutant, which still yields
`grcpool.com` as the first grcpool row; the collapse case covers that one.

The page itself is compile-verified only: rendering it needs the researcher wizard driven to the
pool page in a running GUI. The failure mode is a table with the wrong rows, which is visible at a
glance and affects nothing else.

**Testing.** The full unit suite passes locally on the head, in a GUI + multiprocess build
(`-DENABLE_GUI=ON -DUSE_QT6=ON -DENABLE_MULTIPROCESS=ON`) so the capnp addition is compiled.

https://claude.ai/code/session_01QefexqLUNb5k5qDSJxpnrV

---

### Maintainer note (jamescowens, 2026-09-06)

Two fixups landed on this branch after review; the text above is the author's original apart from the heading of the previous section.

- 7796a8387 bumps the IPC schema minor (3.0 -> 3.1) for the additive `activePools @19` and updates `doc/multiprocess_interface_spec.md`. Without it a newer GUI against an older node passes the handshake and then exits with a runaway-exception modal the moment the wizard's Pool page calls the method the node does not serve; with it the handshake refuses with "Update the node".
- 3b811abc3 drops ACTIVE entries with an empty URL from the wizard reduction (reachable post-V15 via an operator REMOVE without a URL followed by a Foundation APPROVE ADD), breaks sort ties on the URL, pins `PoolRow` as marshalable, corrects the "never empty" wording, documents the exact-string/ACTIVE-only collapse in `pool.h`, and adds a test that exercises the label rule, the ACTIVE filter and the empty-URL drop beyond the seed family.
