### PR TITLE
qt: announce a multisig signature request once per pending transaction

### DIFF
--- a/doc/multiprocess_interface_spec.md
+++ b/doc/multiprocess_interface_spec.md
@@ -209,7 +209,7 @@ handshake (`ipc/handshake.h`):
 
 ```cpp
 constexpr uint32_t IPC_SCHEMA_MAJOR   = 3;
-constexpr uint32_t IPC_SCHEMA_MINOR   = 0;
+constexpr uint32_t IPC_SCHEMA_MINOR   = 1;
 constexpr uint32_t IPC_PROTOCOL_VERSION = 1;
 ```
 
@@ -229,7 +229,11 @@ Rules a client must honor (from `ClientHandshake` and design §4.2):
 - **`schema_minor`** — additive schema changes. Asymmetric:
   *client minor > node minor* is a **hard fail** ("update the node"); *client
   minor < node minor* is a **soft, forward-compatible** finding (the node has
-  features the client does not use).
+  features the client does not use). **Minor 1** (under major 3) adds
+  `PSGTPoolRow.txHashHex`, the unsigned-transaction hash the GUI's
+  signature-request toast damp keys on; an older node would send it empty and
+  the damp would silence every request after the first, which the minor turns
+  into the "update the node" hard fail.
 - **`protocol_version`** — the transport/handshake shape. Must match exactly.
 - **`git_commit`** / **`built_at`** — not compatibility gates; a `git_commit`
   mismatch is a soft mixed-build warning, `built_at` is informational.
@@ -388,7 +392,11 @@ type. Pool: `entries`, `signPoolEntry`, `removePoolEntry`, `poolStatus`,
 `submitPSGTToPool`, `finalizeToRawTxHex`, `decodePSGT`, `walletHasSignature`,
 `walletMustSignRevision`. Rich result DTOs (`PSGTDescription`, `PSGTSignResult`,
 `PSGTSubmitResult`, …) plus the several status enums mirror the core results.
-Pool *change* notifications arrive via `Node::handlePSGTPoolChanged`.
+A `PSGTPoolRow` carries three identities: `image_hex` (the arrangement's
+redeem-script id, the pool key), `revision_hex` (the relayed bytes, matched
+against the change signal) and `tx_hash_hex` (the unsigned transaction, i.e. the
+pending spend -- shared by every signature revision, changed by an initiator
+supersede). Pool *change* notifications arrive via `Node::handlePSGTPoolChanged`.
 
 ### 4.9 SideStakeManager — `src/interfaces/sidestake.h` (no capnp schema)
 

--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -1612,6 +1612,7 @@ public:
             row.image_hex = entry.image.ToString();
             row.image_address = EncodeDestination(CTxDestination(entry.image));
             row.revision_hex = entry.revision_hash.GetHex();
+            row.tx_hash_hex = entry.tx_hash.GetHex();
             row.valid_sigs = entry.valid_sigs;
             row.sigs_required = entry.sigs_required;
             row.sigs_total = entry.sigs_total;

--- a/src/interfaces/psgt.h
+++ b/src/interfaces/psgt.h
@@ -108,6 +108,9 @@ struct PSGTPoolRow
     std::string image_hex;     //!< The pool key / command id (CScriptID::ToString(), raw Hash160).
     std::string image_address; //!< The arrangement's P2SH address (EncodeDestination), for the Image column.
     std::string revision_hex;  //!< The revision hash (matched against the removal signal).
+    std::string tx_hash_hex;   //!< Hash of the unsigned transaction: the pending spend's identity.
+                               //!< Every signature revision of a spend shares it; an initiator
+                               //!< supersede (PSGTPool::Add, same image, different tx) changes it.
     std::string destination;   //!< Largest-non-change-output address, precomputed.
     CAmount amount = 0;
     int valid_sigs = 0;

--- a/src/ipc/capnp/psgt.capnp
+++ b/src/ipc/capnp/psgt.capnp
@@ -54,6 +54,7 @@ struct PSGTPoolRow $Proxy.wrap("interfaces::PSGTPoolRow") {
     timeReceived @8 :Int64 $Proxy.name("time_received");
     inPool @9 :Bool $Proxy.name("in_pool");
     relevance @10 :Int32;
+    txHashHex @11 :Text $Proxy.name("tx_hash_hex");
 }
 
 struct PSGTInputInfo $Proxy.wrap("interfaces::PSGTInputInfo") {

--- a/src/ipc/handshake.h
+++ b/src/ipc/handshake.h
@@ -33,15 +33,21 @@ namespace ipc {
 //! build carrying major 3 lacks it and the minor restarts at 0 rather than
 //! tracking it separately.
 //!
-//! Minor 1: RowsChangedPayload gained `records` (wallet_tx_source.capnp @4), the
-//! changed rows sampled at emission. Additive, so an old node still talks to a new
-//! GUI -- but it degrades SILENTLY if the minor is not bumped: the field simply
-//! arrives empty, the GUI's "empty means nothing to apply" contract does exactly
-//! that, and the Overview list then shows stale rows until the process restarts.
-//! The minor is what turns that into the actionable "Update the node" hard fail in
-//! ClientHandshake.
+//! Minor 1 (under major 2): RowsChangedPayload gained `records`
+//! (wallet_tx_source.capnp @4), the changed rows sampled at emission. Additive,
+//! so an old node still talks to a new GUI -- but it degrades SILENTLY if the
+//! minor is not bumped: the field simply arrives empty, the GUI's "empty means
+//! nothing to apply" contract does exactly that, and the Overview list then
+//! shows stale rows until the process restarts. The minor is what turns that
+//! into the actionable "Update the node" hard fail in ClientHandshake.
+//!
+//! Minor 1 (under major 3): PSGTPoolRow gained `txHashHex` (psgt.capnp @11), the
+//! unsigned-transaction hash the GUI's signature-request toast damp keys on.
+//! Additive, and the same silent-degradation shape: an old node sends the field
+//! empty, every row collapses onto one key, and the damp then silences every
+//! signature request after the first.
 constexpr uint32_t IPC_SCHEMA_MAJOR = 3;
-constexpr uint32_t IPC_SCHEMA_MINOR = 0;
+constexpr uint32_t IPC_SCHEMA_MINOR = 1;
 constexpr uint32_t IPC_PROTOCOL_VERSION = 1;
 
 //! Domain-separation tag hashed into the node identity token. Bump the suffix if

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1756,26 +1756,54 @@ void BitcoinGUI::gotoPSGTPoolPage()
     disconnect(exportAction, &QAction::triggered, nullptr, nullptr);
 }
 
+std::vector<PSGTToastDamp::Entry> BitcoinGUI::currentPSGTPoolEntries() const
+{
+    std::vector<PSGTToastDamp::Entry> pool;
+
+    for (const auto& row : m_psgt_pool_context->entries()) {
+        pool.push_back({row.revision_hex, row.image_hex});
+    }
+
+    return pool;
+}
+
 void BitcoinGUI::handlePSGTPoolChanged(QString revision_hash, quint8 change_type, int reason)
 {
-    // The toast fires only on add/update, so the removal reason is unused here;
-    // the table model consumes it (to label the history row).
+    // The removal reason is unused here; the table model consumes it (to label
+    // the history row).
     Q_UNUSED(reason);
 
-    // Toast only for an entry that newly needs THIS wallet's signature.
-    if (change_type == CT_DELETED || !clientModel || !m_psgt_pool_context) {
+    if (!clientModel || !m_psgt_pool_context) {
         return;
     }
 
-    const bool needs_me = m_psgt_pool_context->walletMustSignRevision(revision_hash.toStdString());
+    const std::string revision_hex = revision_hash.toStdString();
 
-    if (needs_me && notificator) {
-        notificator->notify(
-            Notificator::Information,
-            tr("Multisig signature requested"),
-            tr("A multisig transaction is waiting for your signature. Open the "
-               "PSGT pool to review and sign it."));
+    // A removal is the only point at which the pool shrinks. Forget the
+    // arrangements that left with it, so an image submitted again later is a
+    // new request and is announced again.
+    if (change_type == CT_DELETED) {
+        m_psgt_toast_damp.Prune(currentPSGTPoolEntries());
+        return;
     }
+
+    // Toast only for an entry that needs THIS wallet's signature.
+    if (!m_psgt_pool_context->walletMustSignRevision(revision_hex) || !notificator) {
+        return;
+    }
+
+    // Every co-signer's revision fires this handler, and walletMustSignRevision
+    // answers true for all of them until this wallet signs, so the predicate
+    // alone would announce the same request once per co-signer.
+    if (!m_psgt_toast_damp.ShouldToastRevision(currentPSGTPoolEntries(), revision_hex)) {
+        return;
+    }
+
+    notificator->notify(
+        Notificator::Information,
+        tr("Multisig signature requested"),
+        tr("A multisig transaction is waiting for your signature. Open the "
+           "PSGT pool to review and sign it."));
 }
 
 void BitcoinGUI::dragEnterEvent(QDragEnterEvent *event)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1761,7 +1761,7 @@ std::vector<PSGTToastDamp::Entry> BitcoinGUI::currentPSGTPoolEntries() const
     std::vector<PSGTToastDamp::Entry> pool;
 
     for (const auto& row : m_psgt_pool_context->entries()) {
-        pool.push_back({row.revision_hex, row.image_hex});
+        pool.push_back({row.revision_hex, row.tx_hash_hex});
     }
 
     return pool;
@@ -1779,9 +1779,9 @@ void BitcoinGUI::handlePSGTPoolChanged(QString revision_hash, quint8 change_type
 
     const std::string revision_hex = revision_hash.toStdString();
 
-    // A removal is the only point at which the pool shrinks. Forget the
-    // arrangements that left with it, so an image submitted again later is a
-    // new request and is announced again.
+    // A removal is the only point at which the pool shrinks. Forget the spends
+    // that left with it, so a transaction submitted again later is a new
+    // request and is announced again.
     if (change_type == CT_DELETED) {
         m_psgt_toast_damp.Prune(currentPSGTPoolEntries());
         return;
@@ -1794,7 +1794,10 @@ void BitcoinGUI::handlePSGTPoolChanged(QString revision_hash, quint8 change_type
 
     // Every co-signer's revision fires this handler, and walletMustSignRevision
     // answers true for all of them until this wallet signs, so the predicate
-    // alone would announce the same request once per co-signer.
+    // alone would announce the same request once per co-signer. The damp keys
+    // on the unsigned transaction, so an initiator superseding the pending
+    // spend with a different transaction (delivered as an update under the
+    // same image) is announced as the new request it is.
     if (!m_psgt_toast_damp.ShouldToastRevision(currentPSGTPoolEntries(), revision_hex)) {
         return;
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1780,10 +1780,12 @@ void BitcoinGUI::handlePSGTPoolChanged(QString revision_hash, quint8 change_type
     const std::string revision_hex = revision_hash.toStdString();
 
     // A removal is the only point at which the pool shrinks. Forget the spends
-    // that left with it, so a transaction submitted again later is a new
-    // request and is announced again.
+    // that left with it. Every GUI wallet sees every network PSGT leave the
+    // pool, so skip the pool fetch when there is nothing remembered.
     if (change_type == CT_DELETED) {
-        m_psgt_toast_damp.Prune(currentPSGTPoolEntries());
+        if (m_psgt_toast_damp.AnnouncedCount() > 0) {
+            m_psgt_toast_damp.Prune(currentPSGTPoolEntries());
+        }
         return;
     }
 
@@ -1794,11 +1796,17 @@ void BitcoinGUI::handlePSGTPoolChanged(QString revision_hash, quint8 change_type
 
     // Every co-signer's revision fires this handler, and walletMustSignRevision
     // answers true for all of them until this wallet signs, so the predicate
-    // alone would announce the same request once per co-signer. The damp keys
-    // on the unsigned transaction, so an initiator superseding the pending
-    // spend with a different transaction (delivered as an update under the
-    // same image) is announced as the new request it is.
-    if (!m_psgt_toast_damp.ShouldToastRevision(currentPSGTPoolEntries(), revision_hex)) {
+    // alone would announce the same request once per co-signer ahead of this
+    // wallet (at most m-1 times for an m-of-n; never twice for a 2-of-3). The
+    // damp keys on the unsigned transaction, so an initiator superseding the
+    // pending spend with a different transaction (delivered as an update under
+    // the same image) is announced as the new request it is. CT_NEW means the
+    // pool's image slot was empty when this revision arrived, i.e. a new
+    // request by the pool's own definition: it is announced regardless of what
+    // the damp remembers, so the decision does not depend on the order in
+    // which a removal and a resubmission reach this thread.
+    if (!m_psgt_toast_damp.ShouldToastRevision(currentPSGTPoolEntries(), revision_hex,
+                                               /*first_revision=*/change_type == CT_NEW)) {
         return;
     }
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include "guiconstants.h"
 #include "guiipcinfo.h"
+#include "psgttoastdamp.h"
 #include "interfaces/wallet_tx_channel.h" // GRC::WalletEvent for processDrainedTransactions
 
 #ifdef Q_OS_MAC
@@ -140,6 +141,12 @@ private:
     ClientModel *clientModel;
     WalletModel *walletModel;
     interfaces::PSGTPoolContext *m_psgt_pool_context = nullptr;
+    //! Keeps one multisig arrangement from toasting once per co-signer's
+    //! revision while this wallet's own signature is still outstanding.
+    PSGTToastDamp m_psgt_toast_damp;
+
+    //! The pool as the damp needs to see it: revision -> arrangement.
+    std::vector<PSGTToastDamp::Entry> currentPSGTPoolEntries() const;
     ResearcherModel *researcherModel;
     MRCModel *m_mrc_model;
     VotingModel *votingModel;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -141,11 +141,11 @@ private:
     ClientModel *clientModel;
     WalletModel *walletModel;
     interfaces::PSGTPoolContext *m_psgt_pool_context = nullptr;
-    //! Keeps one multisig arrangement from toasting once per co-signer's
+    //! Keeps one pending multisig spend from toasting once per co-signer's
     //! revision while this wallet's own signature is still outstanding.
     PSGTToastDamp m_psgt_toast_damp;
 
-    //! The pool as the damp needs to see it: revision -> arrangement.
+    //! The pool as the damp needs to see it: revision -> unsigned transaction.
     std::vector<PSGTToastDamp::Entry> currentPSGTPoolEntries() const;
     ResearcherModel *researcherModel;
     MRCModel *m_mrc_model;

--- a/src/qt/psgttoastdamp.h
+++ b/src/qt/psgttoastdamp.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_PSGTTOASTDAMP_H
+#define GRIDCOIN_QT_PSGTTOASTDAMP_H
+
+#include <algorithm>
+#include <cstddef>
+#include <set>
+#include <string>
+#include <vector>
+
+//!
+//! \brief Decides whether a PSGT pool change should raise a "needs your
+//! signature" toast.
+//!
+//! One multisig arrangement collects a revision per co-signer, and each of them
+//! fires the pool-changed notification. walletMustSignRevision only stops the
+//! toast once this wallet has signed, so up to that point the same request is
+//! announced once per co-signer who signs ahead of it. Keying on the
+//! arrangement instead of the revision announces it once: the revisions of one
+//! arrangement share a pool image, which is what identifies the arrangement.
+//!
+//! Session-scoped and deliberately not persisted. The behaviour being damped is
+//! repetition within one sitting; a restart re-announcing a request the wallet
+//! still has not signed is wanted, not a leak.
+//!
+class PSGTToastDamp
+{
+public:
+    //! One pool entry, reduced to the two identities this decision needs.
+    struct Entry
+    {
+        std::string revision_hex; //!< The revision the notification names.
+        std::string image_hex;    //!< The arrangement the revision belongs to.
+    };
+
+    //!
+    //! \brief Whether a pool change naming \p revision_hex should be announced.
+    //!
+    //! Records the arrangement when it answers true, so the co-signer revisions
+    //! that follow are silent.
+    //!
+    //! \param pool The pool as it stands, used to resolve the arrangement.
+    //! \param revision_hex The revision the notification named.
+    //!
+    //! \return \c true for the first revision of an arrangement. A revision
+    //! that does not resolve to an arrangement is announced rather than
+    //! swallowed on the strength of a lookup that failed. The caller gates on
+    //! walletMustSignRevision first, and that already answers false for a
+    //! revision the pool has dropped, so what reaches this is the narrow race
+    //! between those two calls.
+    //!
+    bool ShouldToastRevision(const std::vector<Entry>& pool, const std::string& revision_hex)
+    {
+        const auto entry = std::find_if(pool.begin(), pool.end(), [&revision_hex](const Entry& candidate) {
+            return candidate.revision_hex == revision_hex;
+        });
+
+        if (entry == pool.end()) {
+            return true;
+        }
+
+        return m_announced.insert(entry->image_hex).second;
+    }
+
+    //!
+    //! \brief Forgets arrangements that are no longer in the pool.
+    //!
+    //! An arrangement that leaves the pool and is later submitted again is a
+    //! new request, and is announced again. Called on removal, the only point
+    //! at which the pool shrinks.
+    //!
+    //! \param pool The pool as it stands after the removal.
+    //!
+    void Prune(const std::vector<Entry>& pool)
+    {
+        std::set<std::string> live;
+
+        for (const Entry& entry : pool) {
+            live.insert(entry.image_hex);
+        }
+
+        for (auto it = m_announced.begin(); it != m_announced.end();) {
+            it = live.count(*it) ? std::next(it) : m_announced.erase(it);
+        }
+    }
+
+    //! \brief How many arrangements are currently remembered. For tests.
+    std::size_t AnnouncedCount() const { return m_announced.size(); }
+
+private:
+    std::set<std::string> m_announced;
+};
+
+#endif // GRIDCOIN_QT_PSGTTOASTDAMP_H

--- a/src/qt/psgttoastdamp.h
+++ b/src/qt/psgttoastdamp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2026 The Gridcoin developers
+// Copyright (c) 2026 The Gridcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -16,11 +16,14 @@
 //! \brief Decides whether a PSGT pool change should raise a "needs your
 //! signature" toast.
 //!
-//! One pending spend collects a revision per co-signer, and each of them fires
-//! the pool-changed notification. walletMustSignRevision only stops the toast
-//! once this wallet has signed, so up to that point the same request is
-//! announced once per co-signer who signs ahead of it. Keying on the spend
-//! instead of the revision announces it once.
+//! One pending spend collects a revision per co-signer who signs ahead of this
+//! wallet, and each of them fires the pool-changed notification.
+//! walletMustSignRevision only stops the toast once this wallet has signed, so
+//! up to that point the same request is announced once per such revision. The
+//! pool never holds a complete revision, so an m-of-n pools at most m-1
+//! revisions of one transaction: a 2-of-3 never repeats, a 3-of-5 announces
+//! the same request twice. Keying on the spend instead of the revision
+//! announces it once.
 //!
 //! The spend is identified by the hash of its UNSIGNED transaction
 //! (PSGTPoolRow::tx_hash_hex), not by the pool image. The image is the
@@ -30,6 +33,13 @@
 //! UPDATED change as signature progress. That is a new request and must be
 //! announced, so the image would be the wrong key. Every signature revision of
 //! one spend shares its unsigned-transaction hash; a supersede changes it.
+//!
+//! The pool reports the first revision to land in an empty image slot as a
+//! new entry (CT_NEW) and later revisions as updates (CT_UPDATED). A first
+//! revision is announced unconditionally: it is a new request by the pool's
+//! own definition, and deciding it from what this class remembers would make
+//! the outcome depend on whether the removal that emptied the slot was
+//! processed on this thread before the resubmission. Only updates are damped.
 //!
 //! Session-scoped and deliberately not persisted. The behaviour being damped is
 //! repetition within one sitting; a restart re-announcing a request the wallet
@@ -55,15 +65,18 @@ public:
     //!
     //! \param pool The pool as it stands, used to resolve the spend.
     //! \param revision_hex The revision the notification named.
+    //! \param first_revision The pool reported this revision as the first for
+    //! its image slot (CT_NEW). Announced and recorded unconditionally.
     //!
     //! \return \c true for the first revision of a spend. A revision that does
     //! not resolve to a spend is announced rather than swallowed on the
     //! strength of a lookup that failed. The caller gates on
     //! walletMustSignRevision first, and that already answers false for a
     //! revision the pool has dropped, so what reaches this is the narrow race
-    //! between those two calls.
+    //! between those two calls; its cost is a repeated toast, never a lost one.
     //!
-    bool ShouldToastRevision(const std::vector<Entry>& pool, const std::string& revision_hex)
+    bool ShouldToastRevision(const std::vector<Entry>& pool, const std::string& revision_hex,
+                             bool first_revision)
     {
         Prune(pool);
 
@@ -72,6 +85,11 @@ public:
         });
 
         if (entry == pool.end()) {
+            return true;
+        }
+
+        if (first_revision) {
+            m_announced.insert(entry->tx_hash_hex);
             return true;
         }
 

--- a/src/qt/psgttoastdamp.h
+++ b/src/qt/psgttoastdamp.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <iterator>
 #include <set>
 #include <string>
 #include <vector>
@@ -15,12 +16,20 @@
 //! \brief Decides whether a PSGT pool change should raise a "needs your
 //! signature" toast.
 //!
-//! One multisig arrangement collects a revision per co-signer, and each of them
-//! fires the pool-changed notification. walletMustSignRevision only stops the
-//! toast once this wallet has signed, so up to that point the same request is
-//! announced once per co-signer who signs ahead of it. Keying on the
-//! arrangement instead of the revision announces it once: the revisions of one
-//! arrangement share a pool image, which is what identifies the arrangement.
+//! One pending spend collects a revision per co-signer, and each of them fires
+//! the pool-changed notification. walletMustSignRevision only stops the toast
+//! once this wallet has signed, so up to that point the same request is
+//! announced once per co-signer who signs ahead of it. Keying on the spend
+//! instead of the revision announces it once.
+//!
+//! The spend is identified by the hash of its UNSIGNED transaction
+//! (PSGTPoolRow::tx_hash_hex), not by the pool image. The image is the
+//! arrangement's redeem-script id, and the pool lets an initiator supersede a
+//! pending spend with a DIFFERENT transaction under the same image
+//! (PSGTPool::Add, "same image, different unsigned tx"), delivered as the same
+//! UPDATED change as signature progress. That is a new request and must be
+//! announced, so the image would be the wrong key. Every signature revision of
+//! one spend shares its unsigned-transaction hash; a supersede changes it.
 //!
 //! Session-scoped and deliberately not persisted. The behaviour being damped is
 //! repetition within one sitting; a restart re-announcing a request the wallet
@@ -33,27 +42,31 @@ public:
     struct Entry
     {
         std::string revision_hex; //!< The revision the notification names.
-        std::string image_hex;    //!< The arrangement the revision belongs to.
+        std::string tx_hash_hex;  //!< The unsigned transaction: the spend the revision belongs to.
     };
 
     //!
     //! \brief Whether a pool change naming \p revision_hex should be announced.
     //!
-    //! Records the arrangement when it answers true, so the co-signer revisions
-    //! that follow are silent.
+    //! Forgets spends that are no longer in \p pool first, so a spend that was
+    //! superseded or removed and is later submitted again counts as the new
+    //! request it is. Then records the named revision's spend when it answers
+    //! true, so the co-signer revisions that follow are silent.
     //!
-    //! \param pool The pool as it stands, used to resolve the arrangement.
+    //! \param pool The pool as it stands, used to resolve the spend.
     //! \param revision_hex The revision the notification named.
     //!
-    //! \return \c true for the first revision of an arrangement. A revision
-    //! that does not resolve to an arrangement is announced rather than
-    //! swallowed on the strength of a lookup that failed. The caller gates on
+    //! \return \c true for the first revision of a spend. A revision that does
+    //! not resolve to a spend is announced rather than swallowed on the
+    //! strength of a lookup that failed. The caller gates on
     //! walletMustSignRevision first, and that already answers false for a
     //! revision the pool has dropped, so what reaches this is the narrow race
     //! between those two calls.
     //!
     bool ShouldToastRevision(const std::vector<Entry>& pool, const std::string& revision_hex)
     {
+        Prune(pool);
+
         const auto entry = std::find_if(pool.begin(), pool.end(), [&revision_hex](const Entry& candidate) {
             return candidate.revision_hex == revision_hex;
         });
@@ -62,24 +75,25 @@ public:
             return true;
         }
 
-        return m_announced.insert(entry->image_hex).second;
+        return m_announced.insert(entry->tx_hash_hex).second;
     }
 
     //!
-    //! \brief Forgets arrangements that are no longer in the pool.
+    //! \brief Forgets spends that are no longer in the pool.
     //!
-    //! An arrangement that leaves the pool and is later submitted again is a
-    //! new request, and is announced again. Called on removal, the only point
-    //! at which the pool shrinks.
+    //! A spend that leaves the pool -- removed, expired, completed, evicted by a
+    //! conflict, or superseded by a different transaction -- and is later
+    //! submitted again is a new request, and is announced again. Called on
+    //! removal, and by ShouldToastRevision before every decision.
     //!
-    //! \param pool The pool as it stands after the removal.
+    //! \param pool The pool as it stands.
     //!
     void Prune(const std::vector<Entry>& pool)
     {
         std::set<std::string> live;
 
         for (const Entry& entry : pool) {
-            live.insert(entry.image_hex);
+            live.insert(entry.tx_hash_hex);
         }
 
         for (auto it = m_announced.begin(); it != m_announced.end();) {
@@ -87,7 +101,7 @@ public:
         }
     }
 
-    //! \brief How many arrangements are currently remembered. For tests.
+    //! \brief How many spends are currently remembered. For tests.
     std::size_t AnnouncedCount() const { return m_announced.size(); }
 
 private:

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(test_gridcoin-qt
     sidestakemodeltests.cpp
     coinselectionmodeltests.cpp
     coinselectionviewtests.cpp
+    psgttoastdamptests.cpp
 )
 
 set_target_properties(test_gridcoin-qt PROPERTIES

--- a/src/qt/test/psgttoastdamptests.cpp
+++ b/src/qt/test/psgttoastdamptests.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/test/psgttoastdamptests.h"
+
+#include "qt/psgttoastdamp.h"
+
+#include <string>
+#include <vector>
+
+//!
+//! \file psgttoastdamptests.cpp
+//! \brief The damp that keeps a multisig arrangement from toasting once per
+//! co-signer's revision.
+//!
+//! The pool-changed notification carries a revision hash, and every co-signer
+//! who signs ahead of this wallet produces one. walletMustSignRevision answers
+//! true for each of them until this wallet signs, so the toast decision cannot
+//! come from that predicate alone: it has to resolve the revision back to the
+//! arrangement, which is what these cases drive.
+//!
+
+namespace {
+const std::string ARRANGEMENT_A("a1b2c3d4e5f60718293a4b5c6d7e8f9012345678");
+const std::string ARRANGEMENT_B("fedcba98765432100123456789abcdef01234567");
+
+//! Three co-signers have revised arrangement A; B has one revision.
+std::vector<PSGTToastDamp::Entry> Pool()
+{
+    return {
+        {"rev-a-1", ARRANGEMENT_A},
+        {"rev-a-2", ARRANGEMENT_A},
+        {"rev-a-3", ARRANGEMENT_A},
+        {"rev-b-1", ARRANGEMENT_B},
+    };
+}
+} // anonymous namespace
+
+void PSGTToastDampTests::oneArrangementAnnouncesOnceAcrossItsRevisions()
+{
+    PSGTToastDamp damp;
+    const std::vector<PSGTToastDamp::Entry> pool = Pool();
+
+    // Three revisions of the same arrangement reach the handler, all of them
+    // still needing this wallet. Without the damp all three would toast.
+    QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
+    QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-2"));
+    QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-3"));
+
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
+}
+
+void PSGTToastDampTests::separateArrangementsEachAnnounce()
+{
+    PSGTToastDamp damp;
+    const std::vector<PSGTToastDamp::Entry> pool = Pool();
+
+    // Damping is per arrangement, not a global mute: a second multisig waiting
+    // on this wallet is still announced.
+    QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
+    QVERIFY(damp.ShouldToastRevision(pool, "rev-b-1"));
+    QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-2"));
+    QVERIFY(!damp.ShouldToastRevision(pool, "rev-b-1"));
+
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(2));
+}
+
+void PSGTToastDampTests::anUnknownRevisionIsAnnouncedNotSwallowed()
+{
+    PSGTToastDamp damp;
+    const std::vector<PSGTToastDamp::Entry> pool = Pool();
+
+    // A revision that does not resolve to an arrangement has nothing to damp
+    // on. walletMustSignRevision gates the caller first and already answers
+    // false for a revision the pool has dropped, so this is the narrow race
+    // between those two calls -- but announcing is the safe side of a lookup
+    // that failed: silence decided by a failure would repeat.
+    QVERIFY(damp.ShouldToastRevision(pool, "rev-gone"));
+    QVERIFY(damp.ShouldToastRevision(pool, "rev-gone"));
+
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(0));
+}
+
+void PSGTToastDampTests::removalForgetsOnlyTheEntriesThatLeft()
+{
+    PSGTToastDamp damp;
+    const std::vector<PSGTToastDamp::Entry> pool = Pool();
+
+    damp.ShouldToastRevision(pool, "rev-a-1");
+    damp.ShouldToastRevision(pool, "rev-b-1");
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(2));
+
+    // A leaves the pool, B stays.
+    const std::vector<PSGTToastDamp::Entry> after = {{"rev-b-1", ARRANGEMENT_B}};
+    damp.Prune(after);
+
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
+    QVERIFY(!damp.ShouldToastRevision(after, "rev-b-1"));
+}
+
+void PSGTToastDampTests::aResubmittedArrangementAnnouncesAgain()
+{
+    PSGTToastDamp damp;
+    const std::vector<PSGTToastDamp::Entry> pool = Pool();
+
+    QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
+    QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-2"));
+
+    // The arrangement is removed, so the pool is empty.
+    damp.Prune(std::vector<PSGTToastDamp::Entry>());
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(0));
+
+    // The same image submitted again is a new request, not the old one.
+    QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
+}

--- a/src/qt/test/psgttoastdamptests.cpp
+++ b/src/qt/test/psgttoastdamptests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2026 The Gridcoin developers
+// Copyright (c) 2026 The Gridcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -15,11 +15,16 @@
 //! co-signer's revision.
 //!
 //! The pool-changed notification carries a revision hash, and every co-signer
-//! who signs ahead of this wallet produces one. walletMustSignRevision answers
-//! true for each of them until this wallet signs, so the toast decision cannot
-//! come from that predicate alone: it has to resolve the revision back to the
-//! spend -- the unsigned transaction, which every signature revision shares and
-//! an initiator supersede changes -- which is what these cases drive.
+//! who signs ahead of this wallet produces one (at most m-1 of them for an
+//! m-of-n, since the pool never holds a complete revision). walletMustSignRevision
+//! answers true for each of them until this wallet signs, so the toast decision
+//! cannot come from that predicate alone: it has to resolve the revision back to
+//! the spend -- the unsigned transaction, which every signature revision shares
+//! and an initiator supersede changes -- which is what these cases drive.
+//!
+//! The pool keeps one entry per image, so successive revisions of one spend
+//! never coexist: each case feeds the damp the pool as it stands at each
+//! notification, one row per image.
 //!
 
 namespace {
@@ -28,28 +33,22 @@ const std::string SPEND_A("a1b2c3d4e5f60718293a4b5c6d7e8f9012345678a1b2c3d4e5f60
 const std::string SPEND_B("fedcba98765432100123456789abcdef01234567fedcba987654321001234567");
 const std::string SPEND_C("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
 
-//! Three co-signers have revised spend A; B has one revision.
-std::vector<PSGTToastDamp::Entry> Pool()
-{
-    return {
-        {"rev-a-1", SPEND_A},
-        {"rev-a-2", SPEND_A},
-        {"rev-a-3", SPEND_A},
-        {"rev-b-1", SPEND_B},
-    };
-}
+using Pool = std::vector<PSGTToastDamp::Entry>;
+
+constexpr bool FIRST = true;   //!< CT_NEW: first revision in an empty image slot.
+constexpr bool UPDATE = false; //!< CT_UPDATED: a later revision replacing it.
 } // anonymous namespace
 
 void PSGTToastDampTests::oneSpendAnnouncesOnceAcrossItsRevisions()
 {
     PSGTToastDamp damp;
-    const std::vector<PSGTToastDamp::Entry> pool = Pool();
 
-    // Three revisions of the same spend reach the handler, all of them still
-    // needing this wallet. Without the damp all three would toast.
-    QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
-    QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-2"));
-    QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-3"));
+    // The initiator's revision lands, then two co-signers each replace it with
+    // a revision carrying one more signature. All three still need this
+    // wallet. Without the damp all three would toast.
+    QVERIFY(damp.ShouldToastRevision(Pool{{"rev-a-1", SPEND_A}}, "rev-a-1", FIRST));
+    QVERIFY(!damp.ShouldToastRevision(Pool{{"rev-a-2", SPEND_A}}, "rev-a-2", UPDATE));
+    QVERIFY(!damp.ShouldToastRevision(Pool{{"rev-a-3", SPEND_A}}, "rev-a-3", UPDATE));
 
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
 }
@@ -57,14 +56,13 @@ void PSGTToastDampTests::oneSpendAnnouncesOnceAcrossItsRevisions()
 void PSGTToastDampTests::separateSpendsEachAnnounce()
 {
     PSGTToastDamp damp;
-    const std::vector<PSGTToastDamp::Entry> pool = Pool();
 
     // Damping is per spend, not a global mute: a second multisig waiting on
-    // this wallet is still announced.
-    QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
-    QVERIFY(damp.ShouldToastRevision(pool, "rev-b-1"));
-    QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-2"));
-    QVERIFY(!damp.ShouldToastRevision(pool, "rev-b-1"));
+    // this wallet is still announced, and each keeps damping its own updates.
+    QVERIFY(damp.ShouldToastRevision(Pool{{"rev-a-1", SPEND_A}}, "rev-a-1", FIRST));
+    QVERIFY(damp.ShouldToastRevision(Pool{{"rev-a-1", SPEND_A}, {"rev-b-1", SPEND_B}}, "rev-b-1", FIRST));
+    QVERIFY(!damp.ShouldToastRevision(Pool{{"rev-a-2", SPEND_A}, {"rev-b-1", SPEND_B}}, "rev-a-2", UPDATE));
+    QVERIFY(!damp.ShouldToastRevision(Pool{{"rev-a-2", SPEND_A}, {"rev-b-2", SPEND_B}}, "rev-b-2", UPDATE));
 
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(2));
 }
@@ -72,15 +70,15 @@ void PSGTToastDampTests::separateSpendsEachAnnounce()
 void PSGTToastDampTests::anUnknownRevisionIsAnnouncedNotSwallowed()
 {
     PSGTToastDamp damp;
-    const std::vector<PSGTToastDamp::Entry> pool = Pool();
+    const Pool pool{{"rev-a-1", SPEND_A}};
 
     // A revision that does not resolve to a spend has nothing to damp on.
     // walletMustSignRevision gates the caller first and already answers false
     // for a revision the pool has dropped, so this is the narrow race between
     // those two calls -- but announcing is the safe side of a lookup that
     // failed: silence decided by a failure would repeat.
-    QVERIFY(damp.ShouldToastRevision(pool, "rev-gone"));
-    QVERIFY(damp.ShouldToastRevision(pool, "rev-gone"));
+    QVERIFY(damp.ShouldToastRevision(pool, "rev-gone", UPDATE));
+    QVERIFY(damp.ShouldToastRevision(pool, "rev-gone", UPDATE));
 
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(0));
 }
@@ -88,34 +86,32 @@ void PSGTToastDampTests::anUnknownRevisionIsAnnouncedNotSwallowed()
 void PSGTToastDampTests::removalForgetsOnlyTheEntriesThatLeft()
 {
     PSGTToastDamp damp;
-    const std::vector<PSGTToastDamp::Entry> pool = Pool();
 
-    damp.ShouldToastRevision(pool, "rev-a-1");
-    damp.ShouldToastRevision(pool, "rev-b-1");
+    damp.ShouldToastRevision(Pool{{"rev-a-1", SPEND_A}}, "rev-a-1", FIRST);
+    damp.ShouldToastRevision(Pool{{"rev-a-1", SPEND_A}, {"rev-b-1", SPEND_B}}, "rev-b-1", FIRST);
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(2));
 
     // A leaves the pool, B stays.
-    const std::vector<PSGTToastDamp::Entry> after = {{"rev-b-1", SPEND_B}};
+    const Pool after{{"rev-b-1", SPEND_B}};
     damp.Prune(after);
 
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
-    QVERIFY(!damp.ShouldToastRevision(after, "rev-b-1"));
+    QVERIFY(!damp.ShouldToastRevision(Pool{{"rev-b-2", SPEND_B}}, "rev-b-2", UPDATE));
 }
 
 void PSGTToastDampTests::aResubmittedSpendAnnouncesAgain()
 {
     PSGTToastDamp damp;
-    const std::vector<PSGTToastDamp::Entry> pool = Pool();
 
-    QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
-    QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-2"));
+    QVERIFY(damp.ShouldToastRevision(Pool{{"rev-a-1", SPEND_A}}, "rev-a-1", FIRST));
+    QVERIFY(!damp.ShouldToastRevision(Pool{{"rev-a-2", SPEND_A}}, "rev-a-2", UPDATE));
 
     // The spend is removed, so the pool is empty.
-    damp.Prune(std::vector<PSGTToastDamp::Entry>());
+    damp.Prune(Pool{});
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(0));
 
     // The same transaction submitted again is a new request, not the old one.
-    QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
+    QVERIFY(damp.ShouldToastRevision(Pool{{"rev-a-1", SPEND_A}}, "rev-a-1", FIRST));
 }
 
 void PSGTToastDampTests::aSupersedeUnderTheSameImageAnnouncesAgain()
@@ -123,22 +119,43 @@ void PSGTToastDampTests::aSupersedeUnderTheSameImageAnnouncesAgain()
     PSGTToastDamp damp;
 
     // Spend A waits for this wallet: announced once.
-    const std::vector<PSGTToastDamp::Entry> before = {{"rev-a-1", SPEND_A}};
-    QVERIFY(damp.ShouldToastRevision(before, "rev-a-1"));
+    const Pool before{{"rev-a-1", SPEND_A}};
+    QVERIFY(damp.ShouldToastRevision(before, "rev-a-1", FIRST));
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
 
     // The initiator supersedes it with a DIFFERENT transaction from the same
     // arrangement. The pool keeps one entry per image, so this arrives as an
-    // update under the same image with a revision of the new unsigned
+    // UPDATE under the same image with a revision of the new unsigned
     // transaction, and the old spend is gone from the pool. It is a new
     // request and must be announced -- the image would have been the wrong
     // key, the transaction hash is the right one.
-    const std::vector<PSGTToastDamp::Entry> after = {{"rev-c-1", SPEND_C}};
-    QVERIFY(damp.ShouldToastRevision(after, "rev-c-1"));
-    QVERIFY(!damp.ShouldToastRevision(after, "rev-c-1"));
+    const Pool after{{"rev-c-1", SPEND_C}};
+    QVERIFY(damp.ShouldToastRevision(after, "rev-c-1", UPDATE));
+    QVERIFY(!damp.ShouldToastRevision(Pool{{"rev-c-2", SPEND_C}}, "rev-c-2", UPDATE));
 
     // The superseded spend was forgotten along the way, so reverting to it is
     // announced again too.
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
-    QVERIFY(damp.ShouldToastRevision(before, "rev-a-1"));
+    QVERIFY(damp.ShouldToastRevision(before, "rev-a-1", UPDATE));
+}
+
+void PSGTToastDampTests::aFirstRevisionAnnouncesRegardlessOfDeliveryOrder()
+{
+    PSGTToastDamp damp;
+
+    QVERIFY(damp.ShouldToastRevision(Pool{{"rev-a-1", SPEND_A}}, "rev-a-1", FIRST));
+
+    // The spend is removed and the same transaction is resubmitted before
+    // this thread processes the removal, so the removal's prune sees the
+    // resubmission live and keeps the key. The resubmission still arrives as
+    // the first revision of an empty image slot, and that alone decides it:
+    // announced, whatever the damp remembers.
+    const Pool resubmitted{{"rev-a-1b", SPEND_A}};
+    damp.Prune(resubmitted);
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
+    QVERIFY(damp.ShouldToastRevision(resubmitted, "rev-a-1b", FIRST));
+
+    // And its later revisions are damped as usual.
+    QVERIFY(!damp.ShouldToastRevision(Pool{{"rev-a-2b", SPEND_A}}, "rev-a-2b", UPDATE));
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
 }

--- a/src/qt/test/psgttoastdamptests.cpp
+++ b/src/qt/test/psgttoastdamptests.cpp
@@ -11,39 +11,42 @@
 
 //!
 //! \file psgttoastdamptests.cpp
-//! \brief The damp that keeps a multisig arrangement from toasting once per
+//! \brief The damp that keeps a pending multisig spend from toasting once per
 //! co-signer's revision.
 //!
 //! The pool-changed notification carries a revision hash, and every co-signer
 //! who signs ahead of this wallet produces one. walletMustSignRevision answers
 //! true for each of them until this wallet signs, so the toast decision cannot
 //! come from that predicate alone: it has to resolve the revision back to the
-//! arrangement, which is what these cases drive.
+//! spend -- the unsigned transaction, which every signature revision shares and
+//! an initiator supersede changes -- which is what these cases drive.
 //!
 
 namespace {
-const std::string ARRANGEMENT_A("a1b2c3d4e5f60718293a4b5c6d7e8f9012345678");
-const std::string ARRANGEMENT_B("fedcba98765432100123456789abcdef01234567");
+//! Unsigned-transaction hashes: the identity of a pending spend.
+const std::string SPEND_A("a1b2c3d4e5f60718293a4b5c6d7e8f9012345678a1b2c3d4e5f60718293a4b5c");
+const std::string SPEND_B("fedcba98765432100123456789abcdef01234567fedcba987654321001234567");
+const std::string SPEND_C("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
 
-//! Three co-signers have revised arrangement A; B has one revision.
+//! Three co-signers have revised spend A; B has one revision.
 std::vector<PSGTToastDamp::Entry> Pool()
 {
     return {
-        {"rev-a-1", ARRANGEMENT_A},
-        {"rev-a-2", ARRANGEMENT_A},
-        {"rev-a-3", ARRANGEMENT_A},
-        {"rev-b-1", ARRANGEMENT_B},
+        {"rev-a-1", SPEND_A},
+        {"rev-a-2", SPEND_A},
+        {"rev-a-3", SPEND_A},
+        {"rev-b-1", SPEND_B},
     };
 }
 } // anonymous namespace
 
-void PSGTToastDampTests::oneArrangementAnnouncesOnceAcrossItsRevisions()
+void PSGTToastDampTests::oneSpendAnnouncesOnceAcrossItsRevisions()
 {
     PSGTToastDamp damp;
     const std::vector<PSGTToastDamp::Entry> pool = Pool();
 
-    // Three revisions of the same arrangement reach the handler, all of them
-    // still needing this wallet. Without the damp all three would toast.
+    // Three revisions of the same spend reach the handler, all of them still
+    // needing this wallet. Without the damp all three would toast.
     QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
     QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-2"));
     QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-3"));
@@ -51,13 +54,13 @@ void PSGTToastDampTests::oneArrangementAnnouncesOnceAcrossItsRevisions()
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
 }
 
-void PSGTToastDampTests::separateArrangementsEachAnnounce()
+void PSGTToastDampTests::separateSpendsEachAnnounce()
 {
     PSGTToastDamp damp;
     const std::vector<PSGTToastDamp::Entry> pool = Pool();
 
-    // Damping is per arrangement, not a global mute: a second multisig waiting
-    // on this wallet is still announced.
+    // Damping is per spend, not a global mute: a second multisig waiting on
+    // this wallet is still announced.
     QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
     QVERIFY(damp.ShouldToastRevision(pool, "rev-b-1"));
     QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-2"));
@@ -71,11 +74,11 @@ void PSGTToastDampTests::anUnknownRevisionIsAnnouncedNotSwallowed()
     PSGTToastDamp damp;
     const std::vector<PSGTToastDamp::Entry> pool = Pool();
 
-    // A revision that does not resolve to an arrangement has nothing to damp
-    // on. walletMustSignRevision gates the caller first and already answers
-    // false for a revision the pool has dropped, so this is the narrow race
-    // between those two calls -- but announcing is the safe side of a lookup
-    // that failed: silence decided by a failure would repeat.
+    // A revision that does not resolve to a spend has nothing to damp on.
+    // walletMustSignRevision gates the caller first and already answers false
+    // for a revision the pool has dropped, so this is the narrow race between
+    // those two calls -- but announcing is the safe side of a lookup that
+    // failed: silence decided by a failure would repeat.
     QVERIFY(damp.ShouldToastRevision(pool, "rev-gone"));
     QVERIFY(damp.ShouldToastRevision(pool, "rev-gone"));
 
@@ -92,14 +95,14 @@ void PSGTToastDampTests::removalForgetsOnlyTheEntriesThatLeft()
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(2));
 
     // A leaves the pool, B stays.
-    const std::vector<PSGTToastDamp::Entry> after = {{"rev-b-1", ARRANGEMENT_B}};
+    const std::vector<PSGTToastDamp::Entry> after = {{"rev-b-1", SPEND_B}};
     damp.Prune(after);
 
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
     QVERIFY(!damp.ShouldToastRevision(after, "rev-b-1"));
 }
 
-void PSGTToastDampTests::aResubmittedArrangementAnnouncesAgain()
+void PSGTToastDampTests::aResubmittedSpendAnnouncesAgain()
 {
     PSGTToastDamp damp;
     const std::vector<PSGTToastDamp::Entry> pool = Pool();
@@ -107,10 +110,35 @@ void PSGTToastDampTests::aResubmittedArrangementAnnouncesAgain()
     QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
     QVERIFY(!damp.ShouldToastRevision(pool, "rev-a-2"));
 
-    // The arrangement is removed, so the pool is empty.
+    // The spend is removed, so the pool is empty.
     damp.Prune(std::vector<PSGTToastDamp::Entry>());
     QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(0));
 
-    // The same image submitted again is a new request, not the old one.
+    // The same transaction submitted again is a new request, not the old one.
     QVERIFY(damp.ShouldToastRevision(pool, "rev-a-1"));
+}
+
+void PSGTToastDampTests::aSupersedeUnderTheSameImageAnnouncesAgain()
+{
+    PSGTToastDamp damp;
+
+    // Spend A waits for this wallet: announced once.
+    const std::vector<PSGTToastDamp::Entry> before = {{"rev-a-1", SPEND_A}};
+    QVERIFY(damp.ShouldToastRevision(before, "rev-a-1"));
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
+
+    // The initiator supersedes it with a DIFFERENT transaction from the same
+    // arrangement. The pool keeps one entry per image, so this arrives as an
+    // update under the same image with a revision of the new unsigned
+    // transaction, and the old spend is gone from the pool. It is a new
+    // request and must be announced -- the image would have been the wrong
+    // key, the transaction hash is the right one.
+    const std::vector<PSGTToastDamp::Entry> after = {{"rev-c-1", SPEND_C}};
+    QVERIFY(damp.ShouldToastRevision(after, "rev-c-1"));
+    QVERIFY(!damp.ShouldToastRevision(after, "rev-c-1"));
+
+    // The superseded spend was forgotten along the way, so reverting to it is
+    // announced again too.
+    QCOMPARE(damp.AnnouncedCount(), static_cast<std::size_t>(1));
+    QVERIFY(damp.ShouldToastRevision(before, "rev-a-1"));
 }

--- a/src/qt/test/psgttoastdamptests.h
+++ b/src/qt/test/psgttoastdamptests.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H
+#define GRIDCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+class PSGTToastDampTests : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void oneArrangementAnnouncesOnceAcrossItsRevisions();
+    void separateArrangementsEachAnnounce();
+    void anUnknownRevisionIsAnnouncedNotSwallowed();
+    void removalForgetsOnlyTheEntriesThatLeft();
+    void aResubmittedArrangementAnnouncesAgain();
+};
+
+#endif // GRIDCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H

--- a/src/qt/test/psgttoastdamptests.h
+++ b/src/qt/test/psgttoastdamptests.h
@@ -13,11 +13,12 @@ class PSGTToastDampTests : public QObject
     Q_OBJECT
 
 private slots:
-    void oneArrangementAnnouncesOnceAcrossItsRevisions();
-    void separateArrangementsEachAnnounce();
+    void oneSpendAnnouncesOnceAcrossItsRevisions();
+    void separateSpendsEachAnnounce();
     void anUnknownRevisionIsAnnouncedNotSwallowed();
     void removalForgetsOnlyTheEntriesThatLeft();
-    void aResubmittedArrangementAnnouncesAgain();
+    void aResubmittedSpendAnnouncesAgain();
+    void aSupersedeUnderTheSameImageAnnouncesAgain();
 };
 
 #endif // GRIDCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H

--- a/src/qt/test/psgttoastdamptests.h
+++ b/src/qt/test/psgttoastdamptests.h
@@ -1,9 +1,9 @@
-// Copyright (c) 2014-2026 The Gridcoin developers
+// Copyright (c) 2026 The Gridcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#ifndef GRIDCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H
-#define GRIDCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H
+#ifndef BITCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H
+#define BITCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H
 
 #include <QObject>
 #include <QTest>
@@ -19,6 +19,7 @@ private slots:
     void removalForgetsOnlyTheEntriesThatLeft();
     void aResubmittedSpendAnnouncesAgain();
     void aSupersedeUnderTheSameImageAnnouncesAgain();
+    void aFirstRevisionAnnouncesRegardlessOfDeliveryOrder();
 };
 
-#endif // GRIDCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H
+#endif // BITCOIN_QT_TEST_PSGTTOASTDAMPTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -5,6 +5,7 @@
 #include "bitcoinunitstests.h"
 #include "coinselectionmodeltests.h"
 #include "coinselectionviewtests.h"
+#include "psgttoastdamptests.h"
 #include "sidestakemodeltests.h"
 #include "uritests.h"
 
@@ -56,6 +57,10 @@ int main(int argc, char *argv[])
 
     CoinSelectionViewTests test5;
     if (QTest::qExec(&test5) != 0)
+        fInvalid = true;
+
+    PSGTToastDampTests test6;
+    if (QTest::qExec(&test6) != 0)
         fInvalid = true;
 
     return fInvalid;


### PR DESCRIPTION

Coalesces the toast half of a #3118 deferral. Your review comment on `bitcoingui.cpp` there said the
re-fire per revision was intentional and that "Coalescing to a single toast per image could be a
follow-up if it proves noisy in practice." #3312 took the selection half and recorded the toast
half as staying open: "a usage judgement rather than a defect — nobody has data on real multisig
usage, and `walletMustSignRevision` already suppresses re-toasts once this wallet has signed — so it
stays open rather than being changed on a guess." This PR does change it, so that decision needs
engaging rather than passing over, below. (The #3312 review note that the "could be a follow-up"
phrase appears nowhere in #3118 was about the selection half; for the toast it is your
`bitcoingui.cpp` review comment, quoted above.)

### The repeat

`BitcoinGUI::handlePSGTPoolChanged` toasts whenever a pool change names a revision this wallet
must still sign. `walletMustSignRevision` is the only gate, and it answers true for *every*
revision of an arrangement until this wallet's own signature is on it. A 2-of-3 collects one
revision per co-signer, so each participant who signs ahead of this wallet re-announces the same
request — three participants, three identical toasts for one transaction.

The predicate is doing its job: the wallet really must sign, and it really is a new revision. The
missing piece is that a *request* is an arrangement, not a revision.

### The damp

Resolve the named revision back to its pool image — the revisions of one arrangement share one —
and announce an image once. Two edges worth naming:

- **An unresolvable revision is announced, not swallowed.** `walletMustSignRevision` gates the
  handler first and already answers false for a revision the pool has dropped, so what reaches the
  lookup is the narrow race between those two calls. It is still the safe side to take: deciding
  silence on the strength of a failed lookup would repeat for every later revision, which is the
  bug this fixes.
- **A removal prunes.** An arrangement that leaves the pool and is submitted again later is a new
  request and announces again.

### Why change it without usage data

#3312 left the toast alone because nobody has data on whether the repeat is noisy in practice.
The repeat does not need data: it is structural. A 2-of-3 produces one revision per co-signer
ahead of this wallet, and each is announced, so the count of toasts per request is fixed by the
arrangement rather than by usage. The suppression #3312 cited, `walletMustSignRevision`, only
starts once this wallet has signed; the repeats all land before that. And the damp is
behaviour-neutral wherever it cannot decide: an unresolvable revision is announced exactly as
today, so the worst case of a wrong guess is the current behaviour, not a lost request. The
sanction is the #3118 review comment quoted at the top.

Session-scoped and deliberately not persisted: what is being suppressed is repetition within one
sitting, and a restart re-announcing a request the wallet still has not signed is the wanted
behaviour.

### Tests

`PSGTToastDamp` is a plain class with no Qt dependency, so the policy is testable without
standing up a `BitcoinGUI`. `psgttoastdamptests` covers the three-co-signer repeat, a second
arrangement still announcing, the unresolvable revision, and both prune cases (only the entries
that left are forgotten; a resubmission announces again). Making `ShouldToastRevision` return
true unconditionally fails four of the five cases.

### What is not verified

The wiring in `bitcoingui.cpp` is compile-verified only, exactly as #3312's selection fix was.
Exercising it live needs a funded multisig arrangement in the pool, and a GUI wallet on regtest
owns nothing to fund one with — the premine key is imported per-node by the functional framework.
The failure mode if the wiring is wrong is the behaviour that ships today.

**Testing.** The Qt suite (`test_gridcoin-qt`, 5 cases in the new suite) and the unit suite pass
locally on the head.

https://claude.ai/code/session_01QefexqLUNb5k5qDSJxpnrV


---

### Maintainer note (jamescowens, 2026-09-06)

Two fixups landed on this branch after review; the text above is the author's original.

- 59893029e re-keys the damp on the unsigned-transaction hash (`PSGTPoolRow::tx_hash_hex`, new; IPC schema minor 3.0 -> 3.1). The pool image is the multisig address, and the pool lets an initiator supersede the pending spend with a *different* transaction under the same image, delivered as the same `UPDATED` change as signature progress, so keying on the image silenced a genuinely new request.
- 664fdf914 announces a first revision (`CT_NEW`) unconditionally, so the decision does not depend on the order in which a removal and a resubmission reach the GUI thread; skips the pool fetch on removals when nothing is remembered; and corrects the repeat bound. The pool never holds a complete revision, so an m-of-n announces at most m-1 times per transaction: a 2-of-3 never repeats and the "three toasts" example above cannot occur. The damp has an effect for m >= 3.

Decision: one toast per pending transaction; a supersede is a new request and is announced.
