### PR TITLE
init, doc: stop sealing the autounlock passphrase to TPM PCR 7

### DIFF
--- a/contrib/init/gridcoinresearchd-autounlock.service
+++ b/contrib/init/gridcoinresearchd-autounlock.service
@@ -24,6 +24,11 @@
 #       | sudo systemd-creds encrypt --name=wallet-passphrase --tpm2-pcrs="" \
 #             - /etc/gridcoin/wallet-passphrase.cred
 #
+#   (on a host with sudo I/O logging, the same from a root login shell, no sudo:
+#       systemd-ask-password 'Wallet passphrase:' \
+#           | systemd-creds encrypt --name=wallet-passphrase --tpm2-pcrs="" \
+#                 - /etc/gridcoin/wallet-passphrase.cred)
+#
 #   (or, without systemd-ask-password:
 #       read -rs -p 'Wallet passphrase: ' pw && printf '%s' "$pw" \
 #           | sudo systemd-creds encrypt --name=wallet-passphrase --tpm2-pcrs="" \

--- a/contrib/init/gridcoinresearchd-autounlock.service
+++ b/contrib/init/gridcoinresearchd-autounlock.service
@@ -16,7 +16,9 @@
 # NEVER type the passphrase as a literal on the command line: even with a shell
 # builtin (which keeps it out of `ps`), the whole command line lands in
 # ~/.bash_history -- and in sudo's I/O log if log_input is enabled. Have the
-# terminal prompt for it instead, so it is never part of any command:
+# terminal prompt for it instead, so it is never part of any command (sudo's
+# log_input captures stdin as well: on such a host run this from a root login
+# shell rather than through sudo):
 #
 #   systemd-ask-password 'Wallet passphrase:' \
 #       | sudo systemd-creds encrypt --name=wallet-passphrase --tpm2-pcrs="" \
@@ -35,7 +37,8 @@
 # firmware update, or Secure Boot toggle then changes PCR 7 and the TPM refuses
 # to unseal the credential ever again; the unit fails at credential setup with
 # exit 243/CREDENTIALS and the wallet silently stops staking after the next
-# restart. Binding to the host key and the TPM without a PCR policy keeps the
+# restart. Binding to the host key (and the TPM when present -- the default key
+# selection handles both kinds of host) without a PCR policy keeps the
 # protection that matters here -- only PID 1 on THIS machine can decrypt it --
 # while surviving ordinary firmware maintenance. A credential that has already
 # been sealed with the default cannot be recovered; re-encrypt the passphrase

--- a/contrib/init/gridcoinresearchd-autounlock.service
+++ b/contrib/init/gridcoinresearchd-autounlock.service
@@ -19,12 +19,27 @@
 # terminal prompt for it instead, so it is never part of any command:
 #
 #   systemd-ask-password 'Wallet passphrase:' \
-#       | sudo systemd-creds encrypt --name=wallet-passphrase - /etc/gridcoin/wallet-passphrase.cred
+#       | sudo systemd-creds encrypt --name=wallet-passphrase --tpm2-pcrs="" \
+#             - /etc/gridcoin/wallet-passphrase.cred
 #
 #   (or, without systemd-ask-password:
 #       read -rs -p 'Wallet passphrase: ' pw && printf '%s' "$pw" \
-#           | sudo systemd-creds encrypt --name=wallet-passphrase - /etc/gridcoin/wallet-passphrase.cred
+#           | sudo systemd-creds encrypt --name=wallet-passphrase --tpm2-pcrs="" \
+#                 - /etc/gridcoin/wallet-passphrase.cred
 #       unset pw)
+#
+# --tpm2-pcrs="" is REQUIRED on a host with a TPM. Without it, systemd-creds
+# additionally seals the credential to PCR 7 (its default), the register that
+# measures the Secure Boot variables -- PK/KEK/db/dbx and the Secure Boot state.
+# Any BIOS "restore factory keys", dbx update (fwupd ships them routinely),
+# firmware update, or Secure Boot toggle then changes PCR 7 and the TPM refuses
+# to unseal the credential ever again; the unit fails at credential setup with
+# exit 243/CREDENTIALS and the wallet silently stops staking after the next
+# restart. Binding to the host key and the TPM without a PCR policy keeps the
+# protection that matters here -- only PID 1 on THIS machine can decrypt it --
+# while surviving ordinary firmware maintenance. A credential that has already
+# been sealed with the default cannot be recovered; re-encrypt the passphrase
+# with the command above and restart this unit.
 #
 #   sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred
 #   sudo chmod 0400 /etc/gridcoin/wallet-passphrase.cred
@@ -70,7 +85,8 @@ RemainAfterExit=yes
 User=gridcoin
 Group=gridcoin
 
-# Host/TPM-bound wallet passphrase, decrypted to %d/wallet-passphrase at runtime.
+# Host/TPM-bound wallet passphrase (no PCR policy -- see SETUP above), decrypted
+# to %d/wallet-passphrase at runtime.
 LoadCredentialEncrypted=wallet-passphrase:/etc/gridcoin/wallet-passphrase.cred
 
 # --once: a single unlock attempt driven by systemd's own lifecycle. The core
@@ -89,7 +105,10 @@ ExecStart=/usr/bin/python3 /usr/share/gridcoin/gridcoin_autounlock.py \
 # Exit 1 (transient: core still coming up, RPC momentarily unreachable) retries.
 Restart=on-failure
 RestartSec=30
-RestartPreventExitStatus=2
+# 243 is systemd's own EXIT_CREDENTIALS: PID 1 could not decrypt the credential
+# (typically a TPM PCR policy that no longer matches -- see SETUP). That never
+# clears on its own, so park it as failed rather than retrying every 30s forever.
+RestartPreventExitStatus=2 243
 
 # Finite, unlike the core (TimeoutStartSec=infinity). The helper's --once worst
 # case is one /proc read plus a getinfo and a walletpassphrase call, each bounded

--- a/contrib/init/gridcoinresearchd-autounlock.service
+++ b/contrib/init/gridcoinresearchd-autounlock.service
@@ -43,11 +43,16 @@
 # to unseal the credential ever again; the unit fails at credential setup with
 # exit 243/CREDENTIALS and the wallet silently stops staking after the next
 # restart. Binding to the host key (and the TPM when present -- the default key
-# selection handles both kinds of host) without a PCR policy keeps the
-# protection that matters here -- only PID 1 on THIS machine can decrypt it --
-# while surviving ordinary firmware maintenance. A credential that has already
-# been sealed with the default cannot be recovered; re-encrypt the passphrase
-# with the command above and restart this unit.
+# selection handles both kinds of host) without a PCR policy keeps the credential
+# tied to this machine's key material: decrypting it needs the host key in
+# /var/lib/systemd/credential.secret plus this machine's TPM, so root on this
+# host can decrypt it and nothing elsewhere can. It also survives ordinary
+# firmware maintenance. The trade-off: without the PCR policy the TPM no longer
+# refuses to unseal after a Secure Boot state change, so that defense-in-depth
+# is given up. To keep it, drop --tpm2-pcrs="" and re-encrypt the passphrase
+# after every BIOS key, dbx, or firmware change instead. A credential that has
+# already been sealed with the default cannot be recovered; re-encrypt the
+# passphrase with the command above and restart this unit.
 #
 #   sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred
 #   sudo chmod 0400 /etc/gridcoin/wallet-passphrase.cred
@@ -113,7 +118,7 @@ ExecStart=/usr/bin/python3 /usr/share/gridcoin/gridcoin_autounlock.py \
 # Exit 1 (transient: core still coming up, RPC momentarily unreachable) retries.
 Restart=on-failure
 RestartSec=30
-# 243 is systemd's own EXIT_CREDENTIALS: PID 1 could not decrypt the credential
+# 243 is systemd's own EXIT_CREDENTIALS: systemd could not decrypt the credential
 # (typically a TPM PCR policy that no longer matches -- see SETUP). That never
 # clears on its own, so park it as failed rather than retrying every 30s forever.
 RestartPreventExitStatus=2 243

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -441,9 +441,10 @@ Set it up once, then enable:
 ```bash
 # Encrypt the wallet passphrase, bound to this host (and its TPM, if present).
 # Let the terminal prompt for it -- never put it in the command line, where it
-# would land in ~/.bash_history and in `ps`. (sudo I/O logging with log_input
-# captures the command's stdin too; on such a host run this from a root login
-# shell rather than through sudo.)
+# would land in ~/.bash_history (and, unless printf is a shell builtin, in
+# process listings). sudo I/O logging with log_input captures the command's
+# stdin too; on such a host run the same pipeline without sudo from a root
+# login shell (e.g. after `su -`).
 systemd-ask-password 'Wallet passphrase:' | sudo systemd-creds encrypt \
     --name=wallet-passphrase --tpm2-pcrs="" - /etc/gridcoin/wallet-passphrase.cred
 sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred
@@ -511,7 +512,7 @@ must run as the account that ran setup. Remove with `.\Set-GridcoinAutounlock.ps
   PCR 7) and the machine's Secure Boot keys, dbx, or firmware have since changed,
   so the TPM refuses to unseal it. The credential cannot be recovered; re-encrypt
   the passphrase with `--tpm2-pcrs=""` as shown in the setup above, then
-  `systemctl restart gridcoinresearchd-autounlock.service`. Unlock the wallet by
+  `sudo systemctl restart gridcoinresearchd-autounlock.service`. Unlock the wallet by
   hand in the meantime (`walletpassphrase` stake-only) — the core keeps running,
   it just is not staking.
 - **"Could not connect to the Gridcoin daemon … node.sock: connection refused."**

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -461,8 +461,13 @@ BIOS key reset, dbx or firmware update, or Secure Boot toggle then makes the
 credential permanently undecryptable (the unit fails with `status=243/CREDENTIALS`).
 Binding to the host key (and the TPM, when one is present — the default key
 selection picks that automatically, so the same command serves both kinds of host)
-without a PCR policy keeps the protection that matters — only this machine can
-decrypt it — and survives ordinary firmware maintenance.
+without a PCR policy keeps the credential tied to this machine's key material
+(decrypting it needs the host key plus this machine's TPM, so root on this host can
+and nothing elsewhere can) and survives ordinary firmware maintenance. The
+trade-off: without the PCR policy the TPM no longer refuses to unseal after a
+Secure Boot state change, so that defense-in-depth is given up. To keep it, drop
+`--tpm2-pcrs=""` and re-encrypt the passphrase after every BIOS key, dbx, or
+firmware change instead.
 
 `systemctl enable` links the unit into `gridcoinresearchd.service.wants/`, so it runs
 whenever the core starts (boot, restart, deploy) without modifying the core unit;
@@ -516,7 +521,7 @@ must run as the account that ran setup. Remove with `.\Set-GridcoinAutounlock.ps
   the passphrase with `--tpm2-pcrs=""` as shown in the setup above, then
   `sudo systemctl restart gridcoinresearchd-autounlock.service`. Unlock the wallet by
   hand in the meantime (`walletpassphrase` stake-only) — the core keeps running,
-  it just is not staking.
+  it is just not staking.
 - **"Could not connect to the Gridcoin daemon … node.sock: connection refused."**
   The daemon is not running yet, was not started with `-multiprocess`, is using a
   different `-datadir`, or (Windows) is running as a different user. Start the daemon

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -440,8 +440,10 @@ Set it up once, then enable:
 
 ```bash
 # Encrypt the wallet passphrase, bound to this host (and its TPM, if present).
-# Let the terminal prompt for it -- never put it in the command line (it would
-# land in ~/.bash_history and sudo's I/O log):
+# Let the terminal prompt for it -- never put it in the command line, where it
+# would land in ~/.bash_history and in `ps`. (sudo I/O logging with log_input
+# captures the command's stdin too; on such a host run this from a root login
+# shell rather than through sudo.)
 systemd-ask-password 'Wallet passphrase:' | sudo systemd-creds encrypt \
     --name=wallet-passphrase --tpm2-pcrs="" - /etc/gridcoin/wallet-passphrase.cred
 sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred
@@ -454,8 +456,10 @@ sudo systemctl enable --now gridcoinresearchd-autounlock.service
 seals the credential to PCR 7, which measures the Secure Boot keys and dbx, and any
 BIOS key reset, dbx or firmware update, or Secure Boot toggle then makes the
 credential permanently undecryptable (the unit fails with `status=243/CREDENTIALS`).
-Host-plus-TPM binding without a PCR policy keeps the protection that matters — only
-this machine can decrypt it — and survives ordinary firmware maintenance.
+Binding to the host key (and the TPM, when one is present — the default key
+selection picks that automatically, so the same command serves both kinds of host)
+without a PCR policy keeps the protection that matters — only this machine can
+decrypt it — and survives ordinary firmware maintenance.
 
 `systemctl enable` links the unit into `gridcoinresearchd.service.wants/`, so it runs
 whenever the core starts (boot, restart, deploy) without modifying the core unit;

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -439,14 +439,23 @@ The helper is Python 3 (standard library only). The daemon package *Recommends*
 Set it up once, then enable:
 
 ```bash
-# Encrypt the wallet passphrase, bound to this host (and its TPM, if present):
-printf '%s' 'YOUR-WALLET-PASSPHRASE' | sudo systemd-creds encrypt \
-    --name=wallet-passphrase - /etc/gridcoin/wallet-passphrase.cred
+# Encrypt the wallet passphrase, bound to this host (and its TPM, if present).
+# Let the terminal prompt for it -- never put it in the command line (it would
+# land in ~/.bash_history and sudo's I/O log):
+systemd-ask-password 'Wallet passphrase:' | sudo systemd-creds encrypt \
+    --name=wallet-passphrase --tpm2-pcrs="" - /etc/gridcoin/wallet-passphrase.cred
 sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred
 sudo chmod 0400 /etc/gridcoin/wallet-passphrase.cred
 
 sudo systemctl enable --now gridcoinresearchd-autounlock.service
 ```
+
+`--tpm2-pcrs=""` matters on any host with a TPM: without it, `systemd-creds` also
+seals the credential to PCR 7, which measures the Secure Boot keys and dbx, and any
+BIOS key reset, dbx or firmware update, or Secure Boot toggle then makes the
+credential permanently undecryptable (the unit fails with `status=243/CREDENTIALS`).
+Host-plus-TPM binding without a PCR policy keeps the protection that matters — only
+this machine can decrypt it — and survives ordinary firmware maintenance.
 
 `systemctl enable` links the unit into `gridcoinresearchd.service.wants/`, so it runs
 whenever the core starts (boot, restart, deploy) without modifying the core unit;
@@ -492,6 +501,15 @@ must run as the account that ran setup. Remove with `.\Set-GridcoinAutounlock.ps
 
 ## Troubleshooting
 
+- **Autounlock unit fails with `status=243/CREDENTIALS` and the journal shows
+  `Failed to unseal secret using TPM2: Operation not permitted`.** The encrypted
+  passphrase was sealed to a TPM PCR policy (the `systemd-creds` default binds
+  PCR 7) and the machine's Secure Boot keys, dbx, or firmware have since changed,
+  so the TPM refuses to unseal it. The credential cannot be recovered; re-encrypt
+  the passphrase with `--tpm2-pcrs=""` as shown in the setup above, then
+  `systemctl restart gridcoinresearchd-autounlock.service`. Unlock the wallet by
+  hand in the meantime (`walletpassphrase` stake-only) — the core keeps running,
+  it just is not staking.
 - **"Could not connect to the Gridcoin daemon … node.sock: connection refused."**
   The daemon is not running yet, was not started with `-multiprocess`, is using a
   different `-datadir`, or (Windows) is running as a different user. Start the daemon

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -443,8 +443,10 @@ Set it up once, then enable:
 # Let the terminal prompt for it -- never put it in the command line, where it
 # would land in ~/.bash_history (and, unless printf is a shell builtin, in
 # process listings). sudo I/O logging with log_input captures the command's
-# stdin too; on such a host run the same pipeline without sudo from a root
-# login shell (e.g. after `su -`).
+# stdin too; on such a host run this from a root login shell (e.g. after
+# `su -`) and drop the `sudo`:
+#   systemd-ask-password 'Wallet passphrase:' | systemd-creds encrypt \
+#       --name=wallet-passphrase --tpm2-pcrs="" - /etc/gridcoin/wallet-passphrase.cred
 systemd-ask-password 'Wallet passphrase:' | sudo systemd-creds encrypt \
     --name=wallet-passphrase --tpm2-pcrs="" - /etc/gridcoin/wallet-passphrase.cred
 sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred

--- a/doc/running-unattended.md
+++ b/doc/running-unattended.md
@@ -43,12 +43,22 @@ Encrypt the wallet passphrase, bound to this host (and its TPM, if present), the
 
 ```bash
 systemd-ask-password 'Wallet passphrase:' \
-    | sudo systemd-creds encrypt --name=wallet-passphrase - /etc/gridcoin/wallet-passphrase.cred
+    | sudo systemd-creds encrypt --name=wallet-passphrase --tpm2-pcrs="" \
+          - /etc/gridcoin/wallet-passphrase.cred
 sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred
 sudo chmod 0400 /etc/gridcoin/wallet-passphrase.cred
 
 sudo systemctl enable --now gridcoinresearchd-autounlock.service
 ```
+
+> **Keep `--tpm2-pcrs=""`.** On a host with a TPM, `systemd-creds` would otherwise also seal the
+> credential to PCR 7 — the register that measures the Secure Boot keys and dbx. Any BIOS
+> *restore factory keys*, dbx update (fwupd ships those routinely), firmware update, or Secure
+> Boot toggle then changes PCR 7 and the TPM refuses to unseal the credential for good: the unit
+> fails with `status=243/CREDENTIALS` and the wallet silently stops staking after the next
+> restart. Binding to the host key and the TPM without a PCR policy keeps the protection that
+> matters (only this machine can decrypt it) and survives ordinary firmware maintenance. A
+> credential already sealed with the default cannot be recovered — re-run the command above.
 
 > **Never put the passphrase in the command itself** (`printf '%s' 'MY-PASSPHRASE' | …`). Even though a shell
 > builtin keeps it out of `ps`, the whole command line is written to `~/.bash_history`, and to sudo's I/O log if

--- a/doc/running-unattended.md
+++ b/doc/running-unattended.md
@@ -65,8 +65,8 @@ sudo systemctl enable --now gridcoinresearchd-autounlock.service
 > builtin keeps it out of `ps`, the whole command line is written to `~/.bash_history`, and to sudo's I/O log if
 > `log_input` is enabled. `systemd-ask-password` prompts for it, so it is never part of any command — though
 > note sudo's `log_input` also captures the command's stdin, so on a host with sudo I/O logging run the
-> encryption from a root login shell rather than through sudo. Without `systemd-ask-password`, use a shell
-> prompt instead:
+> same pipeline without `sudo` from a root login shell (e.g. after `su -`). Without `systemd-ask-password`,
+> use a shell prompt instead:
 > `read -rs -p 'Wallet passphrase: ' pw && printf '%s' "$pw" | sudo systemd-creds encrypt …; unset pw`.
 
 The autounlock unit runs whenever the core starts (boot, restart, upgrade), unlocks **stake-only**, and exits.

--- a/doc/running-unattended.md
+++ b/doc/running-unattended.md
@@ -65,8 +65,9 @@ sudo systemctl enable --now gridcoinresearchd-autounlock.service
 > builtin keeps it out of `ps`, the whole command line is written to `~/.bash_history`, and to sudo's I/O log if
 > `log_input` is enabled. `systemd-ask-password` prompts for it, so it is never part of any command — though
 > note sudo's `log_input` also captures the command's stdin, so on a host with sudo I/O logging run the
-> same pipeline without `sudo` from a root login shell (e.g. after `su -`). Without `systemd-ask-password`,
-> use a shell prompt instead:
+> same pipeline without `sudo` from a root login shell (e.g. after `su -`):
+> `systemd-ask-password 'Wallet passphrase:' | systemd-creds encrypt --name=wallet-passphrase --tpm2-pcrs="" - /etc/gridcoin/wallet-passphrase.cred`.
+> Without `systemd-ask-password`, use a shell prompt instead:
 > `read -rs -p 'Wallet passphrase: ' pw && printf '%s' "$pw" | sudo systemd-creds encrypt …; unset pw`.
 
 The autounlock unit runs whenever the core starts (boot, restart, upgrade), unlocks **stake-only**, and exits.

--- a/doc/running-unattended.md
+++ b/doc/running-unattended.md
@@ -57,9 +57,13 @@ sudo systemctl enable --now gridcoinresearchd-autounlock.service
 > Boot toggle then changes PCR 7 and the TPM refuses to unseal the credential for good: the unit
 > fails with `status=243/CREDENTIALS` and the wallet silently stops staking after the next
 > restart. Binding to the host key (and the TPM when one is present — the default key selection
-> handles both kinds of host) without a PCR policy keeps the protection that matters (only this
-> machine can decrypt it) and survives ordinary firmware maintenance. A credential already
-> sealed with the default cannot be recovered — re-run the command above.
+> handles both kinds of host) without a PCR policy keeps the credential tied to this machine's key
+> material (decrypting it needs the host key plus this machine's TPM, so root on this host can and
+> nothing elsewhere can) and survives ordinary firmware maintenance. The trade-off: without the PCR
+> policy the TPM no longer refuses to unseal after a Secure Boot state change, so that
+> defense-in-depth is given up. To keep it, drop `--tpm2-pcrs=""` and re-encrypt the passphrase
+> after every BIOS key, dbx, or firmware change instead. A credential already sealed with the
+> default cannot be recovered — re-run the command above.
 
 > **Never put the passphrase in the command itself** (`printf '%s' 'MY-PASSPHRASE' | …`). Even though a shell
 > builtin keeps it out of `ps`, the whole command line is written to `~/.bash_history`, and to sudo's I/O log if

--- a/doc/running-unattended.md
+++ b/doc/running-unattended.md
@@ -56,14 +56,17 @@ sudo systemctl enable --now gridcoinresearchd-autounlock.service
 > *restore factory keys*, dbx update (fwupd ships those routinely), firmware update, or Secure
 > Boot toggle then changes PCR 7 and the TPM refuses to unseal the credential for good: the unit
 > fails with `status=243/CREDENTIALS` and the wallet silently stops staking after the next
-> restart. Binding to the host key and the TPM without a PCR policy keeps the protection that
-> matters (only this machine can decrypt it) and survives ordinary firmware maintenance. A
-> credential already sealed with the default cannot be recovered — re-run the command above.
+> restart. Binding to the host key (and the TPM when one is present — the default key selection
+> handles both kinds of host) without a PCR policy keeps the protection that matters (only this
+> machine can decrypt it) and survives ordinary firmware maintenance. A credential already
+> sealed with the default cannot be recovered — re-run the command above.
 
 > **Never put the passphrase in the command itself** (`printf '%s' 'MY-PASSPHRASE' | …`). Even though a shell
 > builtin keeps it out of `ps`, the whole command line is written to `~/.bash_history`, and to sudo's I/O log if
-> `log_input` is enabled. `systemd-ask-password` prompts for it, so it is never part of any command. Without
-> `systemd-ask-password`, use a shell prompt instead:
+> `log_input` is enabled. `systemd-ask-password` prompts for it, so it is never part of any command — though
+> note sudo's `log_input` also captures the command's stdin, so on a host with sudo I/O logging run the
+> encryption from a root login shell rather than through sudo. Without `systemd-ask-password`, use a shell
+> prompt instead:
 > `read -rs -p 'Wallet passphrase: ' pw && printf '%s' "$pw" | sudo systemd-creds encrypt …; unset pw`.
 
 The autounlock unit runs whenever the core starts (boot, restart, upgrade), unlocks **stake-only**, and exits.


### PR DESCRIPTION
Every in-tree setup instruction for the Linux stake-only autounlock runs `systemd-creds encrypt` with its defaults. On any host with a TPM that additionally seals the credential to **PCR 7** — the register that measures the Secure Boot variables (PK, KEK, db, dbx, and the Secure Boot state). Any BIOS *restore factory keys*, dbx update (fwupd/LVFS ships those routinely), firmware update, or Secure Boot toggle then changes PCR 7 and the TPM refuses to unseal the credential for good. PID 1 fails at credential setup **before the helper ever runs**:

```
sd-mkdcr: Failed to unseal secret using TPM2: Operation not permitted
gridcoinresearchd-autounlock.service: Main process exited, code=exited, status=243/CREDENTIALS
```

and because `RestartPreventExitStatus` covered only the helper's own exit 2, the unit restart-loops every 30 s forever while the wallet silently stops staking after its next restart.

Observed on a mainnet staking node after a BIOS *Restore Factory Keys* during firmware maintenance (dbx rolled 20250902 → 20250507): last unlock succeeded, the next boot failed exactly as above, and the credential header decoded to `pcr_mask=0x80` with `systemd-creds` debug output reporting `Current policy digest does not match stored policy digest`. No-TPM hosts are unaffected (host-key-only binding).

**Changes**

- `contrib/init/gridcoinresearchd-autounlock.service`: both setup examples pass `--tpm2-pcrs=""` (host key + TPM binding with no boot-state policy — the protection that matters, that only this machine can decrypt it, without turning routine firmware maintenance into an outage), with the mechanism explained once; `RestartPreventExitStatus=2 243` so a bricked credential parks the unit visibly failed.
- `doc/running-unattended.md` and `doc/multiprocess.md`: the same flag and rationale on every `systemd-creds encrypt` line, plus a Troubleshooting entry for the `status=243/CREDENTIALS` / `Failed to unseal` signature with the recovery (a credential already sealed to PCR 7 cannot be recovered; re-encrypt).
- `doc/multiprocess.md` also put the literal passphrase on the command line in its example — the exact thing its sibling doc and the unit comment say never to do; it now uses the prompted form like the others.

**Verified**: the corrected recipe encrypts and decrypts on a TPM host (the docs keep `systemd-creds`' default key selection — host key plus the TPM when one is present — so one command serves both kinds of host; the affected node was re-provisioned with the explicit `--with-key=host+tpm2 --tpm2-pcrs=""` form, equivalent there), and re-provisioning restored the unlock — proven by locking the wallet and letting the unit unlock it (a restart alone is not a test: with the wallet already unlocked, `walletpassphrase` returns `-17` before the passphrase is checked). `systemd-analyze exit-status 243` confirms `CREDENTIALS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4UiicZ9xa29naEX3CNqr
