### PR TITLE
init, node: correct help text and log strings that contradict the code

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -264,7 +264,7 @@ void Shutdown(void* parg)
                 // The handle is cached and owned by blockstorage, not by us.
                 CloseBlockFile();
                 if (!block_file_synced) {
-                    LogPrintf("WARN: %s: FileCommit failed for blk%05u.dat during shutdown; "
+                    LogPrintf("WARN: %s: FileCommit failed for blk%04u.dat during shutdown; "
                               "skipping LevelDB sync barrier so the block-index DB does not "
                               "become durable referencing unflushed flat-file data.",
                               __func__, nFile);
@@ -707,6 +707,10 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex", "Rebuild chain state and block index from the blk*.dat files on disk",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-checkblocks=<n>", "How many blocks to verify at startup, counting back from the tip (default: 1000, 0 = none)",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-checklevel=<n>", "How thorough the startup block verification is (0-7, default: 1)",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-settings=<file>", strprintf("Specify path to dynamic settings data file. Can be disabled with"
                                                  " -nosettings. File is written at runtime and not meant to be edited by"
                                                  " users (use %s instead for custom settings). Relative paths will be"
@@ -802,10 +806,6 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-zapwallettxes", "Delete all wallet transactions and only recover those parts of the blockchain through"
                                      " -rescan on startup",
-                   ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-    argsman.AddArg("-checkblocks=<n>", "How many blocks to check at startup (default: 2500, 0 = all)",
-                   ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-    argsman.AddArg("-checklevel=<n>", "How thorough the block verification is (0-6, default: 1)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-coherencewalkmax=<n>",
                    strprintf("Cap on how far backward the Phase 2 startup chain-coherence walk will go "

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -107,7 +107,7 @@ bool WriteBlockToDisk(const CBlock& block, unsigned int& nFileRet, unsigned int&
         // no LevelDB entry ever references them), and the peer will
         // re-relay the block. Both calls log their own failure reason.
         if (!FileCommit(fileout.Get())) {
-            return error("%s: FileCommit failed for blk%05u.dat", __func__, nFileRet);
+            return error("%s: FileCommit failed for blk%04u.dat", __func__, nFileRet);
         }
         if (!CTxDB().Sync()) {
             return error("%s: CTxDB::Sync failed (block-index WAL barrier)", __func__);
@@ -292,7 +292,7 @@ FILE* AppendBlockFile(unsigned int& nFileRet)
         // it once per ~2GB boundary is free and makes the handoff strictly more
         // durable than before, not less.
         if (fflush(file) != 0 || !FileCommit(file)) {
-            LogPrintf("WARN: %s: could not commit blk%05u.dat before rolling over to "
+            LogPrintf("WARN: %s: could not commit blk%04u.dat before rolling over to "
                       "the next block file; its tail may not be durable yet",
                       __func__, nCurrentBlockFile);
         }

--- a/src/node/coherence.cpp
+++ b/src/node/coherence.cpp
@@ -80,7 +80,7 @@ CoherenceResult VerifyChainCoherence(int max_walkback)
             break;  // proceed to Phase 2 forward walk
         }
 
-        LogPrintf("WARN: %s: block at height %d (hash %s, blk%05u.dat:%u) failed coherence check "
+        LogPrintf("WARN: %s: block at height %d (hash %s, blk%04u.dat:%u) failed coherence check "
                   "(read_ok=%s); walking back.",
                   __func__, pindex->nHeight, pindex->GetBlockHash().GetHex(),
                   pindex->nFile, pindex->nBlockPos, read_ok ? "true" : "false");


### PR DESCRIPTION
Six strings describe behaviour the code does not have. All were found while writing the
`LoadBlockIndex` verification test for #3322. None of them changes behaviour.

### `-checkblocks` was wrong twice in one line

```
"How many blocks to check at startup (default: 2500, 0 = all)"
```

- The default is **1000**, not 2500: `gArgs.GetArg("-checkblocks", 1000)`.
- **`0 = all` is backwards.** The loop breaks when `nCurrentDepth > nCheckDepth`, and
  `nCurrentDepth` is 1 at the tip, so `0` breaks on the first iteration and verifies nothing.
  An operator setting `0` to ask for a thorough check silently got none.

### `-checklevel` understated its range

```
"How thorough the block verification is (0-6, default: 1)"
```

The signature check is armed by `nCheckLevel > 6`, so **7** is a real level, and the only one
that verifies block signatures. The levels are 0 through 7.

Both strings now also say the verification happens at startup and covers the blocks below the
tip, which is what the loop does: it walks back from `pindexBest` and stops at `-checkblocks`
depth, or at genesis, whichever comes first.

### Four log strings named a file that cannot exist

They formatted the block file as `blk%05u.dat`. `BlockFilePath` names it `blk%04u.dat`, so
those lines printed a name no file has ever had, in exactly the situation they fire in: a
corrupt or uncommittable block file. Sites corrected are in `init.cpp`, `blockstorage.cpp`
(two) and `coherence.cpp`. The two places that build the real path, `dbwrapper.cpp` and
`blockstorage.cpp`, already used four digits and are untouched.

Builds clean; lint clean over the commit range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4UiicZ9xa29naEX3CNqr