### PR TITLE
test, ci: fix the lock discipline the unit suite violates, and run the checks in CI

### DIFF
--- a/.github/workflows/cmake_quality.yml
+++ b/.github/workflows/cmake_quality.yml
@@ -132,7 +132,18 @@ jobs:
             echo "$unexpected"
             echo
             echo "Full reports, each with the historical and current lock stacks:"
-            grep -A30 "POTENTIAL DEADLOCK DETECTED" ctest_asan.log
+            # Print whole blocks rather than a fixed window. A report runs from
+            # the banner to the "potential deadlock detected: a -> b -> a" line
+            # and grows with the depth of the two lock stacks; real ones already
+            # run 29 lines, so a fixed -A window is one frame from truncating
+            # the part worth reading. The cap is a backstop, not the mechanism:
+            # a report thrown rather than logged (sync_tests sets throw mode)
+            # never prints that closing line, so without it the block would run
+            # to the end of the log.
+            awk '/POTENTIAL DEADLOCK DETECTED/            {p = 1; n = 0}
+                 p                                       {print; n++}
+                 /potential deadlock detected:/           {p = 0}
+                 p && n >= 80 {print "  ... truncated at 80 lines ..."; p = 0}' ctest_asan.log
             exit 1
           fi
 

--- a/.github/workflows/cmake_quality.yml
+++ b/.github/workflows/cmake_quality.yml
@@ -62,9 +62,25 @@ jobs:
         run: |
           # -fsanitize=address includes LSan (LeakSanitizer)
           # -fsanitize=undefined catches UB (integer overflow, null deref, etc)
+          #
+          # ENABLE_DEBUG_LOCKORDER turns on two runtime lock checks that every
+          # other job compiles away, so this is the only place they run:
+          #
+          #   * AssertLockHeld / AssertLockNotHeld. Without the flag
+          #     AssertLockHeldInternal is an empty inline (src/sync.h), so a
+          #     function annotated EXCLUSIVE_LOCKS_REQUIRED can be called with
+          #     no lock held and nothing notices. These abort, so they fail the
+          #     ctest step on their own.
+          #   * Lock-order tracking, which reports a pair of locks taken in two
+          #     different orders. This one reports and continues by design, so
+          #     it is gated by the step after the tests rather than by ctest.
+          #
+          # Both are runtime checks, which is why they live here and not on the
+          # Thread Safety job: that one is compile-only and would gain nothing.
           cmake -B build_asan \
             -DENABLE_GUI=OFF \
             -DENABLE_TESTS=ON \
+            -DENABLE_DEBUG_LOCKORDER=ON \
             -DUSE_QT6=ON \
             -DUSE_ASM=OFF \
             -DCMAKE_BUILD_TYPE=Debug \
@@ -86,7 +102,41 @@ jobs:
           ASAN_OPTIONS: malloc_context_size=0:check_initialization_order=1
         run: |
           # We exclude the Qt tests here if they trigger false positives in GUI libs
-          ctest --test-dir build_asan --output-on-failure
+          # -V so the suite's own output is captured even for tests that pass:
+          # the lock-order checker reports through the log, and
+          # --output-on-failure alone shows nothing for a passing test.
+          set -o pipefail
+          ctest --test-dir build_asan -V 2>&1 | tee ctest_asan.log
+
+      - name: Check for lock-order inversions
+        run: |
+          # The checker reports and continues rather than aborting, on purpose:
+          # a single run surfaces every inversion instead of stopping at the
+          # first, so one pass shows the whole picture instead of forcing a
+          # fix-and-rerun cycle per inversion. That also means the suite can
+          # pass while having reported one, so the gate belongs here.
+          #
+          # sync_tests drives the checker deliberately with its own
+          # mutex1/mutex2 fixture and asserts on the message it throws. That
+          # report is expected; any other is not.
+          if ! grep -q "POTENTIAL DEADLOCK DETECTED" ctest_asan.log; then
+            echo "No lock-order reports."
+            exit 0
+          fi
+
+          unexpected=$(grep -A3 "POTENTIAL DEADLOCK DETECTED" ctest_asan.log \
+            | grep "Conflict:" | grep -v "'mutex1'" | grep -v "'mutex2'" || true)
+
+          if [ -n "$unexpected" ]; then
+            echo "::error::The unit suite reported a lock-order inversion."
+            echo "$unexpected"
+            echo
+            echo "Full reports, each with the historical and current lock stacks:"
+            grep -A30 "POTENTIAL DEADLOCK DETECTED" ctest_asan.log
+            exit 1
+          fi
+
+          echo "Only sync_tests' deliberate mutex1/mutex2 report present."
 
   # ----------------------------------------------------------------------
   # JOB 2: Linter

--- a/src/test/addressbook_tests.cpp
+++ b/src/test/addressbook_tests.cpp
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(label_rpcs_roundtrip)
 {
     CKey key;
     key.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(key));   // owned -> purpose "receive"
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(key)));   // owned -> purpose "receive"
     const std::string addr = EncodeDestination(CTxDestination(key.GetPubKey().GetID()));
 
     setlabel(ArgArray({addr, "tabby"}));
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(account_bridge_rpcs_still_work)
 {
     CKey key;
     key.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(key));   // owned -> purpose "receive"
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(key)));   // owned -> purpose "receive"
     const CTxDestination dest = CTxDestination(key.GetPubKey().GetID());
     const std::string addr = EncodeDestination(dest);
 
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(received_by_label_rpcs_work_flag_free)
 {
     CKey key;
     key.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(key));   // owned -> purpose "receive"
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(key)));   // owned -> purpose "receive"
     const std::string addr = EncodeDestination(CTxDestination(key.GetPubKey().GetID()));
     setlabel(ArgArray({addr, "recvlabel"}));
 
@@ -503,7 +503,7 @@ struct OwnedKey
     OwnedKey()
     {
         key.MakeNewKey(false);
-        BOOST_REQUIRE(pwalletMain->AddKey(key));
+        BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(key)));
         dest = CTxDestination(key.GetPubKey().GetID());
         addr = EncodeDestination(dest);
     }
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE(received_by_label_tallies_owned_outputs_only)
     // Owned, labeled address -> its output is tallied.
     CKey key;
     key.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(key));
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(key)));
     const CTxDestination dest = CTxDestination(key.GetPubKey().GetID());
     setlabel(ArgArray({EncodeDestination(dest), "fundedlabel"}));
 
@@ -597,7 +597,7 @@ BOOST_AUTO_TEST_CASE(listreceived_shows_unbooked_address_with_external_receipt)
     // Owned key, deliberately NOT added to the address book.
     CKey key;
     key.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(key));
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(key)));
     const CTxDestination dest = CTxDestination(key.GetPubKey().GetID());
     const std::string addr = EncodeDestination(dest);
     {
@@ -656,7 +656,7 @@ BOOST_AUTO_TEST_CASE(getreceivedby_default_label_matches_grouped_row)
     // Owned key, deliberately NOT added to the address book, paid from outside the wallet.
     CKey key;
     key.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(key));
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(key)));
     const CTxDestination dest = CTxDestination(key.GetPubKey().GetID());
     {
         LOCK(pwalletMain->cs_wallet);
@@ -687,13 +687,13 @@ BOOST_AUTO_TEST_CASE(migratelabels_books_unbooked_external_receipts)
     // E: unbooked, paid from outside the wallet.
     CKey keyE;
     keyE.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(keyE));
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(keyE)));
     const CTxDestination destE = CTxDestination(keyE.GetPubKey().GetID());
 
     // F: unbooked, receives only change from the wallet's own spend.
     CKey keyF;
     keyF.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(keyF));
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(keyF)));
     const CTxDestination destF = CTxDestination(keyF.GetPubKey().GetID());
 
     {
@@ -756,7 +756,7 @@ BOOST_AUTO_TEST_CASE(listreceived_hides_pure_change_until_external_receipt)
     // exactly the shape that would double-emit if the new loop's booked-skip were missing.
     CKey keyA;
     keyA.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(keyA));
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(keyA)));
     const CTxDestination destA = CTxDestination(keyA.GetPubKey().GetID());
     const std::string addrA = EncodeDestination(destA);
     setlabel(ArgArray({addrA, "changetest-ext"}));
@@ -764,7 +764,7 @@ BOOST_AUTO_TEST_CASE(listreceived_hides_pure_change_until_external_receipt)
     // C: owned, unbooked.
     CKey keyC;
     keyC.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(keyC));
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(keyC)));
     const CTxDestination destC = CTxDestination(keyC.GetPubKey().GetID());
     const std::string addrC = EncodeDestination(destC);
 
@@ -821,13 +821,13 @@ BOOST_AUTO_TEST_CASE(listreceived_includeempty_ignores_unbooked_keys_without_rec
     // Owned, unbooked, no receipts.
     CKey keyD;
     keyD.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(keyD));
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(keyD)));
     const std::string addrD = EncodeDestination(CTxDestination(keyD.GetPubKey().GetID()));
 
     // Owned, booked, no receipts.
     CKey keyE;
     keyE.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(keyE));
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(keyE)));
     const std::string addrE = EncodeDestination(CTxDestination(keyE.GetPubKey().GetID()));
     setlabel(ArgArray({addrE, "emptylabel"}));
 
@@ -1078,7 +1078,7 @@ BOOST_AUTO_TEST_CASE(migratelabels_backfills_purpose)
 {
     CKey key;
     key.MakeNewKey(false);
-    BOOST_REQUIRE(pwalletMain->AddKey(key));   // owned -> should become "receive"
+    BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(key)));   // owned -> should become "receive"
     const CTxDestination dest = CTxDestination(key.GetPubKey().GetID());
 
     // Simulate a pre-label entry: a name with the default "unknown" purpose.

--- a/src/test/gridcoin/mrc_tests.cpp
+++ b/src/test/gridcoin/mrc_tests.cpp
@@ -71,7 +71,7 @@ struct Setup {
         // LOCK2. Nothing after this needs the wallet lock.
         {
             LOCK(wallet->cs_wallet);
-            wallet->AddKey(key);
+            BOOST_REQUIRE(wallet->AddKey(key));
         }
 
         GRC::Contract contract = GRC::MakeContract<GRC::BeaconPayload>(

--- a/src/test/gridcoin/mrc_tests.cpp
+++ b/src/test/gridcoin/mrc_tests.cpp
@@ -63,9 +63,16 @@ struct Setup {
 
         key.MakeNewKey(false);
 
-        LOCK(wallet->cs_wallet);
-
-        wallet->AddKey(key);
+        // Scoped to the key insertion alone. Everything below reaches cs_main
+        // -- the beacon registry calls, and Researcher::Reload by way of
+        // StoreResearcher -- so holding cs_wallet across them registers
+        // wallet->cs_wallet -> cs_main, inverting the canonical
+        // cs_main -> cs_wallet order that the test bodies below take with
+        // LOCK2. Nothing after this needs the wallet lock.
+        {
+            LOCK(wallet->cs_wallet);
+            wallet->AddKey(key);
+        }
 
         GRC::Contract contract = GRC::MakeContract<GRC::BeaconPayload>(
                 GRC::ContractAction::ADD,

--- a/src/test/qt_wallettxstore_chain_tests.cpp
+++ b/src/test/qt_wallettxstore_chain_tests.cpp
@@ -149,7 +149,7 @@ struct OwnedKey
     OwnedKey()
     {
         key.MakeNewKey(false);
-        BOOST_REQUIRE(pwalletMain->AddKey(key));
+        BOOST_REQUIRE(WITH_LOCK(pwalletMain->cs_wallet, return pwalletMain->AddKey(key)));
         dest = CTxDestination(key.GetPubKey().GetID());
     }
 };


### PR DESCRIPTION
Closes #3324.

A full unit-suite run under `-DENABLE_DEBUG_LOCKORDER=ON` at current development finds two
distinct problems. One is the lock-order inversion the issue describes. The other the issue does
not mention, and it is the larger of the two.

### The picture has moved since the issue was filed

The report the issue flagged as needing adjudication, `m_wallet->cs_wallet` against `cs_main` in
the interfaces layer, **no longer reproduces**. That matches the code: of the six places in
`interfaces.cpp` that hold the wallet lock, one uses `LOCK2` in canonical order, the MRC `submit`
path takes `cs_main` first, and the rest reach only the PSGT pool lock. Wallet work merged since
1 September appears to have overtaken it. Nothing to fix there.

The reporter also prints both lock stacks now, so the issue's first follow-up, capturing the
missing stack, needed no new instrumentation.

### Twenty-one tests abort, and no ordinary build can see it

Every one at the same place: `AssertLockHeld(cs_wallet)` in `CWallet::AddKey`. Seventeen in
`addressbook_tests`, four in `qt_wallettxstore_chain_tests`. A backtrace puts the caller in the
test itself, calling `AddKey` with no lock held at all, where `AddKey` is annotated
`EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)`.

Without the flag `AssertLockHeldInternal` is an empty inline, so this is unchecked in every build
the project ships, release included. **Production is correct**: `importprivkey` and
`importwallet` take `LOCK2(cs_main, pwalletMain->cs_wallet)` before reaching `AddKey`.

Each of the fifteen call sites now takes the lock for the key insertion and nothing else, via
`WITH_LOCK`. Wrapping whole test bodies would hold `cs_wallet` across code that reaches
`cs_main`, trading these aborts for exactly the inversion below.

### The inversion is the fixture's, not production's

The reported stacks name both halves:

```
Historical: wallet->cs_wallet   at mrc_tests.cpp:66
            cs_msMiningErrors   at researcher.cpp:478
            cs_main             at researcher.cpp:1393
Current:    LOCK2(cs_main, wallet->cs_wallet) at mrc_tests.cpp:218
```

The fixture took `wallet->cs_wallet` and held it for the rest of its constructor, which reaches
`cs_main` twice over, through the beacon registry calls and through `Researcher::Reload`. That
registered the reverse order first; the test bodies then take `LOCK2` in canonical order. The
production code in between is consistent and not at fault. Only `AddKey` needs the wallet lock,
so it is scoped to that.

### Running the checks in CI

`ENABLE_DEBUG_LOCKORDER` goes on the **Sanitizers** job, not the Thread Safety job. Both checks
are runtime, and Thread Safety is compile-only: it builds with clang to check annotations
statically and never executes anything, so the flag would do nothing there. Sanitizers already
runs `ctest` for latent runtime faults.

The two checks need different gating. Assertion failures abort and fail `ctest` by themselves.
Lock-order inversions **report and continue, which is deliberate** — one run surfaces every
inversion rather than stopping at the first, so the whole picture comes out of a single pass
instead of a fix-and-rerun cycle per inversion. The cost is that the suite can pass having
reported one, and `--output-on-failure` prints nothing for a passing test, so such a run looked
identical to a clean one. So `ctest` runs with `-V` and the output is scanned afterwards: the
checker keeps its behaviour, and the job still goes red, listing every report with both stacks.

`sync_tests` drives the checker on purpose with its own `mutex1`/`mutex2` fixture and asserts on
the thrown message, so that report is expected and the scan ignores it. The filter was validated
against captured output from two real runs: silent on the current tree, and it flags the
`mrc_tests` inversion in a run from before the fixture was fixed.

### Result

A full suite run under the flag is now clean: no assertion failures, no test errors, and one
remaining report, which is `sync_tests` exercising the detector as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4UiicZ9xa29naEX3CNqr