### PR TITLE
test, ci: analyse the test targets for thread safety, and fix what that finds

### DIFF
--- a/.github/workflows/cmake_quality.yml
+++ b/.github/workflows/cmake_quality.yml
@@ -229,6 +229,14 @@ jobs:
   # were never checked. That needs capnproto + libcapnp-dev below. (The
   # cmake_multiprocess workflow builds the same surface, but with gcc, which
   # ignores the annotations entirely.)
+  #
+  # ENABLE_TESTS=ON, and the test targets on the build line, because the
+  # analysis is per-translation-unit: a TU that is never compiled is never
+  # analysed. While the tests were excluded their annotation failures were
+  # invisible and accumulated (issue #3344 -- seven of them, across three
+  # files). Tests call the same annotated production API as everything else,
+  # and calling a function that requires cs_main without holding it is the
+  # same defect wherever it is written.
   # ----------------------------------------------------------------------
   thread-safety:
     name: Thread Safety (Clang)
@@ -267,7 +275,7 @@ jobs:
         run: |
           cmake -B build_tsa \
             -DENABLE_GUI=ON \
-            -DENABLE_TESTS=OFF \
+            -DENABLE_TESTS=ON \
             -DUSE_QT6=ON \
             -DENABLE_MULTIPROCESS=ON \
             -DWERROR_THREAD_SAFETY=ON \
@@ -276,4 +284,8 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build (compile-only — analysis runs at compile time)
-        run: cmake --build build_tsa --target gridcoinresearch gridcoinresearchd
+        # -k so one run reports every annotation failure. Without it the build
+        # stops at the first, and finding the rest takes a fix-and-rerun cycle:
+        # the run that motivated adding the test targets stopped after 63 of 92
+        # test TUs and never reached one of the three files at fault.
+        run: cmake --build build_tsa --target gridcoinresearch gridcoinresearchd test_gridcoin test_gridcoin-qt -- -k

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -423,6 +423,11 @@ bool CheckBlockSizeOnly(CBlock& block)
 {
     CValidationState state;
 
+    // CheckBlock is annotated EXCLUSIVE_LOCKS_REQUIRED(cs_main). Taking it here
+    // rather than at each call site keeps the eight BOOST_CHECKs below reading
+    // as the assertions they are.
+    LOCK(cs_main);
+
     // Height below nGrandfather, so the difficulty check does not fire; the
     // rules under test key on the block's version, not on this.
     return CheckBlock(block, state, 1000, false, false, false);

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -146,7 +146,12 @@ BOOST_AUTO_TEST_CASE(addpartdata_accepts_a_part_at_the_cap)
 {
     auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
 
-    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+    // Same order as the case above and as production: cs_mapManifest, then
+    // cs_mapParts, then cs_manifest. addPartData takes the last two itself, so
+    // holding cs_manifest first would have this test model the reverse of what
+    // it is exercising.
+    LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
+    LOCK(manifest->cs_manifest);
 
     CDataStream at_cap(SER_NETWORK, PROTOCOL_VERSION);
     at_cap.resize(kPartWireCap);

--- a/src/test/gridcoin/scraper_net_tests.cpp
+++ b/src/test/gridcoin/scraper_net_tests.cpp
@@ -120,7 +120,12 @@ BOOST_AUTO_TEST_CASE(addpartdata_refuses_an_oversized_part_and_registers_nothing
 {
     auto manifest = std::shared_ptr<CScraperManifest>(new CScraperManifest());
 
-    LOCK2(CScraperManifest::cs_mapManifest, manifest->cs_manifest);
+    // mapParts is guarded by cs_mapParts, which the reads below need. The
+    // order is the one production uses: cs_mapManifest, then cs_mapParts, then
+    // cs_manifest (scraper.cpp and CSplitBlob::addPart, which re-takes the last
+    // two under this).
+    LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
+    LOCK(manifest->cs_manifest);
 
     const size_t before = CSplitBlob::mapParts.size();
 

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -709,10 +709,15 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics_v3
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence)
 {
     const ScraperStatsMeta meta;
+    // Built before cs_main is taken: GetTestConvergence takes the scraper
+    // locks, and FromConvergence takes none, so nesting them under cs_main
+    // would couple the two for no reason.
+    const auto convergence = GetTestConvergence(meta);
+
     // FromConvergence documents that the call site holds cs_main: below the
     // gate the V1 path reads pindexBest internally.
     GRC::Superblock superblock = WITH_LOCK(cs_main, return GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta), 2, /*update_pending_cache=*/true, pindexBest));
+        convergence, 2, /*update_pending_cache=*/true, pindexBest));
 
     BOOST_CHECK(superblock.m_version == 2);
 
@@ -849,10 +854,15 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence)
 {
     const ScraperStatsMeta meta;
+    // Built before cs_main is taken: GetTestConvergence takes the scraper
+    // locks, and FromConvergence takes none, so nesting them under cs_main
+    // would couple the two for no reason.
+    const auto convergence = GetTestConvergence(meta, true); // Set fallback by project flag
+
     // FromConvergence documents that the call site holds cs_main: below the
     // gate the V1 path reads pindexBest internally.
     GRC::Superblock superblock = WITH_LOCK(cs_main, return GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta, true), 2, /*update_pending_cache=*/true, pindexBest)); // Set fallback by project flag
+        convergence, 2, /*update_pending_cache=*/true, pindexBest));
 
     BOOST_CHECK(superblock.m_version == 2);
     BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
@@ -1301,10 +1311,15 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
         << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
         << std::vector<uint160> { meta.beacon_id_1, meta.beacon_id_2 };
 
+    // Built before cs_main is taken: GetTestConvergence takes the scraper
+    // locks, and FromConvergence takes none, so nesting them under cs_main
+    // would couple the two for no reason.
+    const auto convergence = GetTestConvergence(meta);
+
     // FromConvergence documents that the call site holds cs_main: below the
     // gate the V1 path reads pindexBest internally.
     GRC::Superblock superblock = WITH_LOCK(cs_main, return GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta), 2, /*update_pending_cache=*/true, pindexBest));
+        convergence, 2, /*update_pending_cache=*/true, pindexBest));
 
     BOOST_CHECK(GetSerializeSize(superblock, SER_NETWORK, 1) == expected.size());
 
@@ -1443,10 +1458,15 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_fallback_convergences)
         << calc_2_convergence_hint                      // Convergence hint for project 2
         << std::vector<uint160> { meta.beacon_id_1, meta.beacon_id_2 };
 
+    // Built before cs_main is taken: GetTestConvergence takes the scraper
+    // locks, and FromConvergence takes none, so nesting them under cs_main
+    // would couple the two for no reason.
+    const auto convergence = GetTestConvergence(meta, true); // Set fallback by project flag
+
     // FromConvergence documents that the call site holds cs_main: below the
     // gate the V1 path reads pindexBest internally.
     GRC::Superblock superblock = WITH_LOCK(cs_main, return GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta, true), 2, /*update_pending_cache=*/true, pindexBest)); // Set fallback by project flag
+        convergence, 2, /*update_pending_cache=*/true, pindexBest));
 
     BOOST_CHECK(GetSerializeSize(superblock, SER_NETWORK, 1) == expected.size());
 

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -709,8 +709,10 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics_v3
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence)
 {
     const ScraperStatsMeta meta;
-    GRC::Superblock superblock = GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta), 2, /*update_pending_cache=*/true, pindexBest);
+    // FromConvergence documents that the call site holds cs_main: below the
+    // gate the V1 path reads pindexBest internally.
+    GRC::Superblock superblock = WITH_LOCK(cs_main, return GRC::Superblock::FromConvergence(
+        GetTestConvergence(meta), 2, /*update_pending_cache=*/true, pindexBest));
 
     BOOST_CHECK(superblock.m_version == 2);
 
@@ -847,8 +849,10 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence)
 {
     const ScraperStatsMeta meta;
-    GRC::Superblock superblock = GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta, true), 2, /*update_pending_cache=*/true, pindexBest); // Set fallback by project flag
+    // FromConvergence documents that the call site holds cs_main: below the
+    // gate the V1 path reads pindexBest internally.
+    GRC::Superblock superblock = WITH_LOCK(cs_main, return GRC::Superblock::FromConvergence(
+        GetTestConvergence(meta, true), 2, /*update_pending_cache=*/true, pindexBest)); // Set fallback by project flag
 
     BOOST_CHECK(superblock.m_version == 2);
     BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
@@ -1297,8 +1301,10 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
         << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
         << std::vector<uint160> { meta.beacon_id_1, meta.beacon_id_2 };
 
-    GRC::Superblock superblock = GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta), 2, /*update_pending_cache=*/true, pindexBest);
+    // FromConvergence documents that the call site holds cs_main: below the
+    // gate the V1 path reads pindexBest internally.
+    GRC::Superblock superblock = WITH_LOCK(cs_main, return GRC::Superblock::FromConvergence(
+        GetTestConvergence(meta), 2, /*update_pending_cache=*/true, pindexBest));
 
     BOOST_CHECK(GetSerializeSize(superblock, SER_NETWORK, 1) == expected.size());
 
@@ -1437,8 +1443,10 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_fallback_convergences)
         << calc_2_convergence_hint                      // Convergence hint for project 2
         << std::vector<uint160> { meta.beacon_id_1, meta.beacon_id_2 };
 
-    GRC::Superblock superblock = GRC::Superblock::FromConvergence(
-        GetTestConvergence(meta, true), 2, /*update_pending_cache=*/true, pindexBest); // Set fallback by project flag
+    // FromConvergence documents that the call site holds cs_main: below the
+    // gate the V1 path reads pindexBest internally.
+    GRC::Superblock superblock = WITH_LOCK(cs_main, return GRC::Superblock::FromConvergence(
+        GetTestConvergence(meta, true), 2, /*update_pending_cache=*/true, pindexBest)); // Set fallback by project flag
 
     BOOST_CHECK(GetSerializeSize(superblock, SER_NETWORK, 1) == expected.size());
 


### PR DESCRIPTION
Closes #3344.

Clang's `-Wthread-safety` works per translation unit, so a TU that is never compiled is never
analysed. The Thread Safety job configured with `ENABLE_TESTS=OFF` and named only
`gridcoinresearch` and `gridcoinresearchd` on its build line, so **no test TU has ever been
analysed** and its annotation failures accumulated unseen.

### What was hiding there

Seven errors across three files. None is a false positive: each is a test reaching annotated
production state without the lock that state is declared to need.

| Site | Diagnostic |
|---|---|
| `connectinputs_tests.cpp:428` | calling `CheckBlock` requires `cs_main` |
| `scraper_net_tests.cpp:125,133` | reading `mapParts` requires `cs_mapParts` |
| `superblock_tests.cpp:713,851,1301,1441` | reading `pindexBest` requires `cs_main` |

Each is fixed by honouring the contract rather than by quieting the diagnostic:

- `CheckBlockSizeOnly` takes `cs_main` before calling `CheckBlock`. Putting it in the helper
  rather than at each of its eight call sites leaves those reading as the assertions they are.
- The scraper test held `cs_mapManifest` and `cs_manifest` but read `mapParts`, guarded by a
  third lock it never took. The missing lock goes where production puts it: `cs_mapManifest`,
  then `cs_mapParts`, then `cs_manifest` — the order used in `scraper.cpp` and by
  `CSplitBlob::addPart`, which re-takes the last two underneath this.
- The four superblock cases pass `pindexBest` to `Superblock::FromConvergence`, whose
  declaration states that the call site must hold `cs_main` because the pre-gate path reads that
  pointer internally. So `cs_main` is held across the call, not merely around the read.

The three suites pass and the whole unit suite passes.

### The job

`ENABLE_TESTS=ON`, and `test_gridcoin` and `test_gridcoin-qt` join the build line. Both targets
exist in this configuration because the job already builds with `ENABLE_GUI=ON`.

The build also gains `-k`, and that is not incidental. The first run I made stopped at the first
failures after compiling **63 of the 92 test TUs**, and never reached `connectinputs_tests.cpp`
— one of the three files at fault. Its report looked smaller than the truth, and acting on it
would have meant a fix-and-rerun cycle to discover the rest. With keep-going, one run reports
everything.

### Not analysed, by prior decision rather than by this change

- `compilerbug_tests.cpp` is commented out in `src/test/CMakeLists.txt`.
- `key_io_tests.cpp` is referenced by no `CMakeLists` at all, so it is never built or run,
  despite carrying a maintenance commit as recent as "test: set chain to mainnet after testing in
  key_io_tests". 153 lines of tests that nobody runs. Filed separately rather than folded in
  here, since adding it to the build is its own decision and may surface its own failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4UiicZ9xa29naEX3CNqr