### PR TITLE
net: do not seed a regtest node from the compiled-in mainnet lists

### DIFF
--- a/doc/regtest.md
+++ b/doc/regtest.md
@@ -4,7 +4,10 @@ Regtest is a private, instant-staking chain mode for development and automated
 testing. Unlike mainnet and testnet it has no peers, no real BOINC/research
 component, and a trivial difficulty target, so you can create blocks on demand
 and exercise wallet, mempool, P2P, and consensus code in a deterministic
-sandbox. It is the chain mode the Python functional tests run against (see
+sandbox. Having no peers is enforced rather than incidental: a regtest node
+performs no DNS seeding and takes none of the peer addresses compiled into the
+binary, so it reaches the network only where you point it. It is the chain mode
+the Python functional tests run against (see
 [`test/functional/README.md`](../test/functional/README.md)).
 
 > Regtest is enabled only on builds where the regtest chain params are compiled

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -132,6 +132,22 @@ inline bool OnTestnet()
 }
 
 /**
+ * Whether the currently selected chain is the main network. Derived the same
+ * way as OnTestnet(), and the correct test for anything that is meaningful
+ * only on mainnet -- hardcoded mainnet peer addresses, for instance.
+ *
+ * !OnTestnet() is not that test. There are three networks, so it is true on
+ * regtest as well, and code written when there were only two reads as if it
+ * meant mainnet when it does not. See the seed handling in net.cpp for what
+ * that cost, and validation.cpp's mainnet address decode for the same trap
+ * caught earlier.
+ */
+inline bool OnMainnet()
+{
+    return Params().NetworkIDString() == CBaseChainParams::MAIN;
+}
+
+/**
  * Sets the params returned by Params() to those for the given chain name.
  * @throws std::runtime_error when the chain is not supported.
  */

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1312,7 +1312,12 @@ void ThreadDNSAddressSeed2(void* parg)
     LogPrint(BCLog::LogFlags::NET, "ThreadDNSAddressSeed started");
     int found = 0;
 
-    if (!OnTestnet())
+    // strDNSSeed resolves to mainnet peers, so only a mainnet node has any use
+    // for them. This was !OnTestnet(), which is also true on regtest, so a
+    // regtest node resolved and dialled real mainnet peers -- and did it at
+    // startup, ahead of the pnSeed fallback below, which is why fixing that one
+    // alone would have left the common case untouched.
+    if (OnMainnet())
     {
         LogPrint(BCLog::LogFlags::NET, "Loading addresses from DNS seeds (could take a while)");
 
@@ -1501,7 +1506,12 @@ void CConnman::ThreadOpenConnections2()
             return;
 
         // Add seed nodes
-        if (g_connman->GetAddrMan().size() == 0 && (GetAdjustedTime() - nStart > 60) && !OnTestnet())
+        //
+        // pnSeed holds mainnet addresses, so this has the same restriction as
+        // the DNS seeds above, and had the same !OnTestnet() defect: a regtest
+        // node whose addrman was still empty after a minute injected real
+        // mainnet peers and started dialling them.
+        if (g_connman->GetAddrMan().size() == 0 && (GetAdjustedTime() - nStart > 60) && OnMainnet())
         {
             std::vector<CAddress> vAdd;
             for (const auto& seed : pnSeed)
@@ -1520,6 +1530,11 @@ void CConnman::ThreadOpenConnections2()
             CNetAddr local;
             LookupHost("127.0.0.1", local, false);
             g_connman->GetAddrMan().Add(vAdd, local);
+
+            // addrman logs the Add itself, but that line is identical whether
+            // the addresses came from a peer's addr message, a DNS seed or this
+            // compiled-in list. Name the path.
+            LogPrint(BCLog::LogFlags::NET, "Added %u fixed seed nodes to addrman", vAdd.size());
         }
 
         //

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -108,6 +108,7 @@ this table mirrors it.
 | `mempool_accept.py` | `sendrawtransaction` accept + double-spend rejection |
 | `rpc_net.py` | two-node `getpeerinfo`/`addnode` + block propagation |
 | `feature_sidestake.py` | local sidestaking config + coinstake reward split |
+| `feature_no_mainnet_seeds_on_regtest.py` | regtest takes neither the DNS seed hostnames nor `pnSeed` |
 
 ### Extended suite (opt-in via `--extended`, not in default CI)
 

--- a/test/functional/feature_no_mainnet_seeds_on_regtest.py
+++ b/test/functional/feature_no_mainnet_seeds_on_regtest.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""A regtest node must never seed itself from the compiled-in mainnet lists.
+
+Two paths in net.cpp hand a node addresses that were compiled into the binary
+rather than learned from the network, and both were guarded by `!OnTestnet()`.
+There are three networks, so that predicate is true on regtest as well as on
+mainnet, and a regtest node took both (issue #3345):
+
+- `ThreadDNSAddressSeed2` resolves the five hostnames in `strDNSSeed` at
+  startup and adds whatever they resolve to;
+- `ThreadOpenConnections2` injects the 39 addresses in `pnSeed` once the node
+  has been up more than 60 seconds with an empty addrman.
+
+Both now key on `OnMainnet()`. Each is tested on its own node, because on one
+node they mask each other: the DNS path populates addrman at startup, and a
+non-empty addrman is exactly what switches the `pnSeed` path off. A single node
+would therefore pass against a broken `pnSeed` guard.
+
+Every arm pairs a "must not appear" assertion with a positive one that the code
+carrying it actually ran, so that a node which never got that far -- a thread
+that did not start, a category that was not enabled, a log that was not written
+-- fails rather than passes quietly.
+"""
+
+import os
+import time
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    chain_subdir,
+)
+
+# Logged inside the DNS guard, before any name resolution, so this arm needs no
+# working DNS and no network: with the guard broken the line is there whether or
+# not the lookups then succeed.
+DNS_ENTERED = "Loading addresses from DNS seeds"
+
+# Logged after the guard, unconditionally, and last in the function. Its
+# presence is the proof that the thread ran and got past the guard.
+DNS_FINISHED = "addresses found from DNS seeds"
+
+# Logged at the top of the connection thread.
+CONN_STARTED = "ThreadOpenConnections started"
+
+# Deliberately does not name the seed count. The unexpected-message check is a
+# substring search, so pinning "39" here would turn the assertion into a no-op
+# the day the seed list changes length.
+SEED_ADDED = "fixed seed nodes to addrman"
+
+# Each step is comfortably past the 60-second gate, and the clock is advanced
+# by one of them per second of the observation window rather than once at the
+# start. See the loop in run_test for why once is not enough.
+CLOCK_STEP = 300
+
+# Ten steps, so twenty turns of the 500 ms connection loop.
+OBSERVE_STEPS = 10
+
+
+class NoMainnetSeedsOnRegtestTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        # -debug=net makes both seed paths visible. Neither node may be given
+        # -connect: any -connect argument sends ThreadOpenConnections2 into a
+        # different infinite loop at the top of the function that never reaches
+        # the pnSeed path, and node1 would pass against a broken guard. It also
+        # soft-sets -dnsseed=0, which would disarm node0.
+        common = ["-staking=0", "-debug=net"]
+        # node0 runs the DNS path. The generated config already sets dnsseed=0,
+        # so it is turned back on explicitly here -- otherwise this arm would be
+        # testing a disabled thread.
+        # node1 keeps DNS seeding off so its addrman stays empty and the pnSeed
+        # gate is reachable.
+        self.extra_args = [common + ["-dnsseed=1"], common + ["-dnsseed=0"]]
+
+    def setup_network(self):
+        # Deliberately not the default: that one links the nodes into a chain
+        # and syncs them, which would put a peer address in both addrmans. An
+        # empty addrman is the precondition for the pnSeed path, so the default
+        # would leave node1 asserting nothing at all.
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+
+    def debug_log(self, n):
+        path = os.path.join(self.nodes[n].datadir, chain_subdir(self.chain), "debug.log")
+        with open(path, encoding="utf-8") as log_file:
+            return log_file.read()
+
+    def run_test(self):
+        dns_node, seed_node = self.nodes
+
+        self.log.info("the DNS seed thread runs and declines to resolve the "
+                      "mainnet seed hostnames")
+
+        # With the guard broken this waits for five real DNS lookups, so it is
+        # given room; with the guard held it is satisfied at once.
+        self.wait_until(lambda: DNS_FINISHED in self.debug_log(0), timeout=60)
+
+        log = self.debug_log(0)
+        assert DNS_ENTERED not in log, \
+            "regtest node entered the mainnet DNS seed block"
+        assert "0 addresses found from DNS seeds" in log, \
+            "regtest node took addresses from the mainnet DNS seeds"
+        # That count is the load-bearing check for this arm: it is incremented
+        # once per resolved address, so it pins the outcome exactly. addrman is
+        # only corroboration here, and weak corroboration -- getnodeaddresses
+        # returns a 23% sample, which rounds to nothing below five entries, and
+        # five hostnames could well resolve to fewer than that.
+        assert_equal(dns_node.getnodeaddresses(1000), [])
+        assert_equal(dns_node.getpeerinfo(), [])
+
+        self.log.info("the connection thread crosses the 60 second gate on an "
+                      "empty addrman without injecting pnSeed")
+
+        assert CONN_STARTED in self.debug_log(1), \
+            "the connection thread never started, so nothing was tested"
+        assert_equal(seed_node.getnodeaddresses(1000), [])
+        assert_equal(seed_node.getpeerinfo(), [])
+
+        # The gate is `GetAdjustedTime() - nStart > 60`, where nStart is sampled
+        # on the connection thread a few statements after the line asserted
+        # above. So the assertion does not prove nStart has been read yet, and a
+        # single setmocktime could land first -- which would pin nStart AT the
+        # mocked value, freeze the difference at zero, and leave the gate
+        # uncrossable for the rest of the run. That is a silent pass, not a
+        # flake: the test would report success against a broken guard.
+        #
+        # Advancing the clock repeatedly removes the ordering question instead
+        # of racing it. Wherever nStart was sampled, the next step puts the
+        # clock CLOCK_STEP seconds beyond it. The seed block also sits at the
+        # top of a loop that turns over every 500 ms and does not latch, so the
+        # window covers about twenty opportunities rather than one.
+        #
+        # timeout_factor is not usable as a multiplier for the per-step sleep:
+        # the framework rewrites a factor of 0 to 99999, which would park this
+        # test for a day. The window is wall-clock and so is the loop it
+        # watches, so it needs no scaling; the clamp only stretches it for a
+        # heavily loaded or instrumented run.
+        step_seconds = min(max(self.options.timeout_factor, 1), 4)
+        base_time = int(time.time())
+
+        with seed_node.assert_debug_log(expected_msgs=[], unexpected_msgs=[SEED_ADDED]):
+            for step in range(1, OBSERVE_STEPS + 1):
+                seed_node.setmocktime(base_time + step * CLOCK_STEP)
+                time.sleep(step_seconds)
+
+        # getnodeaddresses returns a 23% sample of addrman, so it is a sound
+        # check for the 39 entries pnSeed would have added and not a general
+        # emptiness test -- for a handful of entries the sample rounds to zero.
+        # The log assertion above is what covers the general case.
+        assert_equal(seed_node.getnodeaddresses(1000), [])
+        assert_equal(seed_node.getpeerinfo(), [])
+
+
+if __name__ == "__main__":
+    NoMainnetSeedsOnRegtestTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -206,6 +206,14 @@ BASE_SCRIPTS = [
     # disturbing its header, the one corruption class that arms its
     # CheckBlock branch and that Phase 2 coherence recovery does not cover.
     'feature_blockindex_verification.py',
+    # feature_no_mainnet_seeds_on_regtest.py: neither compiled-in mainnet seed
+    # list -- the DNS seed hostnames resolved at startup, nor the pnSeed
+    # addresses injected after 60 seconds with an empty addrman -- may reach a
+    # regtest node. The pnSeed arm spends ten seconds watching a connection loop
+    # that must stay quiet, which puts it alongside feature_mrc.py and
+    # wallet_splitunspent.py rather than in EXTENDED_SCRIPTS: it is deterministic
+    # and drives no staking, so duration is its only cost.
+    'feature_no_mainnet_seeds_on_regtest.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since longer tests benefit from being scheduled


### PR DESCRIPTION
Closes #3345.

Two paths hand a node addresses that were compiled into the binary rather than learned from the
network, and both were guarded by `!OnTestnet()`. `OnTestnet()` compares the network id against
`TESTNET` alone, and there are three networks, so that predicate is true on regtest as well as on
mainnet. A regtest node took both:

- `ThreadDNSAddressSeed2` resolves the five hostnames in `strDNSSeed` at startup and adds whatever
  they resolve to;
- `ThreadOpenConnections2` injects the 39 addresses in `pnSeed` once the node has been up more than
  60 seconds with an empty addrman.

Both lists are mainnet peers, so a regtest node left alone dialled the public internet out of a test
run.

### The issue named the second path; the first is the one that fires

The issue is scoped to `pnSeed`, and taking only that would have made the fix look complete while
changing nothing on a default regtest node. DNS seeding runs at startup and populates addrman —
and a non-empty addrman is exactly what switches the `pnSeed` fallback off. So on any regtest node
with working DNS the fallback was already unreachable, and the traffic came from the path the issue
does not mention. The `pnSeed` path is most reachable precisely where DNS seeding is off: inside the
functional harness, which writes `dnsseed=0`, and on air-gapped machines.

Both sites are fixed here. `doc/regtest.md` claimed regtest "has no peers", which was not true
before this change; it now says why.

### `OnMainnet()`

`!OnTestnet()` reading as if it meant mainnet is a recurring trap in code written when there were
two networks — `src/validation.cpp:834` documents the same one caught earlier in an address decode,
and `253e6095a` fixed a third instance two lines below one of these guards. Rather than open-code
a comparison, this adds `OnMainnet()` beside `OnTestnet()`, derived the same way from the same
chain params, and keys both sites on it. The project rule from `9a0de26bb` is that core code
queries the network through these helpers; there was simply no helper for this direction.

### Why this cannot move mainnet or testnet

There are exactly three networks: `SelectParams` throws on anything else, and `strNetworkID` is
assigned once per params class in `src/chainparams.cpp` — `MAIN` at `CMainParams`, `TESTNET` at
`CTestNetParams`, `REGTEST` at `CRegTestParams`. Enumerating them against both predicates is the
whole argument:

| network | `!OnTestnet()` | `OnMainnet()` |
|---|---|---|
| main | true | true |
| testnet | false | false |
| regtest | **true** | **false** |

Mainnet keeps seeding by both routes, testnet stays excluded exactly as before, and regtest is the
only row that moves. Both sites are in connection threads reachable from no validation or consensus
path.

The issue offered `!IsMockableChain()` as the alternative shape. That one is true on mainnet and
testnet both, so it only works in conjunction with the existing `!OnTestnet()`; `OnMainnet()` says
the same thing in one predicate instead of two, and reads correctly at a glance.

### The log line

The node was acquiring a peer set from a compiled-in list with nothing in the log to distinguish
that from ordinary peer discovery — addrman's own `Added N addresses from ...` line is identical
whether the addresses came from a peer's `addr` message, a DNS seed or `pnSeed`. The new `NET` line
names this one. It fires at most once per process (the injection sets addrman size to 39, which
latches the `size() == 0` guard shut) and only under `-debug`, so there is no volume concern. It is
the only output change, and after this commit it is unreachable off mainnet.

### The test

`feature_no_mainnet_seeds_on_regtest.py` covers both paths, on separate nodes. On one node they mask
each other — the DNS path fills addrman, which disarms the `pnSeed` gate — so a single-node test
would pass against a broken `pnSeed` guard.

Each arm pairs its "must not appear" assertion with a positive one that the code carrying it
actually ran, so that a node which never got that far fails rather than passes quietly:

- the DNS arm waits for `N addresses found from DNS seeds`, which is logged unconditionally after
  the guard, then asserts the guarded line is absent and the count is zero. The guarded line is
  emitted before any name resolution, so this arm needs neither working DNS nor a network;
- the `pnSeed` arm requires `ThreadOpenConnections started` before it begins.

The `pnSeed` arm advances the mock clock repeatedly rather than once. `nStart` is sampled on the
connection thread and the gate reads the same clock, so a single `setmocktime` landing first would
pin `nStart` **at** the mocked value, freeze the difference at zero and leave the gate uncrossable
for the rest of the run — a silent pass, not a flake. Stepping the clock removes the ordering
question instead of racing it.

Two further traps the test has to avoid, both of which would have produced a green vacuous run:

- `setup_network` is overridden. The default links the nodes into a chain and syncs them, which
  would put a peer address in both addrmans.
- neither node may be given `-connect`. Any `-connect` argument sends `ThreadOpenConnections2` into
  a different infinite loop at the top of the function that never reaches the seed path, and it
  soft-sets `-dnsseed=0`.

The seed-line assertion deliberately does not name the seed count. `assert_debug_log` matches by
substring, so pinning "39" would silently turn the check into a no-op the day the list changes
length.

### Verification

Mutation-checked in both directions against the built daemon with the old guards restored, dialling
through a dead local proxy so the check never touched the internet. Each arm fails on its own:

- the DNS arm on `Loading addresses from DNS seeds`;
- the `pnSeed` arm on the injection line, 477 ms after the first clock step — the first turn of the
  500 ms loop;
- with the log assertion removed, the `pnSeed` arm still fails on addrman, returning eight real
  mainnet addresses on port 32747 from a regtest node — the 23% sample cap over 39 entries.

Full build with `ENABLE_GUI=ON -DUSE_QT6=ON -DENABLE_TESTS=ON` clean, unit suite clean, all 39
functional tests pass, lint clean over the commit range.

### Adjacent defects found while reviewing, not fixed here

Three more sites carry the same `!OnTestnet()`-means-mainnet reading and let a regtest node reach
the network or take mainnet behaviour. They are separate subsystems with their own blast radius, so
they get their own issues rather than riding this one:

- `src/gridcoin/gridcoin.cpp:608` / `src/gridcoin/upgrade.cpp:41` — regtest schedules and fires a
  real HTTPS update check against GitHub;
- `src/init.cpp:1844` — `SetDevbuildCripple` fires on regtest, which is why eight functional tests
  carry `-devbuild=override`;
- `src/init.cpp:549` — `CreateNewConfigFile` has no network gate at all and writes six mainnet
  `addnode=` hostnames into a fresh regtest *or testnet* config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4UiicZ9xa29naEX3CNqr
