### PR TITLE
init, gridcoin, qt: stop regtest inheriting mainnet behaviour (config peers, devbuild cripple, update check)

### DIFF
--- a/doc/gridcoinresearch.conf.md
+++ b/doc/gridcoinresearch.conf.md
@@ -108,8 +108,12 @@ behavior.
 ## Addnodes
 
 The list of addnodes you provide are the nodes that your client will
-attempt to establish outbound connections with. The basic configuration
-file does not include addnodes. A full current list of addnodes can be
+attempt to establish outbound connections with. The configuration file
+generated on a first run already contains a small bootstrap set on mainnet and
+testnet -- on testnet those entries are the only automatic peer discovery there
+is, since the DNS seeds and the compiled-in fallback addresses are mainnet-only.
+A regtest config is generated without them, because a regtest node is not meant
+to reach the public network at all. A full current list of addnodes can be
 found at https://github.com/gridcoin-community/Gridcoin-Wiki/wiki/List-of-Addnodes
 
 If your system fails to sync, check your list of addnodes against the current list.

--- a/doc/multiprocess_interface_spec.md
+++ b/doc/multiprocess_interface_spec.md
@@ -209,7 +209,7 @@ handshake (`ipc/handshake.h`):
 
 ```cpp
 constexpr uint32_t IPC_SCHEMA_MAJOR   = 3;
-constexpr uint32_t IPC_SCHEMA_MINOR   = 2;
+constexpr uint32_t IPC_SCHEMA_MINOR   = 3;
 constexpr uint32_t IPC_PROTOCOL_VERSION = 1;
 ```
 
@@ -239,6 +239,12 @@ Rules a client must honor (from `ClientHandshake` and design §4.2):
   carrying it against an older node would otherwise call a method that node does
   not serve, which the minor turns into the "update the node" hard fail at
   connect.
+  **Minor 3** (under major 3) adds `Node.isMainNet @42`. The About dialog has to
+  know whether it is on the live network before it offers the version-info
+  button, and `isTestNet` cannot answer that -- there are three networks, so
+  `!isTestNet()` is also true on regtest. Same failure shape as the two above: a
+  GUI carrying it against an older node would call a method that node does not
+  serve, which the minor turns into the "update the node" hard fail at connect.
 - **`protocol_version`** — the transport/handshake shape. Must match exactly.
 - **`git_commit`** / **`built_at`** — not compatibility gates; a `git_commit`
   mismatch is a soft mixed-build warning, `built_at` is informational.
@@ -286,7 +292,8 @@ exchange), not a Gridcoin method (§9).
 Chain/network state plus node-side notification registration. Query methods
 include `getNodeCount`, `getNumBlocks`, `getBestBlockHash` (returns `uint256`),
 `getLastBlockTime`, `getDifficulty`, `isInitialBlockDownload`,
-`isOutOfSyncByAge`, `getWarnings`, `getClientVersion`, `isTestNet`, and the
+`isOutOfSyncByAge`, `getWarnings`, `getClientVersion`, `isTestNet`,
+`isMainNet` (not the negation of `isTestNet` -- regtest is neither), and the
 byte counters. Note the `try*` variants (`tryGetNumBlocksOfPeers`) that return
 `std::nullopt` instead of blocking on `cs_main` — provided for callers that must
 never wait on a core lock.

--- a/doc/regtest.md
+++ b/doc/regtest.md
@@ -43,6 +43,19 @@ CLI (`gridcoinresearchd -regtest <command>`); there is no separate `gridcoin-cli
   fresh node has spendable coins immediately. `listunspent` shows the premine
   UTXOs (note: `getbalance` reports 0 for the raw premine — it is immature for
   balance accounting even though it is spendable).
+- **No automatic peer discovery, and no update check.** A regtest node performs
+  no DNS seeding, injects none of the compiled-in `pnSeed` addresses, gets no
+  bootstrap `addnode=` lines in its generated config, and does not check GitHub
+  for a newer release, so the peers it dials are the ones you name with
+  `-connect` / `-addnode` / `-seednode`. Read that as the scope it is: it covers
+  what the node starts on its own, not everything it can be made to do. An RPC
+  you call can still reach the network -- `walletdiagnose` issues an NTP query
+  and a port-reachability connect on every chain, which is
+  [issue #3359](https://github.com/gridcoin-community/Gridcoin-Research/issues/3359).
+- **Not treated as a development build.** The cripple that stops a binary with a
+  nonzero version tweak from staking or sending applies only on mainnet, so a
+  regtest node built from a development tree stakes and spends without
+  `-devbuild=override`.
 - **Default ports.** P2P `32747`, RPC `35715` (mainnet uses `32749`/`15715`,
   testnet `32748`/`25715`). The functional framework allocates per-node ports
   dynamically when running multiple instances.

--- a/doc/regtest.md
+++ b/doc/regtest.md
@@ -5,9 +5,11 @@ testing. Unlike mainnet and testnet it has no peers, no real BOINC/research
 component, and a trivial difficulty target, so you can create blocks on demand
 and exercise wallet, mempool, P2P, and consensus code in a deterministic
 sandbox. Having no peers is enforced rather than incidental: a regtest node
-performs no DNS seeding and takes none of the peer addresses compiled into the
-binary, so it reaches the network only where you point it. It is the chain mode
-the Python functional tests run against (see
+performs no DNS seeding, takes none of the peer addresses compiled into the
+binary, and is not given the bootstrap `addnode=` entries that a first run
+writes into a mainnet or testnet config -- so its peers are the ones you name,
+and there is no automatic discovery behind them. It is the chain mode the Python
+functional tests run against (see
 [`test/functional/README.md`](../test/functional/README.md)).
 
 > Regtest is enabled only on builds where the regtest chain params are compiled

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -605,8 +605,14 @@ void ScheduleBackups(CScheduler& scheduler)
 //!
 void ScheduleUpdateChecks(CScheduler& scheduler)
 {
-    if (OnTestnet()) {
-        LogPrintf("Gridcoin: update checks disabled for testnet");
+    // Checking GitHub for a newer release is a mainnet activity: it is an
+    // unsolicited outbound HTTPS request about a release that only mainnet runs.
+    // The guard was !OnTestnet() by way of OnTestnet(), which is false on regtest
+    // too, so a regtest node armed this job and dialled api.github.com a minute
+    // after every start.
+    if (!OnMainnet()) {
+        LogPrintf("Gridcoin: update checks are mainnet-only; disabled on chain \"%s\"",
+                  Params().NetworkIDString());
         return;
     }
 

--- a/src/gridcoin/upgrade.cpp
+++ b/src/gridcoin/upgrade.cpp
@@ -36,9 +36,12 @@ void Upgrade::ScheduledUpdateCheck()
 bool Upgrade::CheckForLatestUpdate(std::string& client_message_out, std::string& change_log, Upgrade::UpgradeType& upgrade_type,
                                    bool ui_dialog)
 {
-    // If testnet skip this || If the user changes this to disable while wallet running just drop out of here now.
-    // (Need a way to remove items from scheduler.)
-    if (OnTestnet() || gArgs.GetBoolArg("-disableupdatecheck", false))
+    // Mainnet only. This is the leaf that the scheduler, the About dialog's
+    // version-info button and walletdiagnose's client-version check all reach,
+    // so it carries the guard for the callers the scheduler gate does not cover.
+    // The -disableupdatecheck arm is re-read on every call so that flipping the
+    // setting on a running wallet takes effect -- there is no way to unschedule.
+    if (!OnMainnet() || gArgs.GetBoolArg("-disableupdatecheck", false))
         return false;
 
     Http VersionPull;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1860,20 +1860,27 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     std::ostringstream strErrors;
 
+    // The cripple exists to keep a non-release binary from staking or spending on
+    // the live money chain. It was written when there were two networks, where
+    // !OnTestnet() did mean mainnet; regtest arrived later and inherited the
+    // mainnet branch by accident. Regtest is further from the live chain than
+    // testnet is -- private, local, and unreachable from the real networks -- so
+    // if testnet is exempt then regtest must be. Ask the question the mechanism
+    // actually means: is this the live money chain.
     SetDevbuildCripple(false);
-    if ((CLIENT_VERSION_BUILD != 0) && !OnTestnet())
+    if ((CLIENT_VERSION_BUILD != 0) && OnMainnet())
     {
         SetDevbuildCripple(true);
         if ((gArgs.GetArg("-devbuild", "") == "override"))
         {
             LogInstance().EnableCategory(BCLog::LogFlags::VERBOSE);
             SetDevbuildCripple(false);
-            LogPrintf("WARNING: Running development version outside of testnet in override mode!\n"
+            LogPrintf("WARNING: Running a non-release build on mainnet in override mode!\n"
                       "VERBOSE logging is enabled.");
         }
         else
         {
-            LogPrintf("WARNING: Running development version outside of testnet!\n"
+            LogPrintf("WARNING: Running a non-release build on mainnet!\n"
                       "Staking and sending transactions will be disabled.");
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -544,14 +544,34 @@ static void CreateNewConfigFile()
         << "# daemon will not start without them. Change them if you like, but do\n"
         << "# not leave rpcpassword empty or equal to rpcuser.\n"
         << "rpcuser=gridcoinrpc\n"
-        << "rpcpassword=" << GenerateRpcPassword() << "\n"
-        << "\n"
-        << "addnode=addnode-us-central.cycy.me\n"
-        << "addnode=ec2-3-81-39-58.compute-1.amazonaws.com\n"
-        << "addnode=gridcoin.network\n"
-        << "addnode=seeds.gridcoin.ifoggz-network.xyz\n"
-        << "addnode=seed.gridcoin.pl\n"
-        << "addnode=www.grcpool.com\n";
+        << "rpcpassword=" << GenerateRpcPassword() << "\n";
+
+    // Bootstrap peers for the public networks, and only for those.
+    //
+    // On testnet these are load-bearing rather than a convenience: ThreadDNSAddressSeed2
+    // and the pnSeed fallback in ThreadOpenConnections2 are both mainnet-only, chainparams
+    // carries no per-network seed list, and peers.dat is empty on a fresh node -- so
+    // without these lines a fresh testnet node has no automatic peer discovery at all.
+    // They are resolved against Params().GetDefaultPort(), so testnet dials them on its
+    // own port rather than mainnet's. That is why the guard here is IsMockableChain()
+    // and not OnMainnet(): excluding testnet would strand it.
+    //
+    // Regtest is a private, local chain, so writing real-network hostnames into its
+    // config is wrong twice over -- an isolated test chain resolves and repeatedly dials
+    // third-party production hosts, and the lines persist for the life of the datadir.
+    //
+    // The credentials above are still written on every network: the daemon soft-sets
+    // -server and StartRPCThreads refuses to start without them.
+    if (!Params().IsMockableChain()) {
+        myConfig
+            << "\n"
+            << "addnode=addnode-us-central.cycy.me\n"
+            << "addnode=ec2-3-81-39-58.compute-1.amazonaws.com\n"
+            << "addnode=gridcoin.network\n"
+            << "addnode=seeds.gridcoin.ifoggz-network.xyz\n"
+            << "addnode=seed.gridcoin.pl\n"
+            << "addnode=www.grcpool.com\n";
+    }
 }
 
 void AddLoggingArgs(ArgsManager& argsman)

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -222,6 +222,11 @@ public:
     //! Whether the node runs on testnet.
     virtual bool isTestNet() = 0;
 
+    //! Whether the node runs on mainnet. Not the negation of isTestNet(): there
+    //! is a third network, and GUI code that needs "is this the live network"
+    //! has to ask for it directly rather than infer it.
+    virtual bool isMainNet() = 0;
+
     //! Request that the node begin shutting down (the GUI->core direction, e.g.
     //! a Windows WM_QUERYENDSESSION). Wraps the core StartShutdown(); in the
     //! monolith this brings the whole app down, matching the prior direct call.

--- a/src/ipc/capnp/node.capnp
+++ b/src/ipc/capnp/node.capnp
@@ -62,6 +62,7 @@ interface Node $Proxy.wrap("interfaces::Node") {
     handleMinerStatusChanged @39 (context :Proxy.Context, callback :MinerStatusChangedCallback) -> (result :Handler.Handler);
     handlePSGTPoolChanged @40 (context :Proxy.Context, callback :PSGTPoolChangedCallback) -> (result :Handler.Handler);
     handleNotifyScraperEvent @41 (context :Proxy.Context, callback :NotifyScraperEventCallback) -> (result :Handler.Handler);
+    isMainNet @42 (context :Proxy.Context) -> (result :Bool);
 }
 
 # --- Notification callbacks (interfaces::Node::*Fn std::function types) ---

--- a/src/ipc/handshake.h
+++ b/src/ipc/handshake.h
@@ -54,8 +54,16 @@ namespace ipc {
 //! reply is rethrown client-side as std::runtime_error out of initializePage(),
 //! which the GUI can only treat as a runaway exception. The minor turns that
 //! into the "Update the node" hard fail at connect.
+//!
+//! Minor 3 (under major 3): Node gained `isMainNet @42` (node.capnp). The About
+//! dialog needs to know whether it is on the live network before it offers the
+//! version-info button, and isTestNet() cannot answer that -- there are three
+//! networks, so !isTestNet() is true on regtest. Additive, so an old node still
+//! talks to a new GUI until the About dialog opens and calls a method the node
+//! does not serve; the minor turns that into the "Update the node" hard fail at
+//! connect instead.
 constexpr uint32_t IPC_SCHEMA_MAJOR = 3;
-constexpr uint32_t IPC_SCHEMA_MINOR = 2;
+constexpr uint32_t IPC_SCHEMA_MINOR = 3;
 constexpr uint32_t IPC_PROTOCOL_VERSION = 1;
 
 //! Domain-separation tag hashed into the node identity token. Bump the suffix if

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -47,8 +47,8 @@ using namespace std;
 unsigned int nMinerSleep;
 CAmount nMinerMinTxFee = -1;  // -1: -mintxfee unset, use GetBaseFee
 
-// Development-build staking cripple; see miner.h. Extracted from the former
-// util.h global. Set from init (AppInit2 devbuild/testnet gating).
+// Non-release-build staking cripple; see miner.h. Extracted from the former
+// util.h global. Set from init (AppInit2, mainnet gating).
 static bool fDevbuildCripple = false;
 bool GetDevbuildCripple() { return fDevbuildCripple; }
 void SetDevbuildCripple(bool crippled) { fDevbuildCripple = crippled; }

--- a/src/miner.h
+++ b/src/miner.h
@@ -53,12 +53,6 @@ int32_t ComputeBlockVersion(int height);
 // (Particl-analog) and consumed in StakeMiner. Unused on testnet / mainnet.
 extern std::atomic<int> g_stakelimit_height;
 
-//! Whether the development-build staking cripple is active. When true,
-//! ThreadStakeMiner refuses to stake and CommitTransaction refuses
-//! reward-bearing sends: a development build disables all staking unless the
-//! hidden `devbuild=override` setting is passed. State lives in miner.cpp;
-//! extracted from the former util.h fDevbuildCripple global so util.h is
-//! stateless. Set from init.
 namespace GRC { class Superblock; }
 
 //! \brief Stage an explicit superblock for the next block the miner assembles.
@@ -72,6 +66,13 @@ namespace GRC { class Superblock; }
 //! before consumption replaces the pending value (last writer wins).
 void StageRegtestSuperblock(GRC::Superblock superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+//! Whether the non-release-build cripple is active. When true, ThreadStakeMiner
+//! refuses to stake and CommitTransaction refuses reward-bearing sends, unless
+//! the hidden `devbuild=override` setting is passed. Set from init, and only on
+//! mainnet: a build carrying a nonzero version tweak is unvetted code, and the
+//! live money chain is the one place that matters. Testnet and regtest are
+//! where such builds are meant to run. State lives in miner.cpp, extracted from
+//! the former util.h fDevbuildCripple global so util.h is stateless.
 bool GetDevbuildCripple();
 void SetDevbuildCripple(bool crippled);
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -156,6 +156,8 @@ public:
 
     bool isTestNet() override { return OnTestnet(); }
 
+    bool isMainNet() override { return OnMainnet(); }
+
     void startShutdown() override { StartShutdown(); }
 
     LatestVersionInfo checkForLatestUpdate() override

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -47,12 +47,16 @@ void AboutDialog::setModel(ClientModel *model)
     {
         ui->versionLabel->setText(model->formatFullVersion());
 
-        // Wire the version-info / update-check button. Testnet status is read
-        // through the client model's node interface (ClientModel::isTestNet ->
-        // interfaces::Node), never by calling chainparams (OnTestnet()) from GUI
+        // Wire the version-info / update-check button. Network identity is read
+        // through the client model's node interface (ClientModel::isMainNet ->
+        // interfaces::Node), never by calling chainparams (OnMainnet()) from GUI
         // code; done here rather than in the constructor because the model is
         // only available once set. -disableupdatecheck is a config read.
-        if (!model->isTestNet() && !gArgs.GetBoolArg("-disableupdatecheck", false)) {
+        //
+        // isMainNet() rather than !isTestNet(): the check is served only on
+        // mainnet, and !isTestNet() is true on regtest, which would leave the
+        // button live and reporting a network error caused by policy.
+        if (model->isMainNet() && !gArgs.GetBoolArg("-disableupdatecheck", false)) {
             connect(ui->versionInfoButton, &QAbstractButton::pressed, this, [this]() { handlePressVersionInfoButton(); });
         } else if (gArgs.GetBoolArg("-disableupdatecheck", false)) {
             ui->versionInfoButton->setDisabled(true);
@@ -60,7 +64,7 @@ void AboutDialog::setModel(ClientModel *model)
                                                  "by config or startup parameter."));
         } else {
             ui->versionInfoButton->setDisabled(true);
-            ui->versionInfoButton->setToolTip(tr("Version information is not available on testnet."));
+            ui->versionInfoButton->setToolTip(tr("Version information is only available on mainnet."));
         }
     }
 }

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -217,6 +217,11 @@ bool ClientModel::isTestNet() const
     return m_node.isTestNet();
 }
 
+bool ClientModel::isMainNet() const
+{
+    return m_node.isMainNet();
+}
+
 bool ClientModel::inInitialBlockDownload() const
 {
     return m_node.isInitialBlockDownload();

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -51,6 +51,9 @@ public:
 
     //! Return true if client connected to testnet
     bool isTestNet() const;
+    //! Return true if client connected to mainnet. Distinct from !isTestNet(),
+    //! which is also true on regtest.
+    bool isMainNet() const;
     //! Return true if core is doing initial block download
     bool inInitialBlockDownload() const;
     //! Return conservative estimate of total number of blocks, or 0 if unknown

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -160,11 +160,15 @@ void OptionsDialog::setModel(OptionsModel *model)
     {
         connect(model, &OptionsModel::displayUnitChanged, this, &OptionsDialog::updateDisplayUnit);
 
-        // Hide the update-check option on testnet. Read testnet status through
-        // the model's node interface (never the raw fTestNet global), and do it
-        // here rather than in the constructor because the model -- and thus the
-        // node -- is only available once it is set.
-        if (model->isTestNet()) {
+        // Hide the update-check option wherever the check does not run, which
+        // is everywhere but mainnet. Read network identity through the model's
+        // node interface (never the raw fTestNet global), and do it here rather
+        // than in the constructor because the model -- and thus the node -- is
+        // only available once it is set.
+        //
+        // isMainNet() rather than isTestNet(): the latter is false on regtest,
+        // which would leave the option on offer for a check that never runs.
+        if (!model->isMainNet()) {
             ui->disableUpdateCheck->setHidden(true);
         }
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -481,6 +481,11 @@ bool OptionsModel::isTestNet()
     return m_node.isTestNet();
 }
 
+bool OptionsModel::isMainNet()
+{
+    return m_node.isMainNet();
+}
+
 bool OptionsModel::getCoinControlFeatures()
 {
     return fCoinControlFeatures;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -89,6 +89,11 @@ public:
     //! (interfaces::Node::isTestNet). Lets dialogs that hold an OptionsModel gate
     //! testnet-only UI without calling chainparams (OnTestnet()) from GUI code.
     bool isTestNet();
+    //! Whether the node is on mainnet, read through the node interface
+    //! (interfaces::Node::isMainNet). Distinct from !isTestNet(), which is also
+    //! true on regtest -- use this to gate UI for anything that only happens on
+    //! the live network.
+    bool isMainNet();
     bool getStartAtStartup();
     bool getStartMin();
     bool getMinimizeToTray();

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -94,6 +94,7 @@ BOOST_AUTO_TEST_CASE(node_wraps_chain_globals)
     BOOST_CHECK_EQUAL(node->getNumBlocks(), WITH_LOCK(cs_main, return nBestHeight));
     BOOST_CHECK(node->getBestBlockHash() == WITH_LOCK(cs_main, return hashBestChain));
     BOOST_CHECK_EQUAL(node->isTestNet(), OnTestnet());
+    BOOST_CHECK_EQUAL(node->isMainNet(), OnMainnet());
     BOOST_CHECK_EQUAL(node->getClientVersion(), FormatFullVersion());
     // No peers in the unit-test environment.
     BOOST_CHECK_EQUAL(node->getNodeCount(), 0);

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -109,6 +109,7 @@ this table mirrors it.
 | `rpc_net.py` | two-node `getpeerinfo`/`addnode` + block propagation |
 | `feature_sidestake.py` | local sidestaking config + coinstake reward split |
 | `feature_no_mainnet_seeds_on_regtest.py` | regtest takes neither the DNS seed hostnames nor `pnSeed` |
+| `feature_no_update_check_on_regtest.py` | regtest does not arm the GitHub release check |
 
 ### Extended suite (opt-in via `--extended`, not in default CI)
 

--- a/test/functional/feature_beacon_activation.py
+++ b/test/functional/feature_beacon_activation.py
@@ -44,11 +44,9 @@ class BeaconActivationTest(GridcoinTestFramework):
         self.setup_clean_chain = True
         # -staking=0 keeps the background staker out of it, so the chain only
         # moves on an explicit generate call. -forcecpid supplies the CPID that
-        # BOINC would otherwise have to provide. -devbuild=override lets a
-        # development build send a transaction at all.
+        # BOINC would otherwise have to provide.
         self.extra_args = [[
             "-staking=0",
-            "-devbuild=override",
             "-connect=0",
             "-listen=0",
             f"-forcecpid={CPID}",

--- a/test/functional/feature_contract_replay.py
+++ b/test/functional/feature_contract_replay.py
@@ -50,7 +50,6 @@ class ContractReplayTest(GridcoinTestFramework):
         self.setup_clean_chain = True
         self.extra_args = [[
             "-staking=0",
-            "-devbuild=override",
             "-connect=0",
             "-listen=0",
             f"-forcecpid={CPID}",

--- a/test/functional/feature_mrc.py
+++ b/test/functional/feature_mrc.py
@@ -44,7 +44,7 @@ class MrcTest(GridcoinTestFramework):
         self.num_nodes = 2
         self.chain = "regtest"
         self.setup_clean_chain = True
-        common = ["-staking=0", "-devbuild=override"]
+        common = ["-staking=0"]
         self.extra_args = [common[:], common + [f"-forcecpid={CPID}"]]
 
     def setup_network(self):

--- a/test/functional/feature_no_update_check_on_regtest.py
+++ b/test/functional/feature_no_update_check_on_regtest.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""A regtest node must not check GitHub for a newer release.
+
+`GRC::ScheduleUpdateChecks` arms a scheduler job that issues a synchronous
+libcurl GET to api.github.com, once a minute after start and then on the
+-updatecheckinterval cycle. It was guarded by `OnTestnet()`, and there are three
+networks, so regtest took the mainnet branch and dialled GitHub out of a test
+run (issue #3357).
+
+The guard now keys on `OnMainnet()`, as does the leaf guard in
+`Upgrade::CheckForLatestUpdate` that the About dialog and walletdiagnose reach.
+
+The 60-second delay is not reachable from here: CScheduler runs on
+std::chrono::system_clock, which setmocktime does not move, so the request
+cannot be provoked and then observed not to happen. What the test pins instead
+is the decision -- the node must record that it declined to arm the job, and
+must not record that it armed it.
+
+The two are not redundant, though they are not symmetric either. "Declined is
+present" is the load-bearing one: it can only be logged by the guard itself, so
+it proves the code ran and chose. "Armed is absent" would pass on its own for
+the wrong reason -- a node whose scheduler never started logs neither line --
+but it is kept because it is the property actually being demanded, and it stays
+meaningful if the decline log and the arming ever stop being adjacent.
+
+Deliberately not exercised: the walletdiagnose RPC, which also funnels through
+the leaf guard. It runs two further ungated outbound checks in the same loop --
+a UDP NTP query and a TCP connect to portquiz.net, the latter through a throwing
+resolver with no handler -- so calling it from a test would reintroduce exactly
+the unsolicited network traffic this test exists to forbid, and would fail
+outright on a runner without DNS.
+"""
+
+import os
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import chain_subdir
+
+# Logged when the guard declines. Includes the network name, so the assertion
+# cannot be satisfied by the old testnet-only wording.
+DECLINED = 'Gridcoin: update checks are mainnet-only; disabled on chain "regtest"'
+
+# Logged only after the guard falls through, when the job is actually armed.
+ARMED = "Gridcoin: checking for updates every"
+
+
+class NoUpdateCheckOnRegtestTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        # No -disableupdatecheck: that would satisfy a different guard and the
+        # test would pass without the fix. The node has to decline on the
+        # strength of the network alone.
+        self.extra_args = [["-staking=0"]]
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+
+    def debug_log(self):
+        path = os.path.join(self.nodes[0].datadir, chain_subdir(self.chain), "debug.log")
+        with open(path, encoding="utf-8") as log_file:
+            return log_file.read()
+
+    def run_test(self):
+        self.log.info("the update check declines to arm on regtest")
+
+        # Not a plain read: StartRPCThreads runs well before
+        # ScheduleBackgroundJobs, so the node answers RPC -- and the framework
+        # therefore returns from start_nodes -- before ScheduleUpdateChecks has
+        # decided anything. Reading debug.log straight away would race, and the
+        # race is silent in the direction that matters: the DECLINED line would
+        # simply not be there yet.
+        self.wait_until(lambda: DECLINED in self.debug_log(), timeout=60)
+
+        # Re-read once, so both assertions see one consistent snapshot taken
+        # after the decision was recorded.
+        log = self.debug_log()
+
+        assert DECLINED in log, \
+            "regtest node did not record declining the update check"
+        assert ARMED not in log, \
+            "regtest node armed the GitHub update check"
+
+
+if __name__ == "__main__":
+    NoUpdateCheckOnRegtestTest().main()

--- a/test/functional/feature_research_reward.py
+++ b/test/functional/feature_research_reward.py
@@ -48,7 +48,6 @@ class ResearchRewardTest(GridcoinTestFramework):
         self.setup_clean_chain = True
         self.extra_args = [[
             "-staking=0",
-            "-devbuild=override",
             "-connect=0",
             "-listen=0",
             f"-forcecpid={CPID}",

--- a/test/functional/feature_shutdown.py
+++ b/test/functional/feature_shutdown.py
@@ -40,7 +40,12 @@ class FeatureShutdownTest(GridcoinTestFramework):
         # Skip the default deterministic-coinbase wallet import: it calls
         # createwallet with named args, which Gridcoin's RPC parser rejects
         # ("Params must be an array"). This test needs no wallet or chain state.
-        self.add_nodes(self.num_nodes)
+        #
+        # -staking=0 is explicit rather than inherited. Staking defaults to on,
+        # and until the non-release-build cripple stopped applying to regtest it
+        # was what kept the staker inert here. This test is about a clean bounded
+        # shutdown, so the staker has no business running during it.
+        self.add_nodes(self.num_nodes, [["-staking=0"]])
         self.start_nodes()
 
     def run_test(self):

--- a/test/functional/feature_shutdown.py
+++ b/test/functional/feature_shutdown.py
@@ -35,17 +35,17 @@ class FeatureShutdownTest(GridcoinTestFramework):
         self.num_nodes = 1
         self.chain = "regtest"
         self.setup_clean_chain = True
+        # -staking=0 is explicit rather than inherited. Staking defaults to on,
+        # and until the non-release-build cripple stopped applying to regtest it
+        # was what kept the staker inert here. This test is about a clean bounded
+        # shutdown, so the staker has no business running during it.
+        self.extra_args = [["-staking=0"]]
 
     def setup_network(self):
         # Skip the default deterministic-coinbase wallet import: it calls
         # createwallet with named args, which Gridcoin's RPC parser rejects
         # ("Params must be an array"). This test needs no wallet or chain state.
-        #
-        # -staking=0 is explicit rather than inherited. Staking defaults to on,
-        # and until the non-release-build cripple stopped applying to regtest it
-        # was what kept the staker inert here. This test is about a clean bounded
-        # shutdown, so the staker has no business running during it.
-        self.add_nodes(self.num_nodes, [["-staking=0"]])
+        self.add_nodes(self.num_nodes, self.extra_args)
         self.start_nodes()
 
     def run_test(self):

--- a/test/functional/feature_stakelimit.py
+++ b/test/functional/feature_stakelimit.py
@@ -41,11 +41,9 @@ class RegtestStakeLimitTest(GridcoinTestFramework):
         self.chain = "regtest"
         self.setup_clean_chain = True
         # -staking=1 runs the background ThreadStakeMiner (the path stakelimit
-        # gates). -devbuild=override clears fDevbuildCripple, which otherwise
-        # disables staking on a dev build outside testnet (regtest is not
-        # testnet). Isolated (-connect=0/-listen=0); solo staking is allowed on
+        # gates). Isolated (-connect=0/-listen=0); solo staking is allowed on
         # regtest via the IsMockableChain bypass in IsMiningAllowed.
-        self.extra_args = [["-staking=1", "-devbuild=override", "-connect=0", "-listen=0"]]
+        self.extra_args = [["-staking=1", "-connect=0", "-listen=0"]]
 
     def setup_network(self):
         # Single isolated node; bypass the base regtest createwallet path (Gridcoin

--- a/test/functional/mining_fee_escalator.py
+++ b/test/functional/mining_fee_escalator.py
@@ -155,7 +155,7 @@ class MiningFeeEscalatorTest(GridcoinTestFramework):
         self.num_nodes = 2
         self.chain = "regtest"
         self.setup_clean_chain = True
-        common = ["-staking=0", "-devbuild=override",
+        common = ["-staking=0",
                   "-blockmaxsize=%d" % BLOCK_MAX_SIZE]
         self.extra_args = [
             common,                     # node0: spends

--- a/test/functional/mining_fee_policy.py
+++ b/test/functional/mining_fee_policy.py
@@ -76,9 +76,9 @@ BULK_INPUTS = 20
 
 # Hoisted out of set_test_params because case 4 restarts a node itself, and
 # TestNode.start REPLACES extra_args rather than appending to it -- a restart
-# that passes only "-mintxfee=..." would drop -devbuild=override and fail for
-# an unrelated reason.
-COMMON_ARGS = ["-staking=0", "-connect=0", "-listen=0", "-devbuild=override"]
+# that passes only "-mintxfee=..." would drop the isolation and staking flags
+# and fail for an unrelated reason.
+COMMON_ARGS = ["-staking=0", "-connect=0", "-listen=0"]
 
 
 class MiningFeePolicyTest(GridcoinTestFramework):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -918,8 +918,9 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         The outputs are ordinary (non-coinstake), spendable at 1 confirmation, so
         a single confirming block suffices (mining more would over-mine the
         shared premine pool -> "CreateCoinStake: no stake found"). The split is a
-        *raw* transaction because dev builds cripple wallet-level
-        CommitTransaction (fDevbuildCripple), so sendmany/sendtoaddress fail.
+        *raw* transaction so that it depends on no wallet-level send policy at
+        all; three of this helper's five callers never passed -devbuild=override
+        even when the cripple still applied on regtest.
 
         Args:
           funder: node whose premine UTXO is fanned out; the outputs go to

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -214,6 +214,11 @@ BASE_SCRIPTS = [
     # wallet_splitunspent.py rather than in EXTENDED_SCRIPTS: it is deterministic
     # and drives no staking, so duration is its only cost.
     'feature_no_mainnet_seeds_on_regtest.py',
+    # feature_no_update_check_on_regtest.py: the GitHub release check must not be
+    # armed on regtest. Pins the decision rather than the request, because
+    # CScheduler runs on the real clock and setmocktime cannot reach the
+    # 60-second delay.
+    'feature_no_update_check_on_regtest.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since longer tests benefit from being scheduled

--- a/test/functional/wallet_splitunspent.py
+++ b/test/functional/wallet_splitunspent.py
@@ -6,21 +6,15 @@
 floor, the piece cap, the -minstakesplitvalue floor, the error paths and the
 consolidateunspent round trip.
 
-Three regtest facts shape the design:
+Two regtest facts shape the design:
 
-1. -devbuild=override is mandatory. Without it CWallet::CommitTransaction
-   short-circuits (src/wallet/wallet.cpp) and every splitunspent fails with RPC
-   -4 "...coins in your wallet were already spent..." even though the wallet is
-   fine. Raw-transaction funding is NOT gated, so a missing flag funds cleanly
-   and only fails at the split.
-
-2. generatetoaddress' address argument is advisory: the coinstake pays back to
+1. generatetoaddress' address argument is advisory: the coinstake pays back to
    the kernel's own script, so on regtest every reward lands on the single
    premine address and a fresh address never receives anything from mining.
    Split targets are funded by explicit raw transactions instead, and the test
    mines no blocks at all.
 
-3. splitunspent calls AvailableCoins with fOnlyConfirmed=false, and depth-0
+2. splitunspent calls AvailableCoins with fOnlyConfirmed=false, and depth-0
    mempool outputs clear the remaining filters, so the funding outputs never
    need to confirm.
 
@@ -54,8 +48,7 @@ class WalletSplitUnspentTest(GridcoinTestFramework):
         # to be today's default). The exact-fee assertions below (per-piece
         # floor, conservation sums) are written against this value, so a
         # change to the daemon default cannot shift them.
-        self.extra_args = [["-staking=0", "-connect=0", "-listen=0", "-devbuild=override",
-                            "-paytxfee=0.001"]]
+        self.extra_args = [["-staking=0", "-connect=0", "-listen=0", "-paytxfee=0.001"]]
 
     def setup_network(self):
         # Single isolated regtest node; bypass the base regtest createwallet path


### PR DESCRIPTION
Closes #3357.

Three sites used `!OnTestnet()` (or `OnTestnet()`) as if it meant "mainnet". It does not — there are
exactly three networks, so the predicate is true on regtest as well, and regtest inherited mainnet
behaviour in each case. #3356 fixed two of the same vintage in `net.cpp` and added `OnMainnet()`;
these are the rest.

The bug was live rather than theoretical. `strace` on a regtest node from this tree caught
`connect(…, {AF_INET, htons(443), inet_addr("140.82.112.6")})` — api.github.com — at exactly T+60s
after start, and six node datadirs surviving a full functional-suite run all carried
`Gridcoin: checking for updates every 120 hours`.

### The three fixes, and why two of them use different predicates

| # | site | new guard |
|---|---|---|
| 1 | `CreateNewConfigFile` writes six mainnet `addnode=` lines | `!IsMockableChain()` |
| 2 | the non-release-build cripple | `OnMainnet()` |
| 3 | the GitHub update check (four gates) | `OnMainnet()` |

**Commit 1 is deliberately not `OnMainnet()`, and this is the one that matters.** Those `addnode`
entries are testnet's *only* automatic peer discovery: `ThreadDNSAddressSeed2` and the `pnSeed`
fallback are both mainnet-only, chainparams carries no per-network seed list, and `peers.dat` is
empty on a fresh node. Probing found at least one of the six answering on the testnet default port
today. Gating on mainnet would have left a fresh public-testnet node with nothing to dial — the
precise "breaks the live network" outcome the rule forbids. `IsMockableChain()` is true only on
regtest, so mainnet and testnet come out byte-identical.

That asymmetry is also why the two predicates are not interchangeable, and why each commit states
its own enumeration rather than inheriting an argument from the others.

### Why the update check needed an interface change

Fixing the two backend gates alone would have left the Qt About dialog's version-info button wired
on regtest, reporting `No response from GitHub - check network connectivity.` for a request refused
by policy — a new regtest-only lie created by this change. That is *not* what testnet does, where
the button is disabled outright with a tooltip. The options dialog had the same defect, offering the
"disable update check" setting for a check that never runs.

GUI code may not call chainparams directly, and the only predicate on `interfaces::Node` was
`isTestNet()`. So `Node` gains `isMainNet()` — deliberately not the negation — surfaced on both
`ClientModel` and `OptionsModel`. That is `node.capnp @42` and `IPC_SCHEMA_MINOR` 2 → 3, additive,
with `doc/multiprocess_interface_spec.md` updated in the same commit as the previous minor bump
(`7ff6a03fe`) did.

### Inertness

Exactly three networks; `strNetworkID` is assigned once per params class and `SelectParams` throws
otherwise. Enumerated per commit:

- **commit 1** — `IsMockableChain()` is false in both `CMainParams` and `CTestNetParams`, so the
  guard is taken and the same six lines are written in the same order. Verified empirically against
  three empty datadirs: regtest gets credentials and zero `addnode=` lines; the testnet and mainnet
  configs are byte-identical to each other apart from the generated password.
- **commits 2–3** — `!OnTestnet()` and `OnMainnet()` are both true on mainnet and both false on
  testnet. On a shipped release commit 2's block is dead regardless: a release bump zeroes the
  version tweak and the `&&` short-circuits before the network is tested.

Testnet's only observable deltas are the text of one start-up log line and a tooltip on a dialog
that was already disabled there. That tooltip loses its existing translations, which is the ordinary
cost of changing a `tr()` string.

Nothing here is reachable from any validation or consensus path.

### Tests

Eight functional tests carried `-devbuild=override` solely to undo commit 2's cripple. They now drop
it, which is what turns them into the regression test — left in place, CI would only ever exercise
the override path. The prose mattered more than the flag: five files carried comments explaining why
it was required, and stale rationale of exactly that kind is what produced this defect class.
`feature_shutdown.py` gains an explicit `-staking=0`; it was the only regtest test relying on the
cripple to keep its staker inert.

`feature_no_update_check_on_regtest.py` pins the decision rather than the request — `CScheduler` runs
on `std::chrono::system_clock`, which `setmocktime` does not move, so the 60-second delay cannot be
provoked and observed not to fire. It waits for the decline line rather than reading `debug.log`
directly, because `StartRPCThreads` runs ~150 lines before `ScheduleBackgroundJobs` and a plain read
races in the silent direction. Mutation-checked against the old guard.

It deliberately does not call `walletdiagnose`, despite that RPC reaching the leaf guard: the same
loop runs a UDP NTP query and a TCP connect to portquiz.net through a throwing resolver with no
handler, so using it would reintroduce the traffic the test forbids and fail on a runner without DNS.

Commit 1 has no automated coverage and cannot get any — the framework pre-writes the per-chain
config, so `IsConfigFileEmpty()` is never true under test. Verified manually instead, as above.

### Verification

Full Qt6 GUI + tests build clean, unit suite clean, extended functional suite green, lint clean over
the commit range.

On flakes: two extended-suite runs failed on unrelated P2P/RPC-timing tests. Rather than assume, I
built the unmodified base in a separate worktree and ran the same suite three times — it failed too
(`feature_mrc.py`, "no RPC connection"). Every implicated test passes standalone on both trees
(`rpc_net` 10/10, `p2p_version_handshake` 10/10, `rpc_audit_snapshot_accrual` 6/6 on branch and
6/6 on base). Different victim each run, never reproducible standalone, present on unmodified base:
environmental, not this diff.

### Out of scope, filed separately

- `src/qt/guiutil.cpp` `GetAutoStartupArguments()` — same defect family, and the worst of them: a
  regtest GUI enabling "start on system login" writes an autostart entry with no `-regtest`, so it
  launches a **mainnet** node. Left out because it is a different subsystem and carries a design
  question (should autostart be offered on regtest at all?).
- `walletdiagnose`'s ungated NTP and portquiz.net calls, reachable on regtest.
- The `!OnTestnet()` uses in `validation.cpp` and `voting/registry.cpp` are consensus-strictness
  gates where mainnet-strict behaviour on regtest is the safe direction; deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4UiicZ9xa29naEX3CNqr
