### PR TITLE
test: restore key_io_tests to the build, and lint for the next orphan

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(test_gridcoin
     getarg_tests.cpp
     gridcoin_tests.cpp
     htlc_tests.cpp
+    key_io_tests.cpp
     gridcoin/block_finder_tests.cpp
     gridcoin/block_rewards_tests.cpp
     gridcoin/boinc_tests.cpp

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -5,6 +5,7 @@
 #include <test/data/key_io_invalid.json.h>
 #include <test/data/key_io_valid.json.h>
 
+#include <chainparams.h>
 #include <key.h>
 #include <key_io.h>
 #include <script.h>
@@ -16,7 +17,28 @@
 
 UniValue read_json(const std::string& jsondata);
 
-BOOST_AUTO_TEST_SUITE(key_io_tests)
+namespace {
+//! Restores the selected chain when a case exits, however it exits.
+//!
+//! These cases switch chain params per vector, and the params are a process
+//! global that the module fixture sets once (BOOST_GLOBAL_FIXTURE, not
+//! per-case). This suite runs near the head of the binary, so whatever it
+//! leaves selected is what nearly every later suite sees, and plenty of those
+//! read Params() without selecting first. The cases used to end with an
+//! explicit SelectParams(MAIN), which any throw skips -- get_str() on a
+//! malformed vector, for one. Scope-based restoration cannot be skipped.
+//!
+//! Attached with BOOST_FIXTURE_TEST_SUITE rather than declared per case, so a
+//! case added later is covered without anyone having to remember.
+struct ChainParamsRestorer
+{
+    const std::string m_original{Params().NetworkIDString()};
+
+    ~ChainParamsRestorer() { SelectParams(m_original); }
+};
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(key_io_tests, ChainParamsRestorer)
 
 // Goal: check that parsed keys match test payload
 BOOST_AUTO_TEST_CASE(key_io_valid_parse)
@@ -78,8 +100,6 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
             BOOST_CHECK_MESSAGE(!privkey.IsValid(), "IsValid pubkey as privkey:" + strTest);
         }
     }
-
-    SelectParams(CBaseChainParams::MAIN);
 }
 
 // Goal: check that generated keys match test vectors
@@ -115,8 +135,6 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
             BOOST_CHECK_EQUAL(address, exp_base58string);
         }
     }
-
-    SelectParams(CBaseChainParams::MAIN);
 }
 
 
@@ -146,8 +164,18 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
             BOOST_CHECK_MESSAGE(!privkey.IsValid(), "IsValid privkey in mainnet:" + strTest);
         }
     }
+}
 
-    SelectParams(CBaseChainParams::MAIN);
+// Goal: a direct regression test on the restorer above.
+//
+// The suite fixture restores the chain around every case, so correctness no
+// longer depends on where this sits. It is declared last only because it can
+// only observe a leak from a case that ran before it: with the restorer
+// neutered, key_io_invalid ends its loop on testnet and this fails
+// "test != main".
+BOOST_AUTO_TEST_CASE(key_io_leaves_chain_params_unchanged)
+{
+    BOOST_CHECK_EQUAL(Params().NetworkIDString(), CBaseChainParams::MAIN);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/lint/lint-test-sources.sh
+++ b/test/lint/lint-test-sources.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+#
+# Every .cpp under src/test/ must be wired into src/test/CMakeLists.txt.
+#
+# A file in the tree that no CMakeLists names is never compiled, never linked
+# into test_gridcoin and never run, while looking exactly like coverage to
+# anyone reading it. key_io_tests.cpp was wired into the autotools build and
+# never into CMake, so it dropped out silently when autotools was removed and
+# nothing noticed for months (issue #3355). A build-system migration is exactly
+# when this happens, and exactly when nobody is looking for it.
+#
+# What counts as wiring is deliberately loose, because sources reach the target
+# by several routes: the add_executable list, target_sources() inside a
+# conditional block (ipc_wire_handshake_tests.cpp), and set_property(SOURCE ...)
+# (test_gridcoin.cpp). A deliberate omission is recorded by commenting the entry
+# out, as compilerbug_tests.cpp does, and that counts too -- the check is that
+# the file was considered, not how.
+#
+# What does NOT count is a filename mentioned inside an explanatory comment.
+# src/test/CMakeLists.txt is comment-heavy and its prose names source files, so
+# accepting any occurrence would leave the check green for a file whose real
+# wiring had been deleted -- true today of both ipc_wire_handshake_tests.cpp and
+# alt_signal_stack.cpp, each named once in wiring and once in a paragraph.
+
+export LC_ALL=C
+
+# Paths below are repository-relative, so anchor there rather than requiring the
+# caller to be in the right directory (lint-qt-includes.sh does the same). The
+# toplevel is captured and tested separately: `cd "$(git ...)"` is not enough,
+# because a failed rev-parse yields an empty string and `cd ""` is a successful
+# no-op, which would leave this check silently passing over no files at all.
+TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "${TOPLEVEL}" ] || ! cd "${TOPLEVEL}"; then
+    echo "lint-test-sources: not inside a git repository."
+    exit 1
+fi
+
+CMAKELISTS="src/test/CMakeLists.txt"
+
+if [ ! -f "${CMAKELISTS}" ]; then
+    echo "lint-test-sources: ${CMAKELISTS} is missing."
+    exit 1
+fi
+
+# Reduce the CMakeLists to wiring lines: every non-comment line as-is, plus the
+# commented-out-entry convention -- a comment whose entire content is one source
+# path. Prose comments drop out here, which is the whole point.
+WIRING=$(awk '
+    {
+        stripped = $0
+        sub(/^[[:space:]]+/, "", stripped)
+        if (stripped ~ /^#/) {
+            sub(/^#[[:space:]]*/, "", stripped)
+            if (stripped ~ /^[A-Za-z0-9_\/.+-]+\.(cpp|c)$/) print stripped
+        } else {
+            print $0
+        }
+    }
+' "${CMAKELISTS}")
+
+EXIT_CODE=0
+FOUND_ANY=0
+
+for SOURCE_FILE in $(git ls-files -- "src/test/**.cpp"); do
+    FOUND_ANY=1
+    REL=${SOURCE_FILE#src/test/}
+    # Word-boundary match so foo_tests.cpp cannot be satisfied by bar_foo_tests.cpp.
+    if ! printf '%s\n' "${WIRING}" | grep -qE "(^|[^[:alnum:]_/.-])${REL//./\\.}([^[:alnum:]_]|$)"; then
+        echo "${SOURCE_FILE} is not wired into ${CMAKELISTS}, so it is never built or run."
+        echo "  Add it to the test_gridcoin sources, or comment the entry out to record that the omission is deliberate."
+        EXIT_CODE=1
+    fi
+done
+
+# Guard against the pathspec silently matching nothing (a wrong glob, or a
+# git version that treats the pattern differently) and the check passing on air.
+if [ "${FOUND_ANY}" -eq 0 ]; then
+    echo "lint-test-sources: found no sources under src/test/; the pathspec is wrong."
+    exit 1
+fi
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
Closes #3355.

`src/test/key_io_tests.cpp` is named by no CMakeLists, so today it is not compiled, not linked into
`test_gridcoin` and not run — while looking exactly like coverage to anyone reading it.

### Correcting the issue's premise

I wrote #3355, and its history is wrong in a way worth stating plainly, because the true story says
where the next one comes from.

The file was **not** a test nobody ever ran. `972a95d94` (2023-03-22) wired it into the autotools
build in the same patch that created it — an entry in `GRIDCOIN_TESTS` in
`src/Makefile.test.include` — and legacy CI built and ran `test_gridcoin` on every push. From the
merge of #2634 (`b07ab3f22`, 2024-10-06) until that CI was deactivated (`46e3822cf`, 2025-11-26) it
was live coverage.

What it never had was a CMake entry. CMake landed in `91a84ffd3` two months *before* the file, and
`src/test/CMakeLists.txt` already listed the sibling `key_tests.cpp` when the file arrived — but
`972a95d94` updated only `src/test/data/CMakeLists.txt`, for the JSON vectors, and never the source
list. So the file fell out of the build silently when autotools was removed (`291528e7f`,
2026-02-18).

This is **build-migration drift**, not neglect. The issue's other inference — that `cff5c14cc`
showed "someone maintained it believing it runs" — is also wrong: that commit is the same day as the
file, when it demonstrably did run, and its change was effective.

### Restore, not delete

The vectors are Gridcoin's, not Bitcoin's: `SE8hQ…` mainnet P2PKH, `bE9be…` mainnet P2SH, `m…`/`2…`
testnet, 48 valid and 50 invalid across both chains, with no bech32 and no `tryCaseFlip` entries —
which is what a base58 chain with no segwit should have. Someone regenerated that data deliberately.

Its generated headers were already wired (`key_io_valid.json` / `key_io_invalid.json` have been in
`JSON_TEST_FILES` all along), so only the `.cpp` was missing. Contrary to what the issue expected it
needed no repair: it compiles clean first time and its cases pass, 464 assertions. Clang
`-Wthread-safety` with `WERROR_THREAD_SAFETY=ON` is clean too, which matters because #3354 put the
test targets under that analysis.

### The one thing worth changing

The cases switch chain params per vector. Those are a process global that the module fixture selects
**once** — `TestingSetup` is a `BOOST_GLOBAL_FIXTURE`, not per-case — and this suite runs near the
head of the binary, so whatever it leaves selected is what nearly every later suite sees.

That is not hypothetical, and the tree does not protect itself: only six of the test sources select
on entry, and others read `Params()` ambiently. `cff5c14cc`, which added the trailing
`SelectParams(MAIN)` calls, says why in as many words:

> Sadly some other tests depends on the chain being mainnet without actually setting it to mainnet
> themselves. Which leads to weird test suite failures.

Those resets are skippable by any throw, and cover only the cases that exist. They are replaced by a
`ChainParamsRestorer` attached through `BOOST_FIXTURE_TEST_SUITE`, which Boost constructs and
destroys around every case including ones added later. The manual form was verified to have exactly
that hole: appending a chain-switching case *after* the invariant check leaves the check passing and
the chain on testnet, while the fixture form restores it. Two in-tree precedents for this shape:
`coinstake_construction_tests` and `mrc_tests`.

`key_io_leaves_chain_params_unchanged` is a direct regression test on the restorer. Neutering the
destructor makes it fail `test != main`, which also confirms the leak is real — `key_io_invalid`
ends its loop on testnet.

### Closing the class

`lint-test-sources.sh` requires every `.cpp` under `src/test/` to be wired into
`src/test/CMakeLists.txt`. Wiring is read loosely, because sources arrive by several routes — the
`add_executable` list, `target_sources()` in a conditional (`ipc_wire_handshake_tests.cpp`),
`set_property(SOURCE ...)` (`test_gridcoin.cpp`) — and a deliberate omission is recorded by
commenting the entry out (`compilerbug_tests.cpp`).

A filename mentioned in an *explanatory comment* is not wiring, and that distinction is not
academic. My first version accepted any occurrence, under which deleting the real entry for either
`ipc_wire_handshake_tests.cpp` or `alt_signal_stack.cpp` left the check green — each is named once
in wiring and once in prose. Adversarial review caught it.

Verified against constructed cases: flags exactly `key_io_tests.cpp` on the pre-fix tree and nothing
here; flags each of those two files when only their real wiring is deleted; still accepts the
commented-out entry; `lint-all.sh` picks it up and propagates the failure (confirmed by breaking the
tree deliberately, since a passing lint is silent); and it refuses rather than passes when run
outside a repository — `cd "$(git rev-parse --show-toplevel)"` is not sufficient there, because a
failed rev-parse gives `cd ""`, which succeeds, and the loop would run over no files and exit 0.

### Verification

Full Qt6 GUI + tests build clean, unit suite clean (465 assertions in this suite), Clang
thread-safety clean, lint clean over the commit range. Every mutation described above was run
against the built binary rather than reasoned about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4UiicZ9xa29naEX3CNqr
