### PR TITLE
ci: pin the Intel Homebrew installer to its last Intel-capable commit

### DIFF
--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -574,7 +574,20 @@ jobs:
         run: |
           # Install a separate x86_64 Homebrew at /usr/local (Intel prefix).
           # The ARM64 runner has Rosetta 2, so x86_64 binaries run transparently.
-          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" </dev/null
+          #
+          # PINNED, and deliberately not to HEAD. Homebrew removed Intel macOS
+          # support from the installer on 2026-09-11 (Homebrew/install#1140,
+          # merge fde1410a6). HEAD now aborts with "Homebrew on macOS is only
+          # supported on Apple Silicon processors!" whenever uname -m is not
+          # arm64 -- which is exactly what arch -x86_64 makes it -- and past
+          # that check it hardcodes HOMEBREW_PREFIX=/opt/homebrew, so there is
+          # no env-var escape hatch and no /usr/local branch left to reach.
+          # df3c25561 is the last commit that still installs the Intel prefix.
+          #
+          # This is a stopgap on a road upstream has closed: the bottle
+          # demotion the source-fallback script below exists for was the first
+          # step, and this is the second. Tracking issue: #3362.
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/df3c25561/install.sh)" </dev/null
           arch -x86_64 /usr/local/bin/brew update
           # shellcheck disable=SC2086
           BREW_ARCH="arch -x86_64" contrib/devtools/brew-install-with-source-fallback.sh \


### PR DESCRIPTION
Unblocks every PR. Not caused by anything on our side.

Homebrew removed Intel macOS support from its installer on 2026-09-11 ([Homebrew/install#1140](https://github.com/Homebrew/install/pull/1140), merge `fde1410a6`). `install.sh` at HEAD now aborts with

```
Homebrew on macOS is only supported on Apple Silicon processors!
```

whenever `uname -m` is not `arm64` — which is exactly what `arch -x86_64` makes it — and past that check it hardcodes `HOMEBREW_PREFIX="/opt/homebrew"`, so there is no env-var escape hatch and no `/usr/local` branch left to reach.

The job fetches `install.sh` from HEAD on every run, so it broke with no change on our side. The last `cmake_production.yml` run on `development` succeeded at 2026-09-10 21:26; the merge landed upstream the next day.

### The fix

Pin to `df3c25561`, the commit immediately before that merge. Verified by fetching both revisions:

- HEAD: `if [[ "${UNAME_MACHINE}" != "arm64" ]]` → `abort`, then `HOMEBREW_PREFIX="/opt/homebrew"`
- `df3c25561`: still carries `# On Intel macOS, this script installs to /usr/local only` → `HOMEBREW_PREFIX="/usr/local"`

### Stopgap, deliberately

A pinned URL is the whole fix and also the whole problem, so the comment in the workflow says so and **#3362** carries the decision.

This is the second step on a road upstream has closed. The first was the bottle demotion that `contrib/devtools/brew-install-with-source-fallback.sh` exists to absorb (#3342). A pinned installer does not stop `brew` itself, or the formulae, from dropping Intel next.

Whether Gridcoin keeps shipping a macOS Intel DMG — and if so whether it moves to the `depends` `x86_64-apple-darwin` target, which is documented in `depends/README.md` and `contrib/macdeploy/README.md` but has **no CI coverage**, was last touched 2025-12-06, and needs an Xcode SDK that cannot be redistributed — is a release decision, not one to take during an outage.

Lint clean over the commit range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv4UiicZ9xa29naEX3CNqr