### PR TITLE
test: detect and fix cross-suite process-state leaks in test_gridcoin

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(test_gridcoin
     dos_tests.cpp
     accounting_tests.cpp
     chain_setup.cpp
+    state_guard.cpp
     miner_block_assembly_tests.cpp
     addressbook_tests.cpp
     addrman_tests.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(test_gridcoin
     accounting_tests.cpp
     chain_setup.cpp
     state_guard.cpp
+    state_leak_detector.cpp
     miner_block_assembly_tests.cpp
     addressbook_tests.cpp
     addrman_tests.cpp

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -19,3 +19,87 @@ the current test cases.
 
 For further reading, [see Boost's documentation](https://www.boost.org/doc/libs/1_73_0/libs/test/doc/html/boost_test/intro.html)
 about how the boost unit test framework works
+
+## Process state, and what a suite must put back
+
+Every suite runs in one process on top of a single global fixture,
+`TestingSetup` in test_gridcoin.cpp, which builds the in-memory transaction
+database, the mock wallet, ECC and the (quiescent) net managers once for the
+whole binary. Nothing rebuilds them per suite: the LevelDB handle must never be
+closed, the wallet's Berkeley DB environment is bound to the one data
+directory, and the net managers assert they are created exactly once.
+
+The consequence is that anything a suite leaves in a process global is the
+next suite's input, and which suite is next is link order -- so a leak that is
+harmless on one CI leg is a failure on another (the Windows cross-compile leg
+links in a different order from the Linux legs, and has been the one to find
+them).
+
+### The leak detector
+
+`state_leak_detector.cpp`, installed from `TestingSetup`, checks the boundary.
+It attaches a fixture to every top-level suite that snapshots a fixed set of
+process globals at suite entry and compares at suite exit, and fails the run
+with one error per invariant that changed, naming the suite, the value before
+and after, and the first test case that changed it. The invariant set is
+`grc_test::StateSnapshot` in state_guard.h: the chain tip and the mapBlockIndex
+key set, the selected network, the consensus globals `LoadBlockIndex()`
+overwrites, mock time, `g_mock_deterministic_tests`, the mempool size, the
+miner status, `fUseFastIndex`, the ArgsManager settings, and the registry
+sizes that have a cheap accessor.
+
+Two rules of the comparison matter when reading a report:
+
+- Size-like fields (mempool, mapBlockIndex, registries, miner status) fail on
+  **growth only**. A suite that clears an earlier suite's residue is reported
+  as a cleaner in a note, not as a leaker; several fixtures clear on exit by
+  design.
+- The settings comparison is **presence-sensitive**. A key that is present
+  at its default value is a different state from an absent key: an empty
+  string parses as `true` for a boolean argument and as `0` for an integer
+  one, and `IsArgSet()` changes its answer. "Restoring" an argument by
+  writing a value back is therefore still a leak.
+
+`kKnownLeaks` in state_leak_detector.cpp downgrades a listed leak to a printed
+note. An entry is a tolerance for a leak that is tracked and not yet fixed,
+never a requirement: whether it fires depends on which suite ran first (two
+suites that exit with the same value are mutually exclusive) and on
+`--run_test` filters. Add one only with an issue reference, and remove it in
+the commit that fixes the leak at source. The table is empty at the time of
+writing.
+
+### Writing a suite that mutates globals
+
+Use `grc_test::StateGuard` (state_guard.h). It captures on construction and
+restores on destruction, and works as a suite decorator, a per-case fixture
+base, or a local:
+
+    BOOST_AUTO_TEST_SUITE(x_tests, *boost::unit_test::fixture<grc_test::StateGuard>())
+    BOOST_FIXTURE_TEST_SUITE(x_tests, grc_test::StateGuard)
+    { grc_test::StateGuard guard; ... }
+
+`CleanStateGuard` also moves mapBlockIndex aside, nulls the tip and clears
+the mempool on entry, which is what a suite needs before `LoadBlockIndex()`
+will create genesis. `MempoolStateGuard` clears only the mempool, on entry
+and exit. The registries are deliberately outside `StateGuard` because
+`Reset()` is destructive; use `RegistryResetFor<GRC::ContractType::...>` as a
+suite decorator, which resets on entry AND exit. `V15HeightGuard` pins
+`-blockv15height` for a scope and restores its presence exactly;
+`RequireV15Unscheduled()` is the precondition for tests that rely on V15
+rules being inert.
+
+What the guard deliberately does not restore, and why, is in the header
+comment of state_guard.h: the LevelDB handle, the wallet, the net managers,
+the registered-argument table `ClearArgs()` wipes, and the temporary data
+directory on disk.
+
+Two habits keep a new suite out of the detector's report:
+
+- Never `ForceSetArg(name, "")` to "unset" an argument. Use a guard, which
+  puts the whole settings map back.
+- A fixture that points `pindexBest` / `pindexGenesisBlock` at memory it
+  owns must restore the pointers as well as free the memory; a `StateGuard`
+  as the fixture's first member does both in the right order.
+
+A `--run_test=<suite>/<case>` filter still runs the suite's fixtures, so a
+single case can show a diff set that the whole suite would not.

--- a/src/test/addressbook_tests.cpp
+++ b/src/test/addressbook_tests.cpp
@@ -17,6 +17,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -51,7 +53,9 @@ bool ReloadEntry(const CTxDestination& dest, CAddressBookData& out)
 }
 } // namespace
 
-BOOST_AUTO_TEST_SUITE(addressbook_tests)
+// Suite-level guard: loading a wallet through CWalletDB can force -rescan,
+// which otherwise stays set for the rest of the process.
+BOOST_AUTO_TEST_SUITE(addressbook_tests, *boost::unit_test::fixture<grc_test::StateGuard>())
 
 // A default-constructed entry has an empty label and the "unknown" purpose. This is the
 // default that old wallets (which carry only "name" records) inherit on load.

--- a/src/test/coinstake_construction_tests.cpp
+++ b/src/test/coinstake_construction_tests.cpp
@@ -22,6 +22,7 @@
 #include <gridcoin/tally.h>
 #include <gridcoin/contract/contract.h>
 #include <rpc/blockchain.h>
+#include <test/state_guard.h>
 #include <test/test_gridcoin.h>
 #include <wallet/wallet.h>
 
@@ -30,6 +31,12 @@ namespace {
 // Reuses the fixture pattern from mrc_tests.cpp with additions for
 // coinstake construction testing (pindexBest, sidestake config, etc.)
 struct CoinstakeSetup {
+    // First member: restores the tip globals, mock time and every argument
+    // this fixture forces, after the members below are gone. The destructor
+    // used to write empty strings back and leave pindexGenesisBlock pointing
+    // at the index it had just freed.
+    grc_test::StateGuard guard;
+
     CBlockIndex* pindex{nullptr};
     GRC::Cpid cpid = GRC::Cpid(InsecureRandBytes(16));
     GRC::ResearchAccount& account = GRC::Tally::CreateAccount(cpid);
@@ -102,8 +109,6 @@ struct CoinstakeSetup {
 
     ~CoinstakeSetup()
     {
-        pindexBest = nullptr;
-
         GRC::GetBeaconRegistry().Reset();
         GRC::GetSideStakeRegistry().ResetInMemoryOnly();
 
@@ -111,14 +116,10 @@ struct CoinstakeSetup {
         gArgs.ForceSetArg("email", "noncruncher");
         GRC::Researcher::Reload();
         gArgs.ForceSetArg("email", "");
-        gArgs.ForceSetArg("-enablestakesplit", "");
-        gArgs.ForceSetArg("-enablesidestaking", "");
-        gArgs.ForceSetArg("-minstakesplitvalue", "");
-        gArgs.ForceSetArg("-stakingefficiency", "");
         GRC::Tally::RemoveAccount(cpid);
 
-        SetMockTime(0);
-
+        // The staking arguments, mock time and the tip pointers are restored
+        // by `guard` once this destructor has freed the mock chain.
         for (CBlockIndex* tip = pindex; tip->pprev; tip = tip->pprev) {
             mapBlockIndex.erase(tip->GetBlockHash());
             delete tip->phashBlock;
@@ -343,6 +344,12 @@ BOOST_AUTO_TEST_CASE(sidestake_outputs_placed)
         GRC::LocalSideStake::LocalSideStakeStatus::ACTIVE
     );
     GRC::GetSideStakeRegistry().NonContractAdd(sidestake, false);
+
+    // The registry only hands out local sidestakes while -enablesidestaking
+    // is on; the flag passed to SplitCoinStakeOutput below is not enough on
+    // its own. This used to pass anyway because the previous case's teardown
+    // forced -enablesidestaking to an empty string, which parses as true.
+    gArgs.ForceSetArg("-enablesidestaking", "1");
 
     CMutableTransaction coinstake = MakeCoinstake(10000 * COIN);
     CBlock block = MakeBlock();

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -6,6 +6,8 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 #include "wallet/wallet.h"
 #include "net.h"
 #include "util.h"
@@ -64,6 +66,8 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
 
 BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
+    grc_test::StateGuard guard; // -banscore back to absent, not to "100"
+
     CNodeStats nodestats;
     g_banman->ClearBanned();
     gArgs.ForceSetArg("-banscore", "111"); // because 11 is my favorite number
@@ -79,9 +83,6 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     BOOST_CHECK(nodestats.nMisbehavior == 110); // nMisbehavior should be 110.
     dummyNode1.Misbehaving(1);
     BOOST_CHECK(g_banman->IsBanned(addr1));
-
-    // TODO: Why no ClearArg?
-    gArgs.ForceSetArg("-banscore", "100");
 }
 
 BOOST_AUTO_TEST_CASE(DoS_ban_then_clear_lock_order)
@@ -145,6 +146,8 @@ BOOST_AUTO_TEST_CASE(DoS_ban_then_clear_lock_order)
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)
 {
+    grc_test::StateGuard guard; // mock time back to 0 on exit
+
     CNodeStats nodestats;
     g_banman->ClearBanned();
     int64_t nStartTime = GetTime();
@@ -167,6 +170,8 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
 BOOST_AUTO_TEST_CASE(DoS_misbehavior_decay)
 {
+    grc_test::StateGuard guard; // mock time back to 0 on exit
+
     CNodeStats nodestats;
     g_banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -2,9 +2,13 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 #include "util/system.h"
 
-BOOST_AUTO_TEST_SUITE(getarg_tests)
+// Suite-level guard: ResetArgs re-parses test arguments into the global
+// ArgsManager and never removes them.
+BOOST_AUTO_TEST_SUITE(getarg_tests, *boost::unit_test::fixture<grc_test::StateGuard>())
 
 static void AddArgs(const std::string& strArg)
 {

--- a/src/test/gridcoin/beacon_tests.cpp
+++ b/src/test/gridcoin/beacon_tests.cpp
@@ -12,6 +12,8 @@
 #include <util/string.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include "test/state_guard.h"
 #include <vector>
 
 extern leveldb::DB *txdb;
@@ -1000,7 +1002,12 @@ BOOST_AUTO_TEST_SUITE_END()
 // BeaconPayload
 // -----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE(BeaconPayload)
+// Suite-level guards: BeaconRegistryTest inserts every block of the fixture
+// file into mapBlockIndex and advances hashBestChain without ever erasing
+// or restoring them, and resets the beacon registry on entry only.
+BOOST_AUTO_TEST_SUITE(BeaconPayload,
+                      *boost::unit_test::fixture<grc_test::StateGuard>()
+                      * boost::unit_test::fixture<grc_test::RegistryResetFor<GRC::ContractType::BEACON>>())
 
 // BeaconRegistry methods (Reset, Add, ActivatePending, Delete, Try,
 // FindPending, FindHistorical, Deactivate) are EXCLUSIVE_LOCKS_REQUIRED(cs_main).

--- a/src/test/gridcoin/block_finder_tests.cpp
+++ b/src/test/gridcoin/block_finder_tests.cpp
@@ -7,6 +7,8 @@
 #include "primitives/block.h"
 
 #include <boost/test/unit_test.hpp>
+
+#include "test/state_guard.h"
 #include <array>
 #include <cstdint>
 
@@ -26,6 +28,12 @@ namespace
     class BlockChain
     {
     public:
+        // First member, so it captures the tip globals before the constructor
+        // points them at `blocks` and restores them after `blocks` is gone.
+        // Without it every case left pindexBest / pindexGenesisBlock /
+        // nBestHeight aimed at a dead stack frame.
+        grc_test::StateGuard guard;
+
         BlockChain()
         {
             // Initialize block link.

--- a/src/test/gridcoin/connectinputs_tests.cpp
+++ b/src/test/gridcoin/connectinputs_tests.cpp
@@ -21,6 +21,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 
 BOOST_AUTO_TEST_SUITE(connectinputs_tests)
 
@@ -186,11 +188,10 @@ BOOST_AUTO_TEST_CASE(script_flags_follow_the_height_a_transaction_lands_at)
 //!
 BOOST_AUTO_TEST_CASE(v15_script_flags_are_inert_until_v15_is_scheduled)
 {
-    const int v15 = GetBlockV15Height();
-
     // Unscheduled today. If this ever fails, v15 has been given a height and
     // the assertions below need revisiting rather than deleting.
-    BOOST_REQUIRE_EQUAL(v15, std::numeric_limits<int>::max());
+    grc_test::RequireV15Unscheduled();
+    const int v15 = GetBlockV15Height();
 
     for (const int h : {0, 1, 1000000, 3989999, 3990000, 4000000, 100000000}) {
         const unsigned int flags = GetBlockScriptFlags(h);
@@ -242,20 +243,10 @@ BOOST_AUTO_TEST_CASE(a_consensus_script_failure_scores_the_relayer)
 
     // Restored before leaving: three suites in this binary assert that v15 is
     // unscheduled, and pool_tests forces this same argument in the other
-    // direction. Leaving it set would make this file's own earlier cases order
-    // dependent.
-    struct V15HeightGuard {
-        const bool was_set{gArgs.IsArgSet("-blockv15height")};
-        const std::string previous{gArgs.GetArg("-blockv15height", "")};
-        ~V15HeightGuard()
-        {
-            if (was_set) {
-                gArgs.ForceSetArg("-blockv15height", previous);
-            } else {
-                gArgs.ForceSetArg("-blockv15height", strprintf("%d", std::numeric_limits<int>::max()));
-            }
-        }
-    } guard;
+    // direction. The guard puts the argument back exactly as it found it,
+    // presence included; writing the INT_MAX sentinel would leave the key
+    // present where it was absent.
+    grc_test::V15HeightGuard guard(std::numeric_limits<int>::max());
 
     CBlockIndex index;
     index.nHeight = nGrandfather + 1;
@@ -453,7 +444,7 @@ BOOST_AUTO_TEST_CASE(the_superblock_leaves_the_block_bound_only_under_v15_rules)
     LOCK(cs_main);
 
     // Inert until v15 is scheduled.
-    BOOST_REQUIRE_EQUAL(GetBlockV15Height(), std::numeric_limits<int>::max());
+    grc_test::RequireV15Unscheduled();
 
     // Over the block bound on its own, but inside its own bound.
     const GRC::Superblock superblock = SuperblockOfAtLeast(MAX_BLOCK_SIZE + 1);

--- a/src/test/gridcoin/mrc_tests.cpp
+++ b/src/test/gridcoin/mrc_tests.cpp
@@ -13,10 +13,17 @@
 #include <miner.h>
 #include <primitives/transaction.h>
 #include <rpc/blockchain.h>
+#include <test/state_guard.h>
 #include <test/test_gridcoin.h>
 
 namespace {
 struct Setup {
+    // First member: restores the tip globals, mock time and the arguments
+    // this fixture forces, after the members below are gone. The destructor
+    // used to leave pindexGenesisBlock pointing at the index it had just
+    // freed and to write empty strings where the arguments were absent.
+    grc_test::StateGuard guard;
+
     CBlockIndex* pindex{nullptr};
     GRC::Cpid cpid = GRC::Cpid(InsecureRandBytes(16));
     GRC::ResearchAccount& account = GRC::Tally::CreateAccount(cpid);
@@ -101,8 +108,8 @@ struct Setup {
         gArgs.ForceSetArg("email", "");
         GRC::Tally::RemoveAccount(cpid);
 
-        SetMockTime(0);
-
+        // Mock time and the tip pointers are restored by `guard` once this
+        // destructor has freed the mock chain.
         for (CBlockIndex* tip = pindex; tip->pprev; tip = tip->pprev) {
             mapBlockIndex.erase(tip->GetBlockHash());
             delete tip->phashBlock;

--- a/src/test/gridcoin/pool_tests.cpp
+++ b/src/test/gridcoin/pool_tests.cpp
@@ -19,6 +19,8 @@
 #include <set>
 #include <vector>
 
+#include "test/state_guard.h"
+
 extern GRC::MiningPools g_mining_pools;
 
 namespace {
@@ -92,15 +94,13 @@ struct PoolLifecycleFixture
     PoolLifecycleFixture()  { Restore(); }
     ~PoolLifecycleFixture() { Restore(); }
 
-    // Leave the registry booted-clean and V15 inert (some tests force
-    // -blockv15height=0 to exercise the validation gate; reset it so the
-    // override never leaks into another case via the global gArgs).
+    // Leave the registry booted-clean. The cases that force
+    // -blockv15height=0 to exercise the validation gate hold a
+    // grc_test::V15HeightGuard, which puts the argument back exactly as it
+    // found it -- absent, normally. Writing the INT_MAX sentinel here instead
+    // left the key present for every later suite.
     static void Restore()
     {
-        // "2147483647" == INT_MAX, the same V15-inert sentinel the chainparams
-        // default uses. A string literal avoids the locale-dependent
-        // integer-to-string conversion flagged by lint-locale-dependence.sh.
-        gArgs.ForceSetArg("-blockv15height", "2147483647");
         LOCK(cs_main);
         GRC::GetPoolRegistry().Reset();
     }
@@ -1020,7 +1020,7 @@ BOOST_FIXTURE_TEST_CASE(pool_contract_rejected_while_v15_inert, PoolLifecycleFix
     // The same contract against the same registry state, with V15 active, is
     // accepted. Without this half the rejection above would pass just as well
     // for a malformed payload or a bad signature, and would pin nothing.
-    gArgs.ForceSetArg("-blockv15height", "0");
+    grc_test::V15HeightGuard v15(0);
     int dos_active = 0;
     BOOST_CHECK(GRC::BlockValidateContracts(&pindex, tx, dos_active));
 }
@@ -1036,7 +1036,7 @@ BOOST_FIXTURE_TEST_CASE(takeover_register_rejected_operator_register_accepted, P
     // the verifier. BlockValidateContracts is used (not ValidateContracts) so
     // the activation height comes from the block index we control rather than
     // the global nBestHeight, which is unset under the test harness.
-    gArgs.ForceSetArg("-blockv15height", "0"); // V15 active at every height >= 0
+    grc_test::V15HeightGuard v15(0); // V15 active at every height >= 0
 
     LOCK(cs_main);
     GRC::PoolRegistry& registry = GRC::GetPoolRegistry();
@@ -1153,7 +1153,7 @@ BOOST_FIXTURE_TEST_CASE(captured_register_add_replayed_as_remove_rejected, PoolL
     // because the signature is bound to the action; and a correctly REMOVE-signed
     // withdrawal by the same operator must be accepted (the path the new
     // withdrawpool RPC drives).
-    gArgs.ForceSetArg("-blockv15height", "0"); // V15 active at every height >= 0
+    grc_test::V15HeightGuard v15(0); // V15 active at every height >= 0
 
     LOCK(cs_main);
     GRC::PoolRegistry& registry = GRC::GetPoolRegistry();
@@ -1214,7 +1214,7 @@ BOOST_FIXTURE_TEST_CASE(builtin_path2_claim_requires_matching_open_authorization
     // VerifyRegisterAuth Path 2) — the sticky takeover defense that governs who
     // may claim the 5 builtin grcpool CPIDs (real magnitude / AVW). The existing
     // takeover test uses a NON-builtin CPID and so never exercises Path 2.
-    gArgs.ForceSetArg("-blockv15height", "0"); // V15 active at every height >= 0
+    grc_test::V15HeightGuard v15(0); // V15 active at every height >= 0
 
     LOCK(cs_main);
     GRC::PoolRegistry& registry = GRC::GetPoolRegistry();
@@ -1309,7 +1309,7 @@ BOOST_FIXTURE_TEST_CASE(expired_pending_nonbuiltin_superseded_by_fresh_key, Pool
     // PENDING stays protected by takeover defense. Exercise that documented
     // consensus consequence through BlockValidateContracts, not just the
     // IsPendingExpired predicate in isolation.
-    gArgs.ForceSetArg("-blockv15height", "0");
+    grc_test::V15HeightGuard v15(0);
 
     LOCK(cs_main);
     GRC::PoolRegistry& registry = GRC::GetPoolRegistry();

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -13,6 +13,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 // Tests are single-threaded and drive the Whitelist contract handler
 // directly (not via ApplyContracts). The handler is
 // EXCLUSIVE_LOCKS_REQUIRED(cs_main) under the thread-safety annotation
@@ -563,7 +565,9 @@ BOOST_AUTO_TEST_SUITE_END()
 // Whitelist
 // -----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE(Whitelist)
+// Suite-level guard: DeepCopyHeightGuard below writes
+// -autogreylistdeepcopyheight on exit where it was absent on entry.
+BOOST_AUTO_TEST_SUITE(Whitelist, *boost::unit_test::fixture<grc_test::StateGuard>())
 
 BOOST_AUTO_TEST_CASE(it_adds_whitelisted_projects_from_contract_data)
 {

--- a/src/test/gridcoin/protocol_tests.cpp
+++ b/src/test/gridcoin/protocol_tests.cpp
@@ -7,6 +7,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 // Tests are single-threaded and drive the ProtocolRegistry contract
 // handler directly. The handler is EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 // suppress the analyzer for this file rather than take a lock the
@@ -96,7 +98,8 @@ void DeleteProtocolEntry(const uint32_t& payload_version, const std::string& key
 
 } // anonymous namespace
 
-BOOST_AUTO_TEST_SUITE(protocol_tests)
+// Symmetric reset: the cases reset the registry on entry only.
+BOOST_AUTO_TEST_SUITE(protocol_tests, *boost::unit_test::fixture<grc_test::RegistryResetFor<GRC::ContractType::PROTOCOL>>())
 
 // Note for these tests we are going to mix payload version 1 and 2 entries to make
 // sure they act equivalently.

--- a/src/test/gridcoin/researcher_tests.cpp
+++ b/src/test/gridcoin/researcher_tests.cpp
@@ -746,7 +746,9 @@ BOOST_AUTO_TEST_SUITE_END()
 
 // Suite-level guard: cases force email / forcecpid / noncruncher /
 // pooloperator and restore them by hand to values, not to absent.
-BOOST_AUTO_TEST_SUITE(Researcher, *boost::unit_test::fixture<grc_test::StateGuard>())
+BOOST_AUTO_TEST_SUITE(Researcher,
+                      *boost::unit_test::fixture<grc_test::StateGuard>()
+                      * boost::unit_test::fixture<grc_test::RegistryResetFor<GRC::ContractType::PROTOCOL>>())
 
 // Researcher::Reload/Refresh are EXCLUSIVE_LOCKS_REQUIRED(cs_main). Tests
 // invoke them directly on the single-threaded test fixture without acquiring

--- a/src/test/gridcoin/researcher_tests.cpp
+++ b/src/test/gridcoin/researcher_tests.cpp
@@ -12,6 +12,8 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/test/unit_test.hpp>
+
+#include "test/state_guard.h"
 #include <iostream>
 #include <vector>
 
@@ -216,7 +218,9 @@ void AddProtocolEntry(const uint32_t& payload_version, const std::string& key, c
 // MiningProject
 // -----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE(MiningProject)
+// Suite-level guard: cases force email / forcecpid / noncruncher /
+// pooloperator and restore them by hand to values, not to absent.
+BOOST_AUTO_TEST_SUITE(MiningProject, *boost::unit_test::fixture<grc_test::StateGuard>())
 
 BOOST_AUTO_TEST_CASE(it_initializes_with_project_data)
 {
@@ -449,7 +453,9 @@ BOOST_AUTO_TEST_SUITE_END()
 // MiningProjectMap
 // -----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE(MiningProjectMap)
+// Suite-level guard: cases force email / forcecpid / noncruncher /
+// pooloperator and restore them by hand to values, not to absent.
+BOOST_AUTO_TEST_SUITE(MiningProjectMap, *boost::unit_test::fixture<grc_test::StateGuard>())
 
 BOOST_AUTO_TEST_CASE(it_initializes_to_an_empty_collection)
 {
@@ -738,7 +744,9 @@ BOOST_AUTO_TEST_SUITE_END()
 // Researcher
 // -----------------------------------------------------------------------------
 
-BOOST_AUTO_TEST_SUITE(Researcher)
+// Suite-level guard: cases force email / forcecpid / noncruncher /
+// pooloperator and restore them by hand to values, not to absent.
+BOOST_AUTO_TEST_SUITE(Researcher, *boost::unit_test::fixture<grc_test::StateGuard>())
 
 // Researcher::Reload/Refresh are EXCLUSIVE_LOCKS_REQUIRED(cs_main). Tests
 // invoke them directly on the single-threaded test fixture without acquiring

--- a/src/test/gridcoin/scraper_registry_tests.cpp
+++ b/src/test/gridcoin/scraper_registry_tests.cpp
@@ -7,6 +7,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 // Tests are single-threaded and drive the ScraperRegistry contract
 // handler directly. The handler is EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 // suppress the analyzer for this file rather than take a lock the
@@ -94,7 +96,8 @@ void AddRemoveScraperEntryV2(const std::string& address, const GRC::ScraperEntry
 
 }// anonymous namespace
 
-BOOST_AUTO_TEST_SUITE(scraper_registry_tests)
+// Symmetric reset: the cases reset the registry on entry only.
+BOOST_AUTO_TEST_SUITE(scraper_registry_tests, *boost::unit_test::fixture<grc_test::RegistryResetFor<GRC::ContractType::SCRAPER>>())
 
 BOOST_AUTO_TEST_CASE(scraper_entries_added_to_scraper_work_correctly_legacy)
 {

--- a/src/test/gridcoin/sidestake_tests.cpp
+++ b/src/test/gridcoin/sidestake_tests.cpp
@@ -4,12 +4,16 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 #include <util.h>
 #include <gridcoin/sidestake.h>
 #include <interfaces/sidestake.h>
 #include <key_io.h>
 
-BOOST_AUTO_TEST_SUITE(sidestake_tests)
+// Suite-level guard: the sidestake editors write read-write settings
+// (sidestakeaddresses / allocations / descriptions) that nothing removes.
+BOOST_AUTO_TEST_SUITE(sidestake_tests, *boost::unit_test::fixture<grc_test::StateGuard>())
 
 BOOST_AUTO_TEST_CASE(sidestake_Allocation_Initialization_trivial)
 {

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -16,6 +16,8 @@
 #include <array>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/test/unit_test.hpp>
+
+#include "test/state_guard.h"
 #include <iostream>
 #include <vector>
 
@@ -769,6 +771,10 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence)
 #endif
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
 {
+    // Restores the tip globals on exit: the deletes at the end of this case
+    // free the indexes but left the pointers behind for later suites.
+    grc_test::StateGuard guard;
+
     // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
     // cannot have a pindex with random data.
     pindexBest = new CBlockIndex;
@@ -926,6 +932,10 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergen
 #endif
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence_v3)
 {
+    // Restores the tip globals on exit: the deletes at the end of this case
+    // free the indexes but left the pointers behind for later suites.
+    grc_test::StateGuard guard;
+
     // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
     // cannot have a pindex with random data.
     pindexBest = new CBlockIndex;

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -9,6 +9,8 @@
 #include "gridcoin/staking/reward.h"
 
 #include <boost/test/unit_test.hpp>
+
+#include "test/state_guard.h"
 #include <boost/algorithm/hex.hpp>
 #include <map>
 #include <string>
@@ -105,7 +107,10 @@ BOOST_AUTO_TEST_SUITE_END()
 #pragma clang diagnostic ignored "-Wthread-safety-analysis"
 #endif
 
-BOOST_AUTO_TEST_SUITE(gridcoin_cbr_tests)
+// Symmetric reset: the cases reset the protocol registry on entry only, and
+// the ACTIVE blockreward1 entry the last case leaves behind changes the
+// reward every later suite that mines a block is paid.
+BOOST_AUTO_TEST_SUITE(gridcoin_cbr_tests, *boost::unit_test::fixture<grc_test::RegistryResetFor<GRC::ContractType::PROTOCOL>>())
 
 BOOST_AUTO_TEST_CASE(gridcoin_DefaultCBRShouldBe10PreV13)
 {

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -21,17 +21,6 @@ namespace {
 // Arbitrary random characters generated with Python UUID.
 const std::string TEST_CPID("17c65330c0924259b2f93c31d25b03ac");
 
-struct GridcoinTestsConfig
-{
-    GridcoinTestsConfig()
-    {
-    }
-
-    ~GridcoinTestsConfig()
-    {
-    }
-};
-
 void AddProtocolEntry(const uint32_t& payload_version, const std::string& key, const std::string& value,
                       const CBlockIndex index, const bool& reset_registry = false) NO_THREAD_SAFETY_ANALYSIS
 {
@@ -69,8 +58,6 @@ void AddProtocolEntry(const uint32_t& payload_version, const std::string& key, c
 
 } // anonymous namespace
 
-BOOST_GLOBAL_FIXTURE(GridcoinTestsConfig);
-
 BOOST_AUTO_TEST_SUITE(gridcoin_tests)
 
 BOOST_AUTO_TEST_CASE(gridcoin_V8ShouldBeEnabledOnBlock1010000InProduction)
@@ -83,13 +70,16 @@ BOOST_AUTO_TEST_CASE(gridcoin_V8ShouldBeEnabledOnBlock1010000InProduction)
 
 BOOST_AUTO_TEST_CASE(gridcoin_V8ShouldBeEnabledOnBlock312000InTestnet)
 {
+    // Puts the network back even if a check below throws; the trailing
+    // SelectParams(MAIN) this replaces only ran on the happy path.
+    grc_test::StateGuard guard;
+
     SelectParams(CBaseChainParams::TESTNET);
     // With testnet block 312000 was created as the first V8 block,
     // hence the difference in testing setup compared to the production
     // tests.
     BOOST_CHECK(IsV8Enabled(311999) == false);
     BOOST_CHECK(IsV8Enabled(312000) == true);
-    SelectParams(CBaseChainParams::MAIN);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/psgt_pool_tests.cpp
+++ b/src/test/psgt_pool_tests.cpp
@@ -4,6 +4,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 #include <key.h>
 #include <keystore.h>
 #include <node/psgt_pool.h>
@@ -20,7 +22,10 @@
 
 using namespace psgt_test;
 
-BOOST_AUTO_TEST_SUITE(psgt_pool_tests)
+// Suite-level guard: the pool is cleared on entry and on exit. The cases
+// clear it on entry themselves; orphan_held_then_promoted_when_funding_arrives
+// ends with its funding transaction still in the pool.
+BOOST_AUTO_TEST_SUITE(psgt_pool_tests, *boost::unit_test::fixture<grc_test::MempoolStateGuard>())
 
 //! Register a transaction with the global mempool so the pool's funding-output
 //! check (chain-or-mempool existence, mapNextTx spentness) can see it. The

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -8,6 +8,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 #include <algorithm>
 #include <random>
 
@@ -22,6 +24,11 @@ BOOST_AUTO_TEST_CASE(osrandom_tests)
 
 BOOST_AUTO_TEST_CASE(fastrandom_tests)
 {
+    // The global fixture runs the whole binary with deterministic GetRand();
+    // the second half of this case turns that off to prove nondeterminism and
+    // used to leave it off for every suite that ran afterwards.
+    grc_test::StateGuard guard;
+
     // Check that deterministic FastRandomContexts are deterministic
     g_mock_deterministic_tests = true;
     FastRandomContext ctx1(true);

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -11,6 +11,8 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 #include <wallet/wallet.h>
 
 #include <test/data/script_valid.json.h>
@@ -630,11 +632,11 @@ BOOST_AUTO_TEST_CASE(script_FindAndDelete)
 // in-memory set with no other ceiling, so the clamp is the whole point.
 BOOST_AUTO_TEST_CASE(maxsigcachesize_is_resolved_and_clamped)
 {
-    // Capture whether it was set at all. Restoring "" would leave the arg SET to
-    // an empty string, which GetArg(name, int64_t) parses as 0 -- i.e. the cache
-    // disabled for the rest of this test binary.
-    const bool had_arg = gArgs.IsArgSet("-maxsigcachesize");
-    const std::string saved = had_arg ? gArgs.GetArg("-maxsigcachesize", "") : std::string();
+    // Restores -maxsigcachesize exactly as found, absent included. Restoring
+    // "" would leave the arg SET to an empty string, which GetArg(name,
+    // int64_t) parses as 0 -- i.e. the cache disabled for the rest of this
+    // test binary -- and restoring the documented default leaves a key behind.
+    grc_test::StateGuard guard;
 
     // A sane operator value passes through untouched.
     gArgs.ForceSetArg("-maxsigcachesize", "120000");
@@ -664,14 +666,6 @@ BOOST_AUTO_TEST_CASE(maxsigcachesize_is_resolved_and_clamped)
     // The default has to sit under the ceiling, or the clamp would silently
     // override the documented default for every node.
     BOOST_CHECK(DEFAULT_MAX_SIG_CACHE_SIZE < MAX_SIG_CACHE_ENTRIES);
-
-    if (had_arg) {
-        gArgs.ForceSetArg("-maxsigcachesize", saved);
-    } else {
-        // No clear-arg API; restore the documented default explicitly rather
-        // than leaving the arg set to an empty string.
-        gArgs.ForceSetArg("-maxsigcachesize", ToString(DEFAULT_MAX_SIG_CACHE_SIZE));
-    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/state_guard.cpp
+++ b/src/test/state_guard.cpp
@@ -1,0 +1,323 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "test/state_guard.h"
+
+#include "chainparams.h"
+#include "gridcoin/beacon.h"
+#include "gridcoin/contract/registry.h"
+#include "gridcoin/protocol.h"
+#include "gridcoin/scraper/scraper_registry.h"
+#include "gridcoin/staking/kernel.h"
+#include "gridcoin/staking/status.h"
+#include "net.h"
+#include "primitives/block.h"
+#include "sync.h"
+#include "tinyformat.h"
+#include "txmempool.h"
+#include "util/system.h"
+#include "util/time.h"
+#include "validation.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <limits>
+
+extern bool g_mock_deterministic_tests;
+
+namespace grc_test {
+
+namespace {
+
+//! The forced-setting key ForceSetArg("-blockv15height", ...) writes: the
+//! ArgsManager strips the leading dash before storing.
+const std::string V15_SETTING_KEY = "blockv15height";
+
+std::string Ptr(const void* p)
+{
+    return p ? strprintf("%p", p) : "null";
+}
+
+void SerializeSettings(const util::Settings& s, std::map<std::string, std::string>& out)
+{
+    for (const auto& [name, value] : s.forced_settings) {
+        out["forced:" + name] = value.write();
+    }
+    for (const auto& [name, values] : s.command_line_options) {
+        std::string joined;
+        for (const auto& v : values) joined += v.write() + ";";
+        out["cmdline:" + name] = joined;
+    }
+    for (const auto& [name, value] : s.rw_settings) {
+        out["rw:" + name] = value.write();
+    }
+}
+
+template <typename T>
+void Plain(std::vector<StateDiff>& out, const char* name, const T& before, const T& after)
+{
+    if (before == after) return;
+    out.push_back({name, strprintf("%s", before), strprintf("%s", after), /*monotone=*/false, /*growth=*/false});
+}
+
+void Monotone(std::vector<StateDiff>& out, const char* name, size_t before, size_t after)
+{
+    if (before == after) return;
+    out.push_back({name, strprintf("%u", before), strprintf("%u", after), /*monotone=*/true, after > before});
+}
+
+} // anonymous namespace
+
+StateSnapshot CaptureState(CaptureScope scope)
+{
+    StateSnapshot s;
+
+    gArgs.LockSettings([&](util::Settings& settings) { SerializeSettings(settings, s.settings); });
+
+    s.network_id = Params().NetworkIDString();
+    s.block_v15_height = GetBlockV15Height();
+    s.stake_min_age = nStakeMinAge;
+    s.coinbase_maturity = nCoinbaseMaturity;
+    s.grandfather = nGrandfather;
+    s.max_outbound = MAX_OUTBOUND_CONNECTIONS;
+
+    s.previous_block_time = g_previous_block_time.load();
+    s.mock_time = GetMockTime().count();
+    s.mock_deterministic = g_mock_deterministic_tests;
+
+    s.mempool_size = mempool.size();
+    s.staking_active = g_miner_status.StakingActive();
+    s.use_fast_index = fUseFastIndex;
+
+    LOCK(cs_main);
+
+    s.pindex_best = pindexBest;
+    s.pindex_genesis = pindexGenesisBlock;
+    s.hash_best_chain = hashBestChain;
+    s.n_best_height = nBestHeight;
+    s.map_block_index_size = mapBlockIndex.size();
+
+    if (scope == CaptureScope::SUITE) {
+        s.has_block_index_keys = true;
+        s.map_block_index_keys.reserve(mapBlockIndex.size());
+        for (const auto& entry : mapBlockIndex) s.map_block_index_keys.insert(entry.first);
+
+        // Only the registries with a cheap accessor. The whitelist, sidestake
+        // and pool registries expose no size without a filtered copy; they are
+        // covered by RegistryReset where a suite touches them.
+        s.has_registry_sizes = true;
+        s.beacon_count = GRC::GetBeaconRegistry().Beacons().size();
+        s.protocol_entry_count = GRC::GetProtocolRegistry().ProtocolEntries().size();
+        s.scraper_count = GRC::GetScraperRegistry().Scrapers().size();
+    }
+
+    return s;
+}
+
+std::vector<StateDiff> DiffState(const StateSnapshot& before, const StateSnapshot& after)
+{
+    std::vector<StateDiff> out;
+
+    Plain(out, "pindexBest", Ptr(before.pindex_best), Ptr(after.pindex_best));
+    Plain(out, "pindexGenesisBlock", Ptr(before.pindex_genesis), Ptr(after.pindex_genesis));
+    Plain(out, "hashBestChain", before.hash_best_chain.ToString(), after.hash_best_chain.ToString());
+    Plain(out, "nBestHeight", before.n_best_height, after.n_best_height);
+
+    if (before.has_block_index_keys && after.has_block_index_keys) {
+        size_t added = 0;
+        for (const auto& key : after.map_block_index_keys) {
+            if (!before.map_block_index_keys.count(key)) ++added;
+        }
+        size_t removed = 0;
+        for (const auto& key : before.map_block_index_keys) {
+            if (!after.map_block_index_keys.count(key)) ++removed;
+        }
+        if (added || removed) {
+            out.push_back({"mapBlockIndex",
+                           strprintf("%u entries", before.map_block_index_keys.size()),
+                           strprintf("%u entries (+%u -%u)", after.map_block_index_keys.size(), added, removed),
+                           /*monotone=*/true, added > 0});
+        }
+    } else {
+        Monotone(out, "mapBlockIndex", before.map_block_index_size, after.map_block_index_size);
+    }
+
+    Plain(out, "Params().NetworkIDString()", before.network_id, after.network_id);
+    Plain(out, "GetBlockV15Height()", before.block_v15_height, after.block_v15_height);
+    Plain(out, "nStakeMinAge", before.stake_min_age, after.stake_min_age);
+    Plain(out, "nCoinbaseMaturity", before.coinbase_maturity, after.coinbase_maturity);
+    Plain(out, "nGrandfather", before.grandfather, after.grandfather);
+    Plain(out, "MAX_OUTBOUND_CONNECTIONS", before.max_outbound, after.max_outbound);
+
+    Plain(out, "g_previous_block_time", before.previous_block_time, after.previous_block_time);
+    Plain(out, "GetMockTime()", before.mock_time, after.mock_time);
+    Plain(out, "g_mock_deterministic_tests", before.mock_deterministic, after.mock_deterministic);
+
+    Monotone(out, "mempool.size()", before.mempool_size, after.mempool_size);
+    Monotone(out, "g_miner_status.StakingActive()", before.staking_active ? 1 : 0, after.staking_active ? 1 : 0);
+    Plain(out, "fUseFastIndex", before.use_fast_index, after.use_fast_index);
+
+    // Settings: one diff per key, so the report names the argument.
+    for (const auto& [key, value] : after.settings) {
+        auto it = before.settings.find(key);
+        if (it == before.settings.end()) {
+            out.push_back({"settings[" + key + "]", "(absent)", value, false, false});
+        } else if (it->second != value) {
+            out.push_back({"settings[" + key + "]", it->second, value, false, false});
+        }
+    }
+    for (const auto& [key, value] : before.settings) {
+        if (!after.settings.count(key)) {
+            out.push_back({"settings[" + key + "]", value, "(absent)", false, false});
+        }
+    }
+
+    if (before.has_registry_sizes && after.has_registry_sizes) {
+        Monotone(out, "GetBeaconRegistry().Beacons().size()", before.beacon_count, after.beacon_count);
+        Monotone(out, "GetProtocolRegistry().ProtocolEntries().size()", before.protocol_entry_count, after.protocol_entry_count);
+        Monotone(out, "GetScraperRegistry().Scrapers().size()", before.scraper_count, after.scraper_count);
+    }
+
+    return out;
+}
+
+StateGuard::StateGuard(unsigned reset)
+    : m_reset(reset)
+    , m_network_id(Params().NetworkIDString())
+    , m_stake_min_age(nStakeMinAge)
+    , m_coinbase_maturity(nCoinbaseMaturity)
+    , m_grandfather(nGrandfather)
+    , m_max_outbound(MAX_OUTBOUND_CONNECTIONS)
+    , m_mock_time(GetMockTime().count())
+    , m_mock_deterministic(g_mock_deterministic_tests)
+    , m_use_fast_index(fUseFastIndex)
+{
+    gArgs.LockSettings([&](util::Settings& settings) { m_settings = settings; });
+
+    {
+        LOCK(cs_main);
+
+        m_pindex_best = pindexBest;
+        m_pindex_genesis = pindexGenesisBlock;
+        m_hash_best_chain = hashBestChain;
+        m_n_best_height = nBestHeight;
+        m_previous_block_time = g_previous_block_time.load();
+
+        if (m_reset & CHAIN) {
+            // Moved, not copied: each CBlockIndex::phashBlock aliases its map key.
+            m_moved_index = std::move(mapBlockIndex);
+            mapBlockIndex.clear();
+
+            pindexBest = nullptr;
+            pindexGenesisBlock = nullptr;
+            hashBestChain = uint256();
+            nBestHeight = -1;
+        } else {
+            m_preexisting_keys.reserve(mapBlockIndex.size());
+            for (const auto& entry : mapBlockIndex) m_preexisting_keys.insert(entry.first);
+        }
+    }
+
+    if (m_reset & MEMPOOL) mempool.clear();
+}
+
+StateGuard::~StateGuard()
+{
+    if (m_reset & MEMPOOL) mempool.clear();
+
+    {
+        LOCK(cs_main);
+
+        if (m_reset & CHAIN) {
+            mapBlockIndex.clear();
+            mapBlockIndex = std::move(m_moved_index);
+        } else {
+            for (auto it = mapBlockIndex.begin(); it != mapBlockIndex.end();) {
+                if (m_preexisting_keys.count(it->first)) {
+                    ++it;
+                } else {
+                    it = mapBlockIndex.erase(it);
+                }
+            }
+        }
+
+        pindexBest = m_pindex_best;
+        pindexGenesisBlock = m_pindex_genesis;
+        hashBestChain = m_hash_best_chain;
+        nBestHeight = m_n_best_height;
+        g_previous_block_time.store(m_previous_block_time);
+    }
+
+    fUseFastIndex = m_use_fast_index;
+    g_mock_deterministic_tests = m_mock_deterministic;
+    SetMockTime(m_mock_time);
+
+    nStakeMinAge = m_stake_min_age;
+    nCoinbaseMaturity = m_coinbase_maturity;
+    nGrandfather = m_grandfather;
+    MAX_OUTBOUND_CONNECTIONS = m_max_outbound;
+
+    // Settings before params: the datadir is network-specific and the path
+    // cache must be dropped after both change.
+    gArgs.LockSettings([&](util::Settings& settings) { settings = m_settings; });
+    gArgs.ClearPathCache();
+    SelectParams(m_network_id);
+    gArgs.ClearPathCache();
+}
+
+RegistryReset::RegistryReset(std::initializer_list<GRC::ContractType> types)
+    : m_types(types)
+{
+    Apply();
+}
+
+RegistryReset::~RegistryReset()
+{
+    Apply();
+}
+
+void RegistryReset::Apply() const
+{
+    LOCK(cs_main);
+
+    for (const auto type : m_types) {
+        GRC::RegistryBookmarks::GetRegistryWithDB(type).Reset();
+    }
+}
+
+V15HeightGuard::V15HeightGuard(int height)
+{
+    gArgs.LockSettings([&](util::Settings& settings) {
+        auto it = settings.forced_settings.find(V15_SETTING_KEY);
+        if (it != settings.forced_settings.end()) m_saved = it->second;
+    });
+
+    gArgs.ForceSetArg("-blockv15height", strprintf("%d", height));
+}
+
+V15HeightGuard::~V15HeightGuard()
+{
+    gArgs.LockSettings([&](util::Settings& settings) {
+        if (m_saved) {
+            settings.forced_settings[V15_SETTING_KEY] = *m_saved;
+        } else {
+            settings.forced_settings.erase(V15_SETTING_KEY);
+        }
+    });
+}
+
+void RequireV15Unscheduled()
+{
+    const int v15 = GetBlockV15Height();
+
+    BOOST_REQUIRE_MESSAGE(v15 == std::numeric_limits<int>::max(),
+                          strprintf("V15 rules must be inert for this test, but GetBlockV15Height() is %d "
+                                    "(-blockv15height %s)",
+                                    v15,
+                                    gArgs.IsArgSet("-blockv15height")
+                                        ? "= " + gArgs.GetArg("-blockv15height", "")
+                                        : "unset; chainparams pinned it"));
+}
+
+} // namespace grc_test

--- a/src/test/state_guard.h
+++ b/src/test/state_guard.h
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_TEST_STATE_GUARD_H
+#define GRIDCOIN_TEST_STATE_GUARD_H
+
+#include "chain.h"
+#include "gridcoin/contract/payload.h"
+#include "uint256.h"
+#include "util/settings.h"
+
+#include <univalue.h>
+
+#include <cstdint>
+#include <initializer_list>
+#include <map>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+//!
+//! Process-state isolation helpers for the unit-test binary.
+//!
+//! test_gridcoin runs every suite in one process on top of a single global
+//! TestingSetup (test_gridcoin.cpp). Anything a suite leaves behind in a
+//! process global is therefore visible to every suite that runs after it, and
+//! WHICH suites run after it is link order -- so a leak that is harmless on one
+//! CI leg is a failure on another. Three helpers address that:
+//!
+//!  - StateSnapshot / CaptureState / DiffState: the invariant set the leak
+//!    detector (state_leak_detector.cpp) checks at every suite boundary.
+//!  - StateGuard: an RAII restorer for the same globals, usable as a suite
+//!    decorator, a per-case fixture base, or a local.
+//!  - RegistryReset and V15HeightGuard: the two mutations the guard deliberately
+//!    does not cover, as opt-ins.
+//!
+//! WHAT IS DELIBERATELY NOT RESTORED. The LevelDB memenv behind txdb is opened
+//! once with error_if_exists and every CTxDB adopts the handle, so it must never
+//! be closed; pwalletMain's Berkeley DB environment is bound to the one
+//! -datadir; bitdb, g_banman, g_connman and g_peerman are created exactly once
+//! (the fixture asserts they are null first). None of those can be rebuilt per
+//! suite without moving them out of process globals, which is a separate
+//! effort. The registries are excluded because Reset() is destructive and some
+//! suites need it on entry only (see RegistryReset). ArgsManager::ClearArgs()
+//! wipes only the registered-argument table, which is outside the snapshot.
+//! The temporary datadir is left on disk: it is under the system temp
+//! directory with a random name, and creating or removing directories through
+//! GetDataDir() is not portable to the Windows cross-compile leg (Wine).
+//!
+
+namespace grc_test {
+
+//!
+//! \brief The process globals the leak detector compares across a suite.
+//!
+//! Case scope captures only the cheap scalars; suite scope also records the
+//! mapBlockIndex key set and the registry sizes, whose accessors copy.
+//!
+struct StateSnapshot
+{
+    const CBlockIndex* pindex_best{nullptr};
+    const CBlockIndex* pindex_genesis{nullptr};
+    uint256 hash_best_chain;
+    int n_best_height{0};
+    size_t map_block_index_size{0};
+    bool has_block_index_keys{false};
+    std::unordered_set<uint256, BlockHasher> map_block_index_keys;
+
+    std::string network_id;
+    int block_v15_height{0};
+    unsigned int stake_min_age{0};
+    int coinbase_maturity{0};
+    int grandfather{0};
+    int max_outbound{0};
+
+    int64_t previous_block_time{0};
+    int64_t mock_time{0};
+    bool mock_deterministic{false};
+
+    unsigned long mempool_size{0};
+    bool staking_active{false};
+    bool use_fast_index{false};
+
+    //! "<map>:<name>" -> serialized value, over forced_settings,
+    //! command_line_options and rw_settings. Presence-sensitive: a key present
+    //! at its default value and an absent key are different states.
+    std::map<std::string, std::string> settings;
+
+    bool has_registry_sizes{false};
+    size_t beacon_count{0};
+    size_t protocol_entry_count{0};
+    size_t scraper_count{0};
+};
+
+enum class CaptureScope { CASE, SUITE };
+
+StateSnapshot CaptureState(CaptureScope scope);
+
+//!
+//! \brief One invariant that differs between two snapshots.
+//!
+//! \p monotone marks the size-like fields (mempool, mapBlockIndex, registries,
+//! StakingActive) for which only growth is a leak: a suite that CLEARS an
+//! earlier suite's residue is a cleaner, not a leaker, and several fixtures
+//! (RegtestChainSetup, CleanStateGuard, RegistryReset) clear on exit by design.
+//!
+struct StateDiff
+{
+    std::string invariant;
+    std::string before;
+    std::string after;
+    bool monotone{false};
+    bool growth{false};
+
+    //! True when this diff should fail a suite: any change for a plain field,
+    //! growth only for a monotone one.
+    bool IsLeak() const { return !monotone || growth; }
+};
+
+std::vector<StateDiff> DiffState(const StateSnapshot& before, const StateSnapshot& after);
+
+//!
+//! \brief Restore the process globals a suite mutates.
+//!
+//! Captures on construction and restores on destruction. Three ways to use it:
+//!
+//!     BOOST_AUTO_TEST_SUITE(x_tests, *boost::unit_test::fixture<grc_test::StateGuard>())
+//!     BOOST_FIXTURE_TEST_SUITE(x_tests, grc_test::StateGuard)
+//!     { grc_test::StateGuard guard; ... }
+//!
+//! Default mode records the mapBlockIndex key set and erases the entries a
+//! suite added. Entries built by MockBlockIndex::InsertBlockIndex are
+//! pool-allocated and their phashBlock aliases the map key, so erasing is the
+//! whole cleanup. A fixture that points phashBlock at heap memory it owns must
+//! still delete that memory itself.
+//!
+//! The Reset flags additionally CLEAR state on entry: MEMPOOL empties the
+//! pool on entry and exit; CHAIN moves mapBlockIndex aside and nulls the tip
+//! globals, which is what a suite needs before it can call LoadBlockIndex()
+//! (it bails with "hashBestChain not found" whenever pindexGenesisBlock is
+//! non-null). CleanStateGuard and MempoolStateGuard are the two named shapes.
+//!
+class StateGuard
+{
+public:
+    //! What to clear on entry (and again on exit), beyond restoring.
+    enum Reset : unsigned {
+        NONE = 0,
+        MEMPOOL = 1, //!< mempool.clear() on entry and exit.
+        CHAIN = 2,   //!< move mapBlockIndex aside and null the tip globals on entry.
+        ALL = MEMPOOL | CHAIN,
+    };
+
+    explicit StateGuard(unsigned reset = NONE);
+    ~StateGuard();
+
+    StateGuard(const StateGuard&) = delete;
+    StateGuard& operator=(const StateGuard&) = delete;
+
+private:
+    unsigned m_reset;
+
+    util::Settings m_settings;
+    std::string m_network_id;
+    unsigned int m_stake_min_age;
+    int m_coinbase_maturity;
+    int m_grandfather;
+    int m_max_outbound;
+    int64_t m_mock_time;
+    bool m_mock_deterministic;
+    bool m_use_fast_index;
+
+    CBlockIndex* m_pindex_best;
+    CBlockIndex* m_pindex_genesis;
+    uint256 m_hash_best_chain;
+    int m_n_best_height;
+    int64_t m_previous_block_time;
+    BlockMap m_moved_index;
+    std::unordered_set<uint256, BlockHasher> m_preexisting_keys;
+};
+
+//! Chain and mempool cleared on entry: what a suite needs before LoadBlockIndex().
+struct CleanStateGuard : StateGuard
+{
+    CleanStateGuard() : StateGuard(ALL) {}
+};
+
+//! Mempool cleared on entry and exit; everything else restored as found.
+struct MempoolStateGuard : StateGuard
+{
+    MempoolStateGuard() : StateGuard(MEMPOOL) {}
+};
+
+//!
+//! \brief Reset the named registries on construction AND destruction.
+//!
+//! Every registry reset in the tree used to be entry-only, which is how an
+//! ACTIVE protocol entry from one suite reached a later suite that mined.
+//! Symmetry is the point of this type.
+//!
+class RegistryReset
+{
+public:
+    explicit RegistryReset(std::initializer_list<GRC::ContractType> types);
+    ~RegistryReset();
+
+    RegistryReset(const RegistryReset&) = delete;
+    RegistryReset& operator=(const RegistryReset&) = delete;
+
+private:
+    std::vector<GRC::ContractType> m_types;
+
+    void Apply() const;
+};
+
+//!
+//! \brief RegistryReset with the types fixed at compile time, so it can be a
+//! suite decorator: *boost::unit_test::fixture<RegistryResetFor<ContractType::PROTOCOL>>().
+//!
+template <GRC::ContractType... Types>
+struct RegistryResetFor : RegistryReset
+{
+    RegistryResetFor() : RegistryReset({Types...}) {}
+};
+
+//!
+//! \brief Pin -blockv15height for a scope and put it back EXACTLY.
+//!
+//! "Back" means presence as well as value: if the forced setting was absent
+//! the key is erased again, not written as the chainparams sentinel. The leak
+//! detector's settings snapshot is presence-sensitive, and an empty string is
+//! not a usable "unset" either -- it would activate the gate from genesis.
+//!
+class V15HeightGuard
+{
+public:
+    explicit V15HeightGuard(int height);
+    ~V15HeightGuard();
+
+    V15HeightGuard(const V15HeightGuard&) = delete;
+    V15HeightGuard& operator=(const V15HeightGuard&) = delete;
+
+private:
+    std::optional<util::SettingsValue> m_saved;
+};
+
+//!
+//! \brief Precondition for tests that rely on V15 rules being inert.
+//!
+//! Fails the case (BOOST_REQUIRE) if GetBlockV15Height() is anything other
+//! than the unscheduled sentinel, naming the override that set it.
+//!
+void RequireV15Unscheduled();
+
+} // namespace grc_test
+
+#endif // GRIDCOIN_TEST_STATE_GUARD_H

--- a/src/test/state_leak_detector.cpp
+++ b/src/test/state_leak_detector.cpp
@@ -50,17 +50,6 @@ struct KnownLeak
 // isolation, and --random seeds 3 and 7 on the commit that introduced it.
 // Each entry is removed by the commit that fixes the leak at source.
 const std::vector<KnownLeak> kKnownLeaks = {
-    // Registries reset on entry only.
-    {"gridcoin_cbr_tests", "GetProtocolRegistry().ProtocolEntries().size()", "AddProtocolEntry resets on entry only"},
-    {"protocol_tests", "GetProtocolRegistry().ProtocolEntries().size()", "cases reset the registry on entry only"},
-    {"Researcher", "GetProtocolRegistry().ProtocolEntries().size()", "cases reset the registry on entry only"},
-    {"scraper_registry_tests", "GetScraperRegistry().Scrapers().size()", "cases reset the registry on entry only"},
-    {"BeaconPayload", "GetBeaconRegistry().Beacons().size()", "BeaconRegistryTest resets on entry only"},
-
-    // Mock chains never torn down.
-    {"BeaconPayload", "mapBlockIndex", "BeaconRegistryTest inserts every block of the fixture file and erases none"},
-    {"BeaconPayload", "hashBestChain", "BeaconRegistryTest advances hashBestChain per block and never restores it"},
-
     // Mempool.
     {"psgt_pool_tests", "mempool.size()", "a case leaves its funding transaction in the pool"},
 };

--- a/src/test/state_leak_detector.cpp
+++ b/src/test/state_leak_detector.cpp
@@ -51,7 +51,6 @@ struct KnownLeak
 // Each entry is removed by the commit that fixes the leak at source.
 const std::vector<KnownLeak> kKnownLeaks = {
     // Determinism and mock time.
-    {"random_tests", "g_mock_deterministic_tests", "fastrandom_tests turns determinism off and never back on"},
     {"DoS_tests", "GetMockTime()", "DoS_bantime and DoS_misbehavior_decay never reset mock time"},
 
     // -blockv15height: both suites exit with the INT_MAX sentinel PRESENT

--- a/src/test/state_leak_detector.cpp
+++ b/src/test/state_leak_detector.cpp
@@ -1,0 +1,321 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "test/state_leak_detector.h"
+
+#include "test/state_guard.h"
+#include "tinyformat.h"
+
+#include <boost/test/tree/traverse.hpp>
+#include <boost/test/tree/visitor.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <iostream>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace grc_test {
+
+namespace {
+
+using boost::unit_test::framework::master_test_suite;
+using boost::unit_test::test_suite;
+using boost::unit_test::test_unit;
+using boost::unit_test::test_unit_id;
+using boost::unit_test::TUT_CASE;
+using boost::unit_test::TUT_SUITE;
+
+//!
+//! \brief Leaks that are known, tracked, and tolerated for now.
+//!
+//! Matching diffs are printed rather than failed. Every entry names the issue
+//! or commit that will remove it. Whether an entry fires in a given run depends
+//! on which suite ran first (two suites that exit with the same value are
+//! mutually exclusive) and on --run_test, so an entry that did not fire is
+//! reported at the end of the run but is never itself an error. Suite names
+//! that do not resolve to a top-level suite are rejected at install time.
+//!
+struct KnownLeak
+{
+    const char* suite;
+    const char* invariant; //!< Matched as a prefix, so "settings[" covers every argument.
+    const char* note;
+};
+
+// The union of what the detector reported over Linux link order, per-suite
+// isolation, and --random seeds 3 and 7 on the commit that introduced it.
+// Each entry is removed by the commit that fixes the leak at source.
+const std::vector<KnownLeak> kKnownLeaks = {
+    // Chain-tip globals left pointing at freed or stack memory.
+    {"block_finder_tests", "pindexBest", "BlockChain<N> points the tip at a stack array and has no destructor"},
+    {"block_finder_tests", "pindexGenesisBlock", "BlockChain<N> points the tip at a stack array and has no destructor"},
+    {"block_finder_tests", "nBestHeight", "BlockChain<N> points the tip at a stack array and has no destructor"},
+    {"Superblock", "pindexBest", "two cases new/delete CBlockIndex into the tip without nulling"},
+    {"Superblock", "pindexGenesisBlock", "two cases new/delete CBlockIndex into the tip without nulling"},
+    {"Superblock", "nBestHeight", "two cases new/delete CBlockIndex into the tip without nulling"},
+    {"coinstake_construction_tests", "pindexBest", "fixture restores neither tip pointer after freeing the index"},
+    {"coinstake_construction_tests", "pindexGenesisBlock", "fixture restores neither tip pointer after freeing the index"},
+    {"mrc_tests", "pindexGenesisBlock", "fixture frees the genesis index and leaves the pointer"},
+
+    // Determinism and mock time.
+    {"random_tests", "g_mock_deterministic_tests", "fastrandom_tests turns determinism off and never back on"},
+    {"DoS_tests", "GetMockTime()", "DoS_bantime and DoS_misbehavior_decay never reset mock time"},
+    {"mrc_tests", "GetMockTime()", "fixture sets mock time and resets it only on the happy path"},
+
+    // -blockv15height: both suites exit with the INT_MAX sentinel PRESENT
+    // where it was absent, so whichever runs first is the one that fires.
+    {"pool_tests", "settings[forced:blockv15height]", "PoolLifecycleFixture writes the sentinel instead of erasing the key"},
+    {"connectinputs_tests", "settings[forced:blockv15height]", "local V15HeightGuard writes the sentinel instead of erasing the key"},
+
+    // Settings restored to a value where the key used to be absent.
+    {"coinstake_construction_tests", "settings[", "fixture restores forcecpid/email/stake args to empty strings"},
+    {"mrc_tests", "settings[", "fixture restores forcecpid/email to empty strings"},
+    {"Researcher", "settings[", "cases restore email/forcecpid/noncruncher/pooloperator by hand"},
+    {"MiningProject", "settings[forced:email]", "cases restore email by hand"},
+    {"MiningProjectMap", "settings[forced:email]", "cases restore email by hand"},
+    {"DoS_tests", "settings[forced:banscore]", "DoS_banscore restores -banscore to 100 rather than absent"},
+    {"script_tests", "settings[forced:maxsigcachesize]", "restores -maxsigcachesize to the default rather than absent"},
+    {"Whitelist", "settings[forced:autogreylistdeepcopyheight]", "DeepCopyHeightGuard writes the chainparams value on exit"},
+    {"addressbook_tests", "settings[forced:rescan]", "a case forces -rescan and never clears it"},
+    {"sidestake_tests", "settings[rw:", "sidestake editors write rw settings that are never removed"},
+    {"util_tests", "settings[", "util_GetArg / util_ParseParameters leave test arguments behind"},
+    {"getarg_tests", "settings[cmdline:", "ResetArgs re-parses test arguments and never clears them"},
+
+    // Registries reset on entry only.
+    {"gridcoin_cbr_tests", "GetProtocolRegistry().ProtocolEntries().size()", "AddProtocolEntry resets on entry only"},
+    {"protocol_tests", "GetProtocolRegistry().ProtocolEntries().size()", "cases reset the registry on entry only"},
+    {"Researcher", "GetProtocolRegistry().ProtocolEntries().size()", "cases reset the registry on entry only"},
+    {"scraper_registry_tests", "GetScraperRegistry().Scrapers().size()", "cases reset the registry on entry only"},
+    {"BeaconPayload", "GetBeaconRegistry().Beacons().size()", "BeaconRegistryTest resets on entry only"},
+
+    // Mock chains never torn down.
+    {"BeaconPayload", "mapBlockIndex", "BeaconRegistryTest inserts every block of the fixture file and erases none"},
+    {"BeaconPayload", "hashBestChain", "BeaconRegistryTest advances hashBestChain per block and never restores it"},
+
+    // Mempool.
+    {"psgt_pool_tests", "mempool.size()", "a case leaves its funding transaction in the pool"},
+};
+
+bool Matches(const KnownLeak& known, const std::string& suite, const std::string& invariant)
+{
+    return suite == known.suite && invariant.rfind(known.invariant, 0) == 0;
+}
+
+const KnownLeak* FindKnown(const std::string& suite, const std::string& invariant)
+{
+    for (const auto& known : kKnownLeaks) {
+        if (Matches(known, suite, invariant)) return &known;
+    }
+    return nullptr;
+}
+
+//! The top-level suite a test unit belongs to (its own id for a top-level suite).
+const test_unit& TopLevelSuiteOf(const test_unit& tu)
+{
+    const test_unit_id master = master_test_suite().p_id;
+    const test_unit* cur = &tu;
+
+    while (cur->p_parent_id != master) {
+        if (cur->p_parent_id == boost::unit_test::INV_TEST_UNIT_ID) break;
+        cur = &boost::unit_test::framework::get(cur->p_parent_id, TUT_SUITE);
+    }
+
+    return *cur;
+}
+
+struct Blame
+{
+    std::string test_case;
+    StateDiff diff;
+};
+
+//!
+//! Per-case capture for attribution only. Nothing here may assert: an
+//! assertion from an observer hook does not reach the exit code.
+//!
+class StateLeakObserver : public boost::unit_test::test_observer
+{
+public:
+    int priority() override { return 5; }
+
+    void test_unit_start(const test_unit& tu) override
+    {
+        if (tu.p_type != TUT_CASE) return;
+        m_case_before = CaptureState(CaptureScope::CASE);
+    }
+
+    void test_unit_finish(const test_unit& tu, unsigned long) override
+    {
+        if (tu.p_type != TUT_CASE) return;
+
+        const StateSnapshot after = CaptureState(CaptureScope::CASE);
+        const std::string suite = TopLevelSuiteOf(tu).p_name.get();
+
+        for (const auto& diff : DiffState(m_case_before, after)) {
+            m_blame[suite].push_back({tu.p_name.get(), diff});
+        }
+    }
+
+    void test_finish() override
+    {
+        std::ostream& out = std::cerr;
+
+        if (!m_reported.empty()) {
+            out << "\nCross-suite state leaks reported this run:\n";
+            for (const auto& line : m_reported) out << "  " << line << "\n";
+        }
+
+        std::vector<std::string> unfired;
+        for (const auto& known : kKnownLeaks) {
+            if (!m_fired.count(std::string(known.suite) + "\n" + known.invariant)) {
+                unfired.push_back(strprintf("%s / %s (%s)", known.suite, known.invariant, known.note));
+            }
+        }
+        if (!unfired.empty()) {
+            out << "\nkKnownLeaks entries that did not fire in this run (order- or filter-dependent; "
+                   "remove an entry only once it is fixed at source):\n";
+            for (const auto& line : unfired) out << "  " << line << "\n";
+        }
+        if (!m_reported.empty() || !unfired.empty()) out << std::endl;
+    }
+
+    //! The first case that changed \p invariant in \p suite, or empty.
+    std::string FirstBlame(const std::string& suite, const std::string& invariant) const
+    {
+        auto it = m_blame.find(suite);
+        if (it == m_blame.end()) return {};
+
+        for (const auto& blame : it->second) {
+            if (blame.diff.invariant == invariant) return blame.test_case;
+        }
+        return {};
+    }
+
+    void Record(const std::string& line) { m_reported.push_back(line); }
+
+    void MarkFired(const KnownLeak& known)
+    {
+        m_fired.insert(std::string(known.suite) + "\n" + known.invariant);
+    }
+
+    void ForgetSuite(const std::string& suite) { m_blame.erase(suite); }
+
+private:
+    StateSnapshot m_case_before;
+    std::map<std::string, std::vector<Blame>> m_blame;
+    std::vector<std::string> m_reported;
+    std::set<std::string> m_fired;
+};
+
+StateLeakObserver& Observer()
+{
+    static StateLeakObserver observer;
+    return observer;
+}
+
+//!
+//! Attached at the FRONT of every top-level suite's fixture list, so its
+//! setup() runs before, and its teardown() after, any fixture the suite
+//! declared for itself. A suite decorator such as RegtestChainSetup is
+//! therefore checked, not bypassed.
+//!
+class SuiteLeakFixture : public boost::unit_test::test_unit_fixture
+{
+public:
+    explicit SuiteLeakFixture(std::string suite) : m_suite(std::move(suite)) {}
+
+    void setup() override
+    {
+        m_before = CaptureState(CaptureScope::SUITE);
+    }
+
+    void teardown() override
+    {
+        const StateSnapshot after = CaptureState(CaptureScope::SUITE);
+
+        for (const auto& diff : DiffState(m_before, after)) {
+            const std::string blame = Observer().FirstBlame(m_suite, diff.invariant);
+            const std::string where = blame.empty() ? "no single case changed it" : "first changed by " + blame;
+
+            if (!diff.IsLeak()) {
+                Observer().Record(strprintf("note: %s shrank %s: %s -> %s (a cleaner, not a leak; %s)",
+                                            m_suite, diff.invariant, diff.before, diff.after, where));
+                continue;
+            }
+
+            if (const KnownLeak* known = FindKnown(m_suite, diff.invariant)) {
+                Observer().MarkFired(*known);
+                Observer().Record(strprintf("known: %s leaked %s: %s -> %s (%s; %s)",
+                                            m_suite, diff.invariant, diff.before, diff.after, known->note, where));
+                continue;
+            }
+
+            const std::string message = strprintf(
+                "suite %s leaked process state: %s was %s at suite entry and %s at suite exit (%s)",
+                m_suite, diff.invariant, diff.before, diff.after, where);
+            Observer().Record("FAIL: " + message);
+            BOOST_ERROR(message);
+        }
+
+        Observer().ForgetSuite(m_suite);
+    }
+
+private:
+    std::string m_suite;
+    StateSnapshot m_before;
+};
+
+//! Collects the ids of the master suite's direct children that are suites.
+struct TopLevelSuites : boost::unit_test::test_tree_visitor
+{
+    test_unit_id master{boost::unit_test::INV_TEST_UNIT_ID};
+    std::vector<test_unit_id> ids;
+
+    bool test_suite_start(const test_suite& ts) override
+    {
+        if (ts.p_id == master) return true;
+        if (ts.p_parent_id == master) ids.push_back(ts.p_id);
+        return false;
+    }
+};
+
+} // anonymous namespace
+
+void InstallStateLeakDetector()
+{
+    static bool installed = false;
+    if (installed) return;
+    installed = true;
+
+    boost::unit_test::framework::register_observer(Observer());
+
+    TopLevelSuites visitor;
+    visitor.master = master_test_suite().p_id;
+    boost::unit_test::traverse_test_tree(master_test_suite(), visitor, /*ignore_status=*/true);
+
+    if (visitor.ids.empty()) {
+        throw std::runtime_error("state leak detector: the master test suite has no child suites to attach to");
+    }
+
+    std::set<std::string> names;
+    for (const test_unit_id id : visitor.ids) {
+        test_unit& tu = boost::unit_test::framework::get(id, TUT_SUITE);
+        names.insert(tu.p_name.get());
+        tu.p_fixtures->insert(tu.p_fixtures->begin(),
+                              boost::shared_ptr<SuiteLeakFixture>(new SuiteLeakFixture(tu.p_name.get())));
+    }
+
+    for (const auto& known : kKnownLeaks) {
+        if (!names.count(known.suite)) {
+            throw std::runtime_error(strprintf(
+                "state leak detector: kKnownLeaks names suite '%s', which is not a top-level suite in this binary",
+                known.suite));
+        }
+    }
+}
+
+} // namespace grc_test

--- a/src/test/state_leak_detector.cpp
+++ b/src/test/state_leak_detector.cpp
@@ -50,21 +50,6 @@ struct KnownLeak
 // isolation, and --random seeds 3 and 7 on the commit that introduced it.
 // Each entry is removed by the commit that fixes the leak at source.
 const std::vector<KnownLeak> kKnownLeaks = {
-    // Determinism and mock time.
-    {"DoS_tests", "GetMockTime()", "DoS_bantime and DoS_misbehavior_decay never reset mock time"},
-
-    // Settings restored to a value where the key used to be absent.
-    {"Researcher", "settings[", "cases restore email/forcecpid/noncruncher/pooloperator by hand"},
-    {"MiningProject", "settings[forced:email]", "cases restore email by hand"},
-    {"MiningProjectMap", "settings[forced:email]", "cases restore email by hand"},
-    {"DoS_tests", "settings[forced:banscore]", "DoS_banscore restores -banscore to 100 rather than absent"},
-    {"script_tests", "settings[forced:maxsigcachesize]", "restores -maxsigcachesize to the default rather than absent"},
-    {"Whitelist", "settings[forced:autogreylistdeepcopyheight]", "DeepCopyHeightGuard writes the chainparams value on exit"},
-    {"addressbook_tests", "settings[forced:rescan]", "a case forces -rescan and never clears it"},
-    {"sidestake_tests", "settings[rw:", "sidestake editors write rw settings that are never removed"},
-    {"util_tests", "settings[", "util_GetArg / util_ParseParameters leave test arguments behind"},
-    {"getarg_tests", "settings[cmdline:", "ResetArgs re-parses test arguments and never clears them"},
-
     // Registries reset on entry only.
     {"gridcoin_cbr_tests", "GetProtocolRegistry().ProtocolEntries().size()", "AddProtocolEntry resets on entry only"},
     {"protocol_tests", "GetProtocolRegistry().ProtocolEntries().size()", "cases reset the registry on entry only"},

--- a/src/test/state_leak_detector.cpp
+++ b/src/test/state_leak_detector.cpp
@@ -50,8 +50,6 @@ struct KnownLeak
 // isolation, and --random seeds 3 and 7 on the commit that introduced it.
 // Each entry is removed by the commit that fixes the leak at source.
 const std::vector<KnownLeak> kKnownLeaks = {
-    // Mempool.
-    {"psgt_pool_tests", "mempool.size()", "a case leaves its funding transaction in the pool"},
 };
 
 bool Matches(const KnownLeak& known, const std::string& suite, const std::string& invariant)

--- a/src/test/state_leak_detector.cpp
+++ b/src/test/state_leak_detector.cpp
@@ -50,21 +50,9 @@ struct KnownLeak
 // isolation, and --random seeds 3 and 7 on the commit that introduced it.
 // Each entry is removed by the commit that fixes the leak at source.
 const std::vector<KnownLeak> kKnownLeaks = {
-    // Chain-tip globals left pointing at freed or stack memory.
-    {"block_finder_tests", "pindexBest", "BlockChain<N> points the tip at a stack array and has no destructor"},
-    {"block_finder_tests", "pindexGenesisBlock", "BlockChain<N> points the tip at a stack array and has no destructor"},
-    {"block_finder_tests", "nBestHeight", "BlockChain<N> points the tip at a stack array and has no destructor"},
-    {"Superblock", "pindexBest", "two cases new/delete CBlockIndex into the tip without nulling"},
-    {"Superblock", "pindexGenesisBlock", "two cases new/delete CBlockIndex into the tip without nulling"},
-    {"Superblock", "nBestHeight", "two cases new/delete CBlockIndex into the tip without nulling"},
-    {"coinstake_construction_tests", "pindexBest", "fixture restores neither tip pointer after freeing the index"},
-    {"coinstake_construction_tests", "pindexGenesisBlock", "fixture restores neither tip pointer after freeing the index"},
-    {"mrc_tests", "pindexGenesisBlock", "fixture frees the genesis index and leaves the pointer"},
-
     // Determinism and mock time.
     {"random_tests", "g_mock_deterministic_tests", "fastrandom_tests turns determinism off and never back on"},
     {"DoS_tests", "GetMockTime()", "DoS_bantime and DoS_misbehavior_decay never reset mock time"},
-    {"mrc_tests", "GetMockTime()", "fixture sets mock time and resets it only on the happy path"},
 
     // -blockv15height: both suites exit with the INT_MAX sentinel PRESENT
     // where it was absent, so whichever runs first is the one that fires.
@@ -72,8 +60,6 @@ const std::vector<KnownLeak> kKnownLeaks = {
     {"connectinputs_tests", "settings[forced:blockv15height]", "local V15HeightGuard writes the sentinel instead of erasing the key"},
 
     // Settings restored to a value where the key used to be absent.
-    {"coinstake_construction_tests", "settings[", "fixture restores forcecpid/email/stake args to empty strings"},
-    {"mrc_tests", "settings[", "fixture restores forcecpid/email to empty strings"},
     {"Researcher", "settings[", "cases restore email/forcecpid/noncruncher/pooloperator by hand"},
     {"MiningProject", "settings[forced:email]", "cases restore email by hand"},
     {"MiningProjectMap", "settings[forced:email]", "cases restore email by hand"},

--- a/src/test/state_leak_detector.cpp
+++ b/src/test/state_leak_detector.cpp
@@ -53,11 +53,6 @@ const std::vector<KnownLeak> kKnownLeaks = {
     // Determinism and mock time.
     {"DoS_tests", "GetMockTime()", "DoS_bantime and DoS_misbehavior_decay never reset mock time"},
 
-    // -blockv15height: both suites exit with the INT_MAX sentinel PRESENT
-    // where it was absent, so whichever runs first is the one that fires.
-    {"pool_tests", "settings[forced:blockv15height]", "PoolLifecycleFixture writes the sentinel instead of erasing the key"},
-    {"connectinputs_tests", "settings[forced:blockv15height]", "local V15HeightGuard writes the sentinel instead of erasing the key"},
-
     // Settings restored to a value where the key used to be absent.
     {"Researcher", "settings[", "cases restore email/forcecpid/noncruncher/pooloperator by hand"},
     {"MiningProject", "settings[forced:email]", "cases restore email by hand"},

--- a/src/test/state_leak_detector.h
+++ b/src/test/state_leak_detector.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_TEST_STATE_LEAK_DETECTOR_H
+#define GRIDCOIN_TEST_STATE_LEAK_DETECTOR_H
+
+namespace grc_test {
+
+//!
+//! \brief Fail the run when a suite leaves process state behind.
+//!
+//! Call once from the global TestingSetup constructor. It registers a
+//! test_observer that captures the StateSnapshot around every test CASE (for
+//! blame: which case first changed an invariant), and attaches a suite-level
+//! fixture to every top-level suite that captures at suite entry, compares at
+//! suite exit, and raises one BOOST_ERROR per leaked invariant.
+//!
+//! The split is forced by Boost.Test: an assertion raised from an observer hook
+//! is either banked against no test unit (test_unit_finish) or discarded
+//! outright (test_start / test_finish), so only a fixture teardown -- which
+//! runs with the suite as the current test unit -- can put a failure on the
+//! exit code. Anything that goes wrong inside this function itself is reported
+//! by throwing, which the framework turns into "Test setup error" and a
+//! nonzero exit; a BOOST_ERROR here would be silently dropped.
+//!
+//! Leaks that are known and tracked are listed in kKnownLeaks
+//! (state_leak_detector.cpp) and downgraded to a printed note. An entry there
+//! is a tolerance, not a requirement: whether it fires depends on suite order
+//! and on --run_test filters.
+//!
+void InstallStateLeakDetector();
+
+} // namespace grc_test
+
+#endif // GRIDCOIN_TEST_STATE_LEAK_DETECTOR_H

--- a/src/test/test_gridcoin.cpp
+++ b/src/test/test_gridcoin.cpp
@@ -6,6 +6,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <test/test_gridcoin.h>
+#include <test/state_leak_detector.h>
 
 #include <leveldb/env.h>
 #include <leveldb/helpers/memenv/memenv.h>
@@ -164,6 +165,12 @@ struct TestingSetup {
             return g_peerman ? g_peerman->ClearMisbehaviorForSubnet(sub_net) : 0u;
         });
         g_mock_deterministic_tests = true;
+
+        // Last, so every global above is in its steady state when the
+        // detector takes its first per-suite snapshot. Throws on failure:
+        // this constructor runs as a framework observer, where an assertion
+        // would be discarded (see state_leak_detector.h).
+        grc_test::InstallStateLeakDetector();
     }
     ~TestingSetup()
     {

--- a/src/test/txmempool_tests.cpp
+++ b/src/test/txmempool_tests.cpp
@@ -9,6 +9,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "test/state_guard.h"
+
 #include <key.h>
 #include <primitives/transaction.h>
 #include <txmempool.h>
@@ -60,7 +62,9 @@ CTxMemPoolEntry MakeEntry(const CTransaction& tx)
 }
 } // anonymous namespace
 
-BOOST_AUTO_TEST_SUITE(txmempool_tests)
+// Suite-level guard: the pool is cleared on entry and on exit, so the
+// per-case clears below defend this suite and nothing leaks out of it.
+BOOST_AUTO_TEST_SUITE(txmempool_tests, *boost::unit_test::fixture<grc_test::MempoolStateGuard>())
 
 BOOST_AUTO_TEST_CASE(entry_caches_fee_size_time_height)
 {

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -6,6 +6,8 @@
 #include "random.h"
 #include <vector>
 #include <boost/test/unit_test.hpp>
+
+#include "test/state_guard.h"
 #include "univalue/include/univalue.h"
 
 #include <wallet/wallet.h>
@@ -70,7 +72,10 @@ int msb3(const int64_t& n_in)
 
 #include <sstream>
 
-BOOST_AUTO_TEST_SUITE(util_tests)
+// Suite-level guard: util_GetArg and util_ParseParameters leave their test
+// arguments in the global ArgsManager (ClearArgs() clears only the
+// registered-argument table, not the settings).
+BOOST_AUTO_TEST_SUITE(util_tests, *boost::unit_test::fixture<grc_test::StateGuard>())
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)
 {

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -90,6 +90,8 @@ EXPECTED_BOOST_INCLUDES=(
     boost/signals2/connection.hpp
     boost/signals2/optional_last_value.hpp
     boost/signals2/signal.hpp
+    boost/test/tree/traverse.hpp
+    boost/test/tree/visitor.hpp
     boost/test/unit_test.hpp
     boost/thread.hpp
     boost/thread/condition_variable.hpp


### PR DESCRIPTION

Every suite in `test_gridcoin` runs in one process on top of one global `TestingSetup`, so
whatever a suite leaves in a process global is the next suite's input, and which suite is next is
link order. That is how a dangling `pindexGenesisBlock` and an ACTIVE `blockreward1` protocol entry
reached suites that mine, on the Windows cross-compile leg only: the Linux legs happened to link the
leaker last. Nothing checked the boundary, no shared restorer existed (the tree had grown about a
dozen ad-hoc RAII structs, several asymmetric or without a destructor), and nothing ran suites in
isolation or in random order.

This PR adds a detector that fails the run at the suite boundary, one shared guard, and then works
through everything the detector found until its allow-list is empty.

### What the detector reported on the first commit that ran it

57 leaks in 22 suites, taking the union over Linux link order (42), per-suite isolation, and
`--random` seeds 3 and 7. The pairs that flip with order behave exactly as expected: `pool_tests`
and `connectinputs_tests` both exit with `-blockv15height` present at INT_MAX, so only whichever
runs first is blamed. Classes, each fixed in its own commit:

| Class | Suites | Fix |
|---|---|---|
| Tip globals left pointing at freed or stack memory | `block_finder_tests`, `Superblock`, `coinstake_construction_tests`, `mrc_tests` | `StateGuard` as the fixture's first member / first local |
| Deterministic `GetRand()` switched off and never back on | `random_tests` | local guard |
| `-blockv15height` restored by writing the sentinel, leaving the key present | `pool_tests`, `connectinputs_tests` | `V15HeightGuard`, which restores presence; `RequireV15Unscheduled()` replaces the two hand-written tripwires |
| Forced arguments and mock time restored to a value where the key was absent | `DoS_tests`, `script_tests`, `Whitelist`, `addressbook_tests`, `sidestake_tests`, `MiningProject`, `MiningProjectMap`, `Researcher`, `util_tests`, `getarg_tests` | local or suite-level `StateGuard` |
| Registries reset on entry only | `gridcoin_cbr_tests`, `protocol_tests`, `scraper_registry_tests`, `Researcher`, `BeaconPayload` | `RegistryResetFor<>` suite decorator (resets on both sides) |
| Mock chain never torn down (2,641 `mapBlockIndex` entries, `hashBestChain`) | `BeaconPayload` | suite-level `StateGuard` |
| Mempool left with a transaction | `psgt_pool_tests` (`txmempool_tests` was cleaning it up) | `MempoolStateGuard` on both suites |

Plus one hygiene commit: the empty `GridcoinTestsConfig` global fixture is deleted and the testnet
`SelectParams` case gets a guard (its manual restore only ran on the happy path; the detector never
flagged it, so this one is not pinned).

### One test was passing for the wrong reason

`coinstake_construction_tests/sidestake_outputs_placed` never enables `-enablesidestaking`, and
the registry hands out no local sidestakes without it. It passed because the previous case's
teardown forced the argument to an empty string, which `InterpretBool()` reads as `true`. Once the
fixture restores the argument to absent, the case fails on its own assertions; it now sets the
argument itself. This is the concrete argument for the detector's settings comparison being
presence-sensitive: "restoring" an argument by writing an empty string is not a restore.

### How the detector fails the run (a Boost.Test detail worth stating)

`BOOST_GLOBAL_FIXTURE` is a `test_observer` in Boost 1.83 (the CI floor), so `TestingSetup`'s
constructor runs inside `framework::run()`'s `test_start` loop. An assertion raised from an observer
hook there is discarded outright, and one raised from `test_unit_finish` is banked against no test
unit. Only a suite-level `test_unit_fixture::teardown()` runs with the suite as the current unit, so
that is where the `BOOST_ERROR`s live: `InstallStateLeakDetector()` inserts a `SuiteLeakFixture`
at the front of every top-level suite's `p_fixtures`, so it brackets any decorator the suite
declares for itself (including #3333's `RegtestChainSetup`, which this validates rather than
bypasses). A `test_observer` records per-case diffs for blame attribution only. Install failures
throw, which the framework turns into a test setup error and a nonzero exit.

Two comparison rules keep the report honest: size-like fields (mempool, `mapBlockIndex`,
registries, miner status) fail on growth only, because several fixtures clear on exit by design and
would otherwise be blamed for cleaning up; and the settings comparison is presence-sensitive, for
the reason above.

`kKnownLeaks` downgrades a listed leak to a note. It is a tolerance, never a requirement: which
entry fires depends on order and on `--run_test`. Suite names that do not resolve are rejected at
install time. The table is empty at the head of this PR.

### What is deliberately not restored

The LevelDB memenv behind `txdb` (opened once with `error_if_exists`; every `CTxDB` adopts the
handle), `pwalletMain` and `bitdb` (the BDB environment is bound to the one datadir), the three net
managers (the fixture asserts they are created once), the registries (`Reset()` is destructive and
some suites want it entry-only, hence the opt-in), the registered-argument table `ClearArgs()`
wipes, and the temp datadir on disk. Upstream's per-case `BasicTestingSetup` layering is only
possible because upstream moved all of those into `NodeContext`; that is a separate effort, and
#3333 already recorded that a datadir per construction crashes the wallet and deleting the LevelDB
segfaults.

### Testing

- Whole binary in link order at HEAD: green, zero notes.
- Every one of the 105 top-level suites run alone (`--run_test=<suite>`): 105/105 green, zero notes.
- `--random` seeds 3, 7, 11, 21: green, zero notes, and no non-leak failures either (the suites
  tolerate intra-suite shuffling as they stand).
- Per-commit pins, mechanical, run on the pre-rebase stack (`194a9bcb7`, on #3333's head; the ten
  commits replayed onto `development` unchanged apart from the include-order merge above): revert the
  commit's source changes to its parent, keep its `kKnownLeaks` removals, rebuild, run. Each goes red (exit 201) naming exactly the suites the
  commit fixes, in Linux link order:

  | Commit | Red on |
  |---|---|
  | chain tip after the four mock-chain fixtures | `block_finder_tests` ×3, `Superblock` ×3, `coinstake_construction_tests` ×7, `mrc_tests` |
  | deterministic `GetRand()` | `random_tests` |
  | `-blockv15height` by presence | `pool_tests` (`connectinputs_tests` is the second of the pair; it fires when it runs first) |
  | forced arguments and mock time by presence | `DoS_tests`, `MiningProject`, `Researcher` ×3, `Whitelist`, `addressbook_tests`, `getarg_tests`, `script_tests`, `sidestake_tests` ×3, `util_tests` ×10 |
  | registries on the way out | `gridcoin_cbr_tests`, `protocol_tests`, `scraper_registry_tests`, `BeaconPayload` ×2 |
  | mempool on both sides | `psgt_pool_tests` |

  The entries that do not appear in a given order (`connectinputs_tests`, `MiningProjectMap`, the
  `DoS_tests` and `mrc_tests` mock-time leaks, `Researcher`'s registry entry) are the same-exit-value
  pairs and the intra-suite-restored cases described above; they fired in the isolation loop or a
  random seed on the unfixed tree instead.
- `test/lint/lint-all.sh` with `COMMIT_RANGE` set: clean (the two Boost tree headers the detector
  needs are added to `lint-includes.sh`'s expected list). No control bytes in the diff.
- `-DENABLE_DEBUG_LOCKORDER=ON` (the guard takes `cs_main` in its constructor and destructor, the
  observer at every case boundary): whole binary green, no lock-order report. The base is #3353's
  lock-discipline fixes, so unlike the pre-rebase run there is no pre-existing abort to compare
  against.
- Everything above was re-run on the rebased head, on top of #3353/#3354's test lock-discipline
  changes, which touch several of the same suites.

Not in this PR: a CI job running the isolation loop and a random seed. The isolation loop is
gating-ready on this evidence; the random-order job is not something I want to argue for gating on
one day of seeds. Follow-up.

https://claude.ai/code/session_01Ek7BaHRzs7jVGJ5V8CZKh3
